### PR TITLE
Make ssh lookup a tad more robust

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -179,8 +179,9 @@ class Device(object):
     sshconf = paramiko.SSHConfig()
     sshconf.parse(open(sshconf_path,'r'))
     found = sshconf.lookup(self._hostname)
-    self._hostname = found['hostname']
-    self._port = found.get('port',self._port)
+    self._hostname = found.get('hostname', self._hostname)
+    self._port = found.get('port', self._port)
+
 
   def __init__(self, *vargs, **kvargs):
     """


### PR DESCRIPTION
If hostname is missing, as it typically is when your ~/.ssh/config
contains a wildcard entry, _sshconf_lkup() would bail out with an
exception. We now handle the lack of hostname in a more robust fashion,
just like is already done for port.

Problem looks like this;

```
kll@lingloi320 ~/kod/py-junos-eznc $ cat ~/.ssh/config
Host *
 ServerAliveInterval 120
kll@lingloi320 ~/kod/ROUMIGA $ python roumiga.py 
Password: 
Traceback (most recent call last):
  File "roumiga.py", line 17, in <module>
    dev = Device(host='my_host_or_ipaddr', user='jeremy', password='jeremy123' )
  File "../py-junos-eznc/lib/jnpr/junos/device.py", line 209, in __init__
    self._sshconf_lkup()
  File "../py-junos-eznc/lib/jnpr/junos/device.py", line 182, in _sshconf_lkup
    self._hostname = found['hostname']
KeyError: 'hostname'
```

Now fixed! =)
