### PR TITLE
Allow lists and tuples as RPC command values

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -106,8 +106,13 @@ class _RpcMetaExec(object):
       if kvargs:
         for arg_name, arg_value in kvargs.items():
           arg_name = re.sub('_','-',arg_name)               
-          arg = etree.SubElement( rpc, arg_name )
-          if arg_value != True: arg.text = arg_value
+          if isinstance(arg_value, (tuple, list)):
+            for a in arg_value:
+              arg = etree.SubElement( rpc, arg_name )
+              if a != True: arg.text = a
+          else:
+            arg = etree.SubElement( rpc, arg_name )
+            if arg_value != True: arg.text = arg_value
 
       # vargs[0] is a dict, command options like format='text'
       if vargs:


### PR DESCRIPTION
There are a few commands in JunOS that require multiple tags to be sent,
for example the <request-package-add> call when using a set of update
packages for a Virtual-Chassis:

```
<rpc>
        <request-package-add>
                <reboot/>
                <set>jinstall-ex-4200-...</set>
                <set>jinstall-ex-4500-...</set>
        </request-package-add>
</rpc>
```

This was not possible as a command value could only be a string. Now it
can also be a tuple or list and a tag will be generated for every value
of the list.
