### PR TITLE
take care of FutureWarning

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -286,7 +286,7 @@ class Config(Util):
             except Exception as err:
                 rerrs = err.rsp[0].findall('rpc-error')
                 if len(rerrs) > 0:
-                    if any([e.find('[error-severity="error"]') for e in rerrs]):
+                    if len([e.find('[error-severity="error"]') for e in rerrs]):
                         raise err
                 return err.rsp[0]
 


### PR DESCRIPTION
/Library/Python/2.7/site-packages/junos_eznc-1.1.0.dev-py2.7.egg/jnpr/junos/utils/config.py:289: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if any([e.find('[error-severity="error"]') for e in rerrs]):
