### PR TITLE
updates for Python 2.6 to resolve no handler on paramiko.transport

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -132,6 +132,8 @@ class SW(Util):
         # check for the logger barncale for 'paramiko.transport'
         plog = logging.getLogger('paramiko.transport')
         if not plog.handlers: 
+            class NullHandler(logging.Handler):
+                def emit(self, record): pass
             plog.addHandler(logging.NullHandler())        
 
         # execute the secure-copy with the Python SCP module


### PR DESCRIPTION
Python 2.6, the logging module did not include a logging.NullHandler() mech.  So need to implement a stub class to deal with this.
