### PR TITLE
Fix personality fact gathering for 'Virtual Chassis' without 'RE0' membe...

### DIFF
--- a/lib/jnpr/junos/facts/personality.py
+++ b/lib/jnpr/junos/facts/personality.py
@@ -4,7 +4,13 @@ def personality( junos, facts ):
   
   model = facts['model']
 
-  examine = model if model != 'Virtual Chassis' else facts['RE0']['model']
+  if model != 'Virtual Chassis':
+    examine = model
+  else:
+    for fact in facts:
+      if re.match("^RE\d", fact):
+        examine = facts[fact]['model']
+        break
 
   if re.match("^(EX)|(QFX)", examine):
     persona = 'SWITCH'


### PR DESCRIPTION
...r.

Routing engines are numbered after the virtual chassis members.
Hence a routing engine number 0, RE0, does not necessarily exist.
So search facts for the first key matching '^RE\d'.
