### PR TITLE
Add regex support for View boolean values

### DIFF
--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -6,6 +6,7 @@ refer to the .yml files in this jnpr.junos.op directory.
 """
 # stdlib
 from copy import deepcopy
+import re
 
 # locally
 from jnpr.junos.factory.factory_cls import *
@@ -62,10 +63,18 @@ class FactoryLoader(object):
     # -----------------------------------------------------------------------
 
     def _fieldfunc_True(self, value_rhs):
-        return lambda x: x == value_rhs
+        def true_test(x):
+            if value_rhs.startswith('regex('):
+                return True if bool(re.search(value_rhs.strip('regex()'), x)) else False
+            return x == value_rhs
+        return true_test
 
     def _fieldfunc_False(self, value_rhs):
-        return lambda x: x != value_rhs
+        def false_test(x):
+            if value_rhs.startswith('regex('):
+                return False if bool(re.search(value_rhs.strip('regex()'), x)) else True
+            return x != value_rhs
+        return false_test
 
     def _add_dictfield(self, fields, f_name, f_dict, kvargs):
         """ add a field based on its associated dictionary """

--- a/lib/jnpr/junos/op/bfd.yml
+++ b/lib/jnpr/junos/op/bfd.yml
@@ -32,7 +32,7 @@ BfdSessionView:
     remote_discriminator: remote-discriminator
     echo_mode_desired: echo-mode-desired
     echo_mode_state: echo-mode-state
-    no_absorb: no-absorb
+    no_absorb: { no-absorb: True=regex(no-absorb) }
     no_refresh: { no-refresh: True=no-refresh }
     bfd_client: _BfdSessionClientTable
 

--- a/tests/unit/factory/rpc-reply/get-bfd-session-information.xml
+++ b/tests/unit/factory/rpc-reply/get-bfd-session-information.xml
@@ -1,0 +1,50 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.3R1/junos">
+    <bfd-session-information xmlns="http://xml.juniper.net/junos/13.3R1/junos-bfd" junos:style="extensive">
+        <bfd-session>
+            <session-neighbor>10.92.20.4</session-neighbor>
+            <session-state>Down</session-state>
+            <session-interface></session-interface>
+            <session-detection-time>0.000</session-detection-time>
+            <session-transmission-interval>3.000</session-transmission-interval>
+            <session-adaptive-multiplier>3</session-adaptive-multiplier>
+            <bfd-client>
+                <client-name>Static</client-name>
+                <client-transmission-interval>0.300</client-transmission-interval>
+                <client-reception-interval>0.300</client-reception-interval>
+            </bfd-client>
+            <local-diagnostic>None</local-diagnostic>
+            <remote-diagnostic>None</remote-diagnostic>
+            <session-version>1</session-version>
+            <remote-state>AdminDown</remote-state>
+            <session-type>Multi hop BFD</session-type>
+            <minimum-asynchronous-interval>0.300</minimum-asynchronous-interval>
+            <minimum-slow-interval>3.000</minimum-slow-interval>
+            <adaptive-asynchronous-transmission-interval>3.000</adaptive-asynchronous-transmission-interval>
+            <adaptive-reception-interval>3.000</adaptive-reception-interval>
+            <minimum-transmission-interval>3.000</minimum-transmission-interval>
+            <minimum-reception-interval>0.300</minimum-reception-interval>
+            <detection-multiplier>3</detection-multiplier>
+            <neighbor-minimum-transmission-interval>0.000</neighbor-minimum-transmission-interval>
+            <neighbor-minimum-reception-interval>0.000</neighbor-minimum-reception-interval>
+            <neighbor-session-multiplier>0</neighbor-session-multiplier>
+            <local-discriminator>16</local-discriminator>
+            <remote-discriminator>0</remote-discriminator>
+            <echo-mode-desired>disabled</echo-mode-desired>
+            <echo-mode-state>inactive</echo-mode-state>
+            <no-absorb>, no-absorb</no-absorb>
+            <no-refresh>no-refresh</no-refresh>
+            <multihop>Multi-hop</multihop>
+            <multihop-time-to-live>1</multihop-time-to-live>
+            <multihop-routing-table-index>0</multihop-routing-table-index>
+            <multihop-local-address>10.60.0.1</multihop-local-address>
+            <no-refresh> Session ID: 0x1</no-refresh>
+        </bfd-session>
+        <sessions>1</sessions>
+        <clients>1</clients>
+        <cumulative-transmission-rate>0.3</cumulative-transmission-rate>
+        <cumulative-reception-rate>0.0</cumulative-reception-rate>
+    </bfd-session-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/factory/test_factory_loader.py
+++ b/tests/unit/factory/test_factory_loader.py
@@ -40,9 +40,41 @@ class TestFactoryLoader(unittest.TestCase):
         self.assertEqual(self.fl._build_view('RouteTableView'),
                          self.fl.catalog['RouteTableView'])
 
+    def test_FactoryLoader__fieldfunc_True(self):
+        fn = self.fl._fieldfunc_True('test')
+        self.assertTrue(fn('test'))
+
+    def test_FactoryLoader__fieldfunc_True_fail(self):
+        # Assert that false is returned if value not found
+        fn = self.fl._fieldfunc_True('test')
+        self.assertFalse(fn('nope'))
+
+    def test_FactoryLoader__fieldfunc_True_regex(self):
+        fn = self.fl._fieldfunc_True('regex(this|test)')
+        self.assertTrue(fn('test'))
+
+    def test_FactoryLoader__fieldfunc_True_regex_fail(self):
+        # Assert that false is returned if value not found
+        fn = self.fl._fieldfunc_True('regex(this|test)')
+        self.assertFalse(fn('nope'))
+
     def test_FactoryLoader__fieldfunc_False(self):
         fn = self.fl._fieldfunc_False('test')
         self.assertFalse(fn('test'))
+
+    def test_FactoryLoader__fieldfunc_False_fail(self):
+        # Assert that true is returned if value not found
+        fn = self.fl._fieldfunc_False('test')
+        self.assertTrue(fn('nope'))
+
+    def test_FactoryLoader__fieldfunc_False_regex(self):
+        fn = self.fl._fieldfunc_False('regex(this|test)')
+        self.assertFalse(fn('test'))
+
+    def test_FactoryLoader__fieldfunc_False_regex_fail(self):
+        # Assert that true is returned if value not found
+        fn = self.fl._fieldfunc_False('regex(this|test)')
+        self.assertTrue(fn('nope'))
 
     def test_FactoryLoader__add_dictfield_RuntimeError(self):
         self.assertRaises(

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -61,6 +61,15 @@ class TestFactoryOpTable(unittest.TestCase):
         self.assertEqual(v['present'], True)
 
     @patch('jnpr.junos.Device.execute')
+    def test_optable_view_get_astype_bool_regex(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        from jnpr.junos.op.bfd import BfdSessionTable
+        bfd = BfdSessionTable(self.dev)
+        bfd.get()
+        v = bfd['10.92.20.4']
+        self.assertEqual(v['no_absorb'], True)
+
+    @patch('jnpr.junos.Device.execute')
     def test_optable_view_get_unknown_field(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.ppt.get()


### PR DESCRIPTION
Regex support for mapping boolean values in Views.

Format is True/False=regex():

```
no_absorb: { no-absorb: True=regex(no-absorb) }
```

Matches are performed via search so they can appear anywhere in the string.

Below are other examples of using regex

```
no_refresh: { no-refresh: True=regex(\dx\d) }
no_refresh: { no-refresh: 'True=regex(Session ID: 0x0|no-refresh)' }
```

Note:  When boolean values contain control chars (such as ':' or ',' the value of the field needs to be enclosed in quotes.

```
no_absorb: { no-absorb: 'True=, no-absorb' }
```

This resolves issue #100 
