### PR TITLE
Add circuit cross connect table/view

### DIFF
--- a/lib/jnpr/junos/op/ccc.py
+++ b/lib/jnpr/junos/op/ccc.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Circuit Cross Connect Table/View (ccc)
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/ccc.yml
+++ b/lib/jnpr/junos/op/ccc.yml
@@ -1,0 +1,25 @@
+---
+CCCTable:
+  rpc: get-ccc-information
+  args: 
+    status: True
+    interface-switch: True
+  item: ccc-connection
+  key: ccc-connection-name
+  view: CCCView
+
+CCCView:
+  fields:
+    status: ccc-connection-status
+    ports: _CCCPorts
+
+_CCCPorts:
+  item: ccc-connection-circuit
+  key:
+    - ccc-circuit-name
+  view: _CCCPortsView
+ 
+_CCCPortsView:
+  fields:
+    type: ccc-circuit-type
+    status: ccc-circuit-status


### PR DESCRIPTION
Implemented the "show connections" command to get information about circuit cross connects:
```
show connections | display xml rpc 
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.3R6/junos">
    <rpc>
        <get-ccc-information>
        </get-ccc-information>
    </rpc>
    <cli>
        <banner>{master}</banner>
    </cli>
</rpc-reply>
```