### PR TITLE
Added handling for missing host-name config in chassis.py

### DIFF
--- a/lib/jnpr/junos/facts/chassis.py
+++ b/lib/jnpr/junos/facts/chassis.py
@@ -38,7 +38,7 @@ def chassis(junos, facts):
 
   hostname = got.find('.//host-name')
   if hostname is not None: facts['hostname'] = hostname.text
-  else: facts['hostname'] = '[undefined]'
+  else: facts['hostname'] = None
   facts['fqdn'] = facts['hostname']
 
   domain = got.find('.//domain-name')


### PR DESCRIPTION
I've approached this by giving a default value of '[undefined]'. It's arguable whether it's neater (or more honest) to just set it to ''.

I like the use of a specific string personally (because in general it distinguishes between null strings and specifically missing data), but whatever it is - if that approach is taken - the 'undefined' value should be used consistently throughout the libraries so that any string value that's undefined should use the same value, making client script testing simpler. And if so, that means that a value should be created somewhere so that we can simply say:

facts['hostname'] = strUNDEFINED

(thus ensuring no typos mess things up).

Over to you - if you don't like the approach, I'm fine with that :)
