### PR TITLE
fix #256 - activate 'replace' option as default with config.load()

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -162,9 +162,9 @@ class Config(Util):
           determines if the contents completely replace the existing
           configuration.  options are [True/False], default: False
 
-        kvargs['replace']
-          set this to :True: if your configuration change uses the
-          replace marker in the 'text' or XML formats (NA for set)
+        kvargs['merge']
+          if set to :True: will set the load-config action to merge.
+          the default load-config action is 'replace'
 
         kvargs['template_path']
           path to a jinja2 template file.  used in conjection with the
@@ -182,7 +182,10 @@ class Config(Util):
           used in conjection with the other template options.  this option
           contains a dictionary of variables to render into the template
         """
-        rpc_xattrs = {'format': 'xml'}      # junos attributes, default to XML
+        rpc_xattrs = {}
+        rpc_xattrs['format'] = 'xml'        # default to XML format
+        rpc_xattrs['action'] = 'replace'    # replace is default action
+
         rpc_contents = None
 
         # support the ability to completely replace the Junos configuration
@@ -191,8 +194,8 @@ class Config(Util):
         overwrite = kvargs.get('overwrite', False)
         if True == overwrite:
             rpc_xattrs['action'] = 'override'
-        elif kvargs.get('replace',False) is True:
-            rpc_xattrs['action'] = 'replace'
+        elif kvargs.get('merge') is True:
+            del rpc_xattrs['action']
 
         # ---------------------------------------------------------------------
         # private helpers ...


### PR DESCRIPTION
The jnpr.junos.utils.config.Config.load() method did not provide a mechanism to activate the 'replace' option.  Added replace as the default action.  User can disengage replace by passing 'merge=True' or 'override=True'.
