### PR TITLE
added auto_probe feature to Device, fix #200

### DIFF
--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -98,6 +98,12 @@ class ConnectError(Exception):
             self.__class__.__name__, 
             self.dev.hostname )
 
+class ProbeError(ConnectError):
+    """
+    Generated if auto_probe is enabled and the probe action fails
+    """
+    pass
+    
 class ConnectAuthError(ConnectError): 
     """
     Generated if the user-name, password is invalid


### PR DESCRIPTION
enable automatically "probing" for NETCONF as part of the Device.open() process.  Disabled by default.  Enabled via Device class variable (Device.auto_probe), at time of Device(auto_probe=<int>) or at time of Device.open(auto_probe=<int>)
