### PR TITLE
feat/ipv6 nd

### DIFF
--- a/lib/jnpr/junos/op/arp.yml
+++ b/lib/jnpr/junos/op/arp.yml
@@ -1,8 +1,6 @@
 ---
 ArpTable:
   rpc: get-arp-table-information
-  args:
-    vpn: default
   item: arp-table-entry
   key: mac-address
   view: ArpView

--- a/lib/jnpr/junos/op/arp.yml
+++ b/lib/jnpr/junos/op/arp.yml
@@ -1,6 +1,8 @@
 ---
 ArpTable:
   rpc: get-arp-table-information
+  args:
+    vpn: default
   item: arp-table-entry
   key: mac-address
   view: ArpView

--- a/lib/jnpr/junos/op/nd.py
+++ b/lib/jnpr/junos/op/nd.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for IPv6 Neighbor Discovery Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/nd.yml
+++ b/lib/jnpr/junos/op/nd.yml
@@ -1,0 +1,13 @@
+---
+NdTable:
+  rpc: get-ipv6-nd-information
+  item: ipv6-nd-entry
+  key: ipv6-nd-neighbor-l2-address
+  view: NdView
+
+NdView:
+  fields:
+    mac_address: ipv6-nd-neighbor-l2-address
+    ip_address: ipv6-nd-neighbor-address
+    interface_name: ipv6-nd-interface-name
+    router: ipv6-nd-isrouter


### PR DESCRIPTION
This table and view brings IPv6 neighbor discovery support.  See below.

```python
>>> from jnpr.junos import Device
>>> from jnpr.junos.op.nd import NdTable
>>> dev = Device('10.49.31.2', user='tyler')
>>> dev.open()
Device(10.49.31.2)
>>> nd_table = NdTable(dev)
>>> nd_table = nd_table.get()
>>> for entry in nd_table:
...     print(entry.items())
...
[('router', 'yes'), ('interface_name', 'xe-0/1/0.0'), ('ip_address', 'fe80::3e61:4ff:fe6c:cd33'), ('mac_address', '3c:61:04:6c:cd:33')]
>>>
```