### PR TITLE
Composite table keys with non-existent XPATH target now Null

### DIFF
--- a/lib/jnpr/junos/factory/view.py
+++ b/lib/jnpr/junos/factory/view.py
@@ -7,6 +7,7 @@ import json
 from jnpr.junos.factory.viewfields import ViewFields
 from jnpr.junos.factory.to_json import TableViewJSONEncoder
 
+
 class View(object):
 
     """
@@ -82,10 +83,14 @@ class View(object):
             return self._xml.findtext(self.ITEM_NAME_XPATH).strip()
         else:
             # composite key
-# return tuple([self.xml.findtext(i).strip() for i in
-# self.ITEM_NAME_XPATH])
-            return tuple([self.xml.xpath(i)[0].text.strip()
-                         for i in self.ITEM_NAME_XPATH])
+            # keys with missing XPATH nodes are set to None
+            keys = []
+            for i in self.ITEM_NAME_XPATH:
+                try:
+                    keys.append(self.xml.xpath(i)[0].text.strip())
+                except:
+                    keys.append(None)
+            return tuple(keys)
 
     # ALIAS key <=> name
     key = name
@@ -187,7 +192,7 @@ class View(object):
         """
         :returns: JSON encoded string of entire View contents
         """
-        return json.dumps(self, cls=TableViewJSONEncoder )        
+        return json.dumps(self, cls=TableViewJSONEncoder)
 
     # -------------------------------------------------------------------------
     # OVERLOADS

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -56,9 +56,9 @@ class TestFactoryTable(unittest.TestCase):
     def test_keys__keys_composite(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.ppt.get('ge-0/0/0')
-        self.ppt.ITEM_NAME_XPATH = ['name', 'mtu']
+        self.ppt.ITEM_NAME_XPATH = ['name', 'missing', 'mtu']
         self.assertEqual(self.ppt.keys(),
-                         [('ge-0/0/0', '1514'), ('ge-0/0/1', '1514')])
+                         [('ge-0/0/0', None, '1514'), ('ge-0/0/1', None, '1514')])
 
     @patch('jnpr.junos.Device.execute')
     def test_table_repr_xml_not_none(self, mock_execute):

--- a/tests/unit/factory/test_view.py
+++ b/tests/unit/factory/test_view.py
@@ -49,8 +49,8 @@ class TestFactoryView(unittest.TestCase):
         self.assertEqual(self.v.name, '1.1.1.1')
 
     def test_view_name_xpath_composite(self):
-        self.v.ITEM_NAME_XPATH = ['name', 'admin-status']
-        self.assertEqual(self.v.name, ('ge-0/0/0', 'up'))
+        self.v.ITEM_NAME_XPATH = ['name', 'missing', 'admin-status']
+        self.assertEqual(self.v.name, ('ge-0/0/0', None, 'up'))
 
     def test_view_asview(self):
         self.assertEqual(


### PR DESCRIPTION
When specifying a composite table key it has been observed that some of the values of the key may not exist.  This is seen in chassis hardware.
In the event of an unfound XPATH the key value in the tuple is now None
Original behaviour was an uncaught exception.
