### PR TITLE
Nexthop for Routes.yml

### DIFF
--- a/lib/jnpr/junos/op/routes.yml
+++ b/lib/jnpr/junos/op/routes.yml
@@ -18,6 +18,7 @@ RouteTableView:
     # fields taken from the group 'entry'
     protocol: protocol-name
     via: nh/via | nh/nh-local-interface
+    nexthop: nh/to
 
 ### ------------------------------------------------------
 ### show route summary


### PR DESCRIPTION
Minor change - not sure if you want to include changes like this, or wait for more significant changes. Either way, I realized that the routes.yml did not include a field for the IP next hop, only the "via" interface, so I added one for my own nefarious purposes..
