### PR TITLE
Add View/Table for BFD sessions

### DIFF
--- a/lib/jnpr/junos/op/bfd.py
+++ b/lib/jnpr/junos/op/bfd.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for BFD Table/View
+"""
+from ..factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/bfd.yml
+++ b/lib/jnpr/junos/op/bfd.yml
@@ -1,0 +1,47 @@
+BfdSessionTable:
+  rpc: get-bfd-session-information
+  args:
+    extensive: True
+  item: bfd-session
+  key: session-neighbor
+  view: BfdSessionView
+
+BfdSessionView:
+  fields:
+    neighbor: session-neighbor
+    state: session-state
+    interface: session-interface
+    detection_time: session-detection-time
+    transmission_interval: session-transmission-interval
+    adaptive_multiplier: session-adaptive-multiplier
+    local_diagnostic: local-diagnostic
+    remote_diagnostic: remote-diagnostic
+    version: session-version
+    remote_state: remote-state
+    minimum_asynchronous_interval: minimum-asynchronous-interval
+    minimum_slow_interval: minimum-slow-interval
+    adaptive_asynchronous_transmission_interval: adaptive-asynchronous-transmission_interval
+    adaptive_reception_interval: adaptive-reception-interval
+    minimum_transmission_interval: minimum-transmission-interval
+    minimum_reception_interval: minimum-reception-interval
+    detection_multiplier: detection-multiplier
+    neighbor_minimum_transmission_interval: neighbor-minimum-transmission_interval
+    neighbor_minimum_reception_interval: neighbor-minimum-reception_interval
+    neighbor_session_multiplier: neighbor-session-multiplier
+    local_discriminator: local-discriminator
+    remote_discriminator: remote-discriminator
+    echo_mode_desired: echo-mode-desired
+    echo_mode_state: echo-mode-state
+    no_absorb: no-absorb
+    no_refresh: { no-refresh: True=no-refresh }
+    bfd_client: _BfdSessionClientTable
+
+_BfdSessionClientTable:
+  item: bfd-client
+  view: _BfdSessionClientView
+
+_BfdSessionClientView:
+  fields:
+    name: client-name
+    transmission_interval: client-transmission-interval
+    reception_interval: client-reception-interval


### PR DESCRIPTION
Maps all data available from 'show bfd sessions extensive'.

Key is set to neighbor-address which I'm not sure is correct. The box
I'm working with does not yet support micro-BFD sessions nor do we have
it configured but those would probably not have an IP address associated
with them at all. Similarily, I'm not sure what happens if there are two
BFD sessions to the same address but in different VRFs.
