### PR TITLE
Update view.py

### DIFF
--- a/lib/jnpr/junos/factory/view.py
+++ b/lib/jnpr/junos/factory/view.py
@@ -242,6 +242,8 @@ class View(object):
             # added support to use the element tag if the text is empty
             def _munch(x):
                 as_str = x if isinstance(x, str) else x.text
+                if isinstance(as_str, unicode):
+                    as_str = as_str.encode('ascii','replace')
                 if as_str is not None:
                     as_str = as_str.strip()
                 if not as_str:


### PR DESCRIPTION
Junos allows non-ASCII characters in interface descriptions. 
Some characters cannot be converted safely into string. In this case it is better to replace them with '?' or ignore. 

> > > astype = type('str')
> > > astype(u'\x96')
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > UnicodeEncodeError: 'ascii' codec can't encode character u'\x96' in position 0: ordinal not in range(128)
