### PR TITLE
Added DELL SRX support to personality.py

### DIFF
--- a/lib/jnpr/junos/facts/personality.py
+++ b/lib/jnpr/junos/facts/personality.py
@@ -16,7 +16,7 @@ def personality( junos, facts ):
     persona = "M"
   elif re.match("SRX\s?(\d){4}", examine):
     persona = 'SRX_HIGHEND'    
-  elif re.match("SRX\s?(\d){3}", examine):
+  elif re.match("(DELL J-)?SRX\s?(\d){3}", examine):
     persona = 'SRX_BRANCH'
   elif re.search("firefly", examine, re.IGNORECASE):
     facts['virtual'] = True


### PR DESCRIPTION
I have a DellSRX which reports itself as a DELL J-SRX100 (or whatever). I updated personality.py to accommodate the possibility that SRXxxx may be prefaced by "DELL J-" so it's correctly identified.
