### PR TITLE
Add description field to op.ethport.EthPortView

### DIFF
--- a/lib/jnpr/junos/op/ethport.yml
+++ b/lib/jnpr/junos/op/ethport.yml
@@ -15,6 +15,7 @@ EthPortView:
   fields:
     oper: oper-status
     admin: admin-status
+    description: description
     mtu: { mtu : int }
     link_mode: link-mode
     macaddr: current-physical-address


### PR DESCRIPTION
op.phyport.PhyPortView has a description field which allows one
to get() the interface descriptions. Since phyport does not
support aggregated ethernet interfaces(ae), this commit adds
description support so one can get these from ae interfaces.

Example:

```
from jnpr.junos.op.ethport import *
from jnpr.junos import Device
dev = Device(host='ex4550.example.com')
dev.open()
ports = EthPortTable(dev).get()
for port in ports:
    print port.description
```