### PR TITLE
Add View/Table support for ISIS adjacencies

### DIFF
--- a/lib/jnpr/junos/op/isis.py
+++ b/lib/jnpr/junos/op/isis.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for ISIS Table/View
+"""
+from ..factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/isis.yml
+++ b/lib/jnpr/junos/op/isis.yml
@@ -1,0 +1,35 @@
+IsisAdjacencyTable:
+  rpc: get-isis-adjacency-information
+  args:
+    extensive: True
+  item: isis-adjacency
+  key:
+    - interface-name
+    - system-name
+  view: IsisAdjView
+
+IsisAdjacencyView:
+  fields:
+    interface_name: interface-name
+    system_name: system-name
+    level: level
+    adjacency_state: adjacency-state
+    holdtime: holdtime
+    circuit_type: circuit-type
+    ip_address: ip-address
+    interface_priority: interface-priority
+    adjacency_flag: adjacency-flag
+    adjacency_topologies: adjacency-topologies
+    adjacency_restart_capable: adjacency-restart-capable
+    adjacency_advertisement: adjacency-advertisement
+    adjacency_log: _IsisAdjacencyLogTable
+
+_IsisAdjacencyLogTable:
+  item: isis-adjacency-log
+  view: _IsisAdjacencyLogView
+
+_IsisAdjacencyLogView:
+  fields:
+    when: adjacency-when
+    state: adjacency-state
+    event: adjacency-event


### PR DESCRIPTION
Retrieves most of the stuff from 'show isis adjacency extensive' apart from adjacency log.

Key is a composite of interface and system-name which seems to be the most natural key to me. I hope I've used the composite keys implementation correctly - I went on a limb based on a quick read of the code.

Apart from that.. well, it works :)

Btw, thanks for #props =)
