### PR TITLE
badges, PyYAML + pre-testing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ nosetests.xml
 
 MANIFEST
 
+# Testing
+.tox
+
 # Vagrant
 .vagrant
 vagrant_ansible*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 #  - "pypy"
 
 before_install:
-  - sudo apt-get install -qq libxml2 libxml2-dev libxslt1.1 libxslt1-dev libgmp10 libgmp-dev python-dev python-setuptools
+  - sudo apt-get install -qq libxml2 libxml2-dev libxslt1.1 libxslt1-dev libyaml-0-2 libyaml-dev libgmp10 libgmp-dev python-dev python-setuptools
 
 install:
   - "pip install -r development.txt"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+[![PyPI version](https://badge.fury.io/py/junos-eznc.png)](http://badge.fury.io/py/junos-eznc)
 [![Build Status](https://travis-ci.org/jeremyschulman/py-junos-eznc.png?branch=master)](https://travis-ci.org/jeremyschulman/py-junos-eznc)
+[![Dependency Status](https://gemnasium.com/jeremyschulman/py-junos-eznc.png)](https://gemnasium.com/jeremyschulman/py-junos-eznc)
 
 The repo is under active development on release 0.0.3.  If you take a clone, you are getting the latest, and perhaps not entirely stable code.  
 

--- a/development.txt
+++ b/development.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
 
-coverage==3.7       # http://nedbatchelder.com/code/coverage/
+coverage==3.7.1     # http://nedbatchelder.com/code/coverage/
 mock==1.0.1         # http://www.voidspace.org.uk/python/mock/
 nose==1.3.0         # http://nose.readthedocs.org/en/latest/
-pep8==1.4			# https://github.com/jcrocholl/pep8
-pyflakes==0.5.0     # https://launchpad.net/pyflakes
-tox==1.4.3          # http://tox.readthedocs.org/en/latest/
-sure==1.2.2         # http://falcao.it/sure/
+pep8==1.4.6	        # https://github.com/jcrocholl/pep8
+pyflakes==0.7.3     # https://launchpad.net/pyflakes
+tox==1.6.1          # http://tox.readthedocs.org/en/latest/
+sure==1.2.3         # http://falcao.it/sure/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ git+git://github.com/Juniper/ncclient.git#egg=ncclient
 paramiko
 scp
 jinja2
+PyYAML
 netaddr

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ import sys
 sys.path.insert(0,'lib')
 from setuptools import setup, find_packages
 
+requirements = [ 'netaddr >= 0.7.10', 'jinja2 >= 2.7.1', 'lxml >= 3.2.4',
+                 'scp >= 0.7.0', 'PyYAML >= 3.10' ]
+
 setup(
     name = "junos-eznc",
     namespace_packages = ['jnpr'],
@@ -17,10 +20,24 @@ setup(
     package_dir={'':'lib'},    
     packages=find_packages('lib'),
     package_data={'jnpr.junos.op': ['*.yml']},
-    install_requires=[
-        "netaddr",
-        "lxml",
-        "jinja2",
-        "scp"
+    install_requires=requirements,
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'Intended Audience :: Telecommunications Industry',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Other Scripting Engines',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: System :: Networking',
+        'Topic :: System :: Networking :: Firewalls',
+        'Topic :: Text Processing :: Markup :: XML'
     ],
 )


### PR DESCRIPTION
**`.gitignore`**: .tox dir will be the basis for Python virtualenv dirs for testing

**`.travis.yml`**: added libyaml OS library packages

**`README.md`**:
- dynamic PyPI badge (no assembly req)
- gemnasium dependency hooks (change branch to master on gemnasium if it doesn't work - it also might need one commit to become active)

**`development.txt`**:  specific versions for testing

**`requirements.txt`**: added PyYAML - should probably also use specific MAJOR.MINOR versions (>=) like
setup.py / [semver](http://semver.org/)
