### PR TITLE
Added support for Dell SRX to personality.py

### DIFF
--- a/lib/jnpr/junos/op/routes.yml
+++ b/lib/jnpr/junos/op/routes.yml
@@ -18,6 +18,7 @@ RouteTableView:
     # fields taken from the group 'entry'
     protocol: protocol-name
     via: nh/via | nh/nh-local-interface
+    nexthop: nh/to
 
 ### ------------------------------------------------------
 ### show route summary


### PR DESCRIPTION
I have a Dell-branded SRX100H at home and realized that the personality module wouldn't recognize my DELL J-SRX100H model string and identify as SRX_BRANCH. I added to the RE so that it would also recognize anything with "DELL J-" at the start.
