### PR TITLE
Update device for ncclient 0.4.2 sshconfig support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 lxml>=3.2.4
-ncclient>=0.4.1
+ncclient>=0.4.2
 paramiko
 scp>=0.7.0
 jinja2>=2.7.1

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -163,6 +163,15 @@ class TestDevice(unittest.TestCase):
         self.dev._sshconf_lkup()
         mock_paramiko.assert_called_any()
 
+    @patch('jnpr.junos.device.os')
+    @patch('__builtin__.open')
+    @patch('paramiko.config.SSHConfig.lookup')
+    def test_device__sshconf_lkup_def(self, os_mock, open_mock, mock_paramiko):
+        os_mock.path.exists.return_value = True
+        self.dev._ssh_config = '/home/rsherman/.ssh/config'
+        self.dev._sshconf_lkup()
+        mock_paramiko.assert_called_any()
+
     @patch('os.getenv')
     def test_device__sshconf_lkup_path_not_exists(self, mock_env):
         mock_env.return_value = '/home/test'


### PR DESCRIPTION
As part of ncclient 0.4.2 greater support for sshconfig was introduced.  Leveraging this allows for the use of proxycommand.

This resolves #302 
