### PR TITLE
Added support for pipe (union) operator in Table keys

### DIFF
--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -125,6 +125,9 @@ class Table(object):
         key_value, xpath = self._keyspec()
 
         if isinstance(key_value, str):
+            # Check if pipe is in the key_value, if so append xpath to each value
+            if ' | ' in key_value:
+                return self._keys_simple(' | '.join([xpath + '/' + x for x in key_value.split(' | ')]))
             return self._keys_simple(xpath + '/' + key_value)
 
         if not isinstance(key_value, list):

--- a/lib/jnpr/junos/op/lldp.yml
+++ b/lib/jnpr/junos/op/lldp.yml
@@ -2,14 +2,14 @@
 LLDPNeighborTable:
   rpc: get-lldp-neighbors-information
   item: lldp-neighbor-information
-  key: lldp-local-interface
+  key: lldp-local-interface | lldp-local-port-id
   view: LLDPNeighborView
 
 LLDPNeighborView:
   fields:
-    local_int: lldp-local-interface
+    local_int: lldp-local-interface | lldp-local-port-id
     local_parent: lldp-local-parent-interface-name
     remote_type: lldp-remote-chassis-id-subtype
-    remote_chassis-id: lldp-remote-chassis-id
-    remote_port-desc: lldp-remote-port-description
+    remote_chassis_id: lldp-remote-chassis-id
+    remote_port_desc: lldp-remote-port-description
     remote_sysname: lldp-remote-system-name

--- a/tests/unit/factory/rpc-reply/get-lldp-neighbors-information.xml
+++ b/tests/unit/factory/rpc-reply/get-lldp-neighbors-information.xml
@@ -1,0 +1,32 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
+    <lldp-neighbors-information junos:style="brief">
+		<lldp-neighbor-information>
+			<lldp-local-port-id>et-0/0/48</lldp-local-port-id>
+			<lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+			<lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+			<lldp-remote-chassis-id>10:0e:7e:ad:ae:00</lldp-remote-chassis-id>
+			<lldp-remote-port-description>et-0/0/2</lldp-remote-port-description>
+			<lldp-remote-system-name>spine-01</lldp-remote-system-name>
+		</lldp-neighbor-information>
+		<lldp-neighbor-information>
+			<lldp-local-port-id>et-0/0/49</lldp-local-port-id>
+			<lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+			<lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+			<lldp-remote-chassis-id>10:0e:7e:ad:De:c0</lldp-remote-chassis-id>
+			<lldp-remote-port-description>et-0/0/2</lldp-remote-port-description>
+			<lldp-remote-system-name>spine-02</lldp-remote-system-name>
+		</lldp-neighbor-information>
+		<lldp-neighbor-information>
+			<lldp-local-port-id>xe-0/0/13</lldp-local-port-id>
+			<lldp-local-parent-interface-name>-</lldp-local-parent-interface-name>
+			<lldp-remote-chassis-id-subtype>Mac address</lldp-remote-chassis-id-subtype>
+			<lldp-remote-chassis-id>10:0e:7e:b1:D3:80</lldp-remote-chassis-id>
+			<lldp-remote-port-description>xe-0/0/13</lldp-remote-port-description>
+			<lldp-remote-system-name>leaf-02</lldp-remote-system-name>
+		</lldp-neighbor-information>
+	</lldp-neighbors-information>
+    <cli>
+        <banner>{master:0}</banner>
+    </cli>
+</rpc-reply>
+	

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -61,6 +61,14 @@ class TestFactoryTable(unittest.TestCase):
                          [('ge-0/0/0', None, '1514'), ('ge-0/0/1', None, '1514')])
 
     @patch('jnpr.junos.Device.execute')
+    def test_keys__keys_pipe(self, mock_execute):
+        from jnpr.junos.op.lldp import LLDPNeighborTable
+        mock_execute.side_effect = self._mock_manager
+        self.lldp = LLDPNeighborTable(self.dev)
+        self.lldp.get()
+        self.assertEqual(self.lldp.keys(), ['et-0/0/48', 'et-0/0/49', 'xe-0/0/13'])
+
+    @patch('jnpr.junos.Device.execute')
     def test_table_repr_xml_not_none(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.ppt.get('ge-0/0/0')


### PR DESCRIPTION
Added the ability to use an XPATH pipe (union) operator for Table keys.  This feature was already supported with View fields.

The syntax is `' | '` (space + pipe + space) between the values.  The table will automatically append the item value + / to each element specified in the piped key.

```
key: lldp-local-interface | lldp-local-port-id

lldp.keys()
['me0.0', 'me0.0', 'me0.0', 'me0.0', 'xe-0/1/0.0']
```

The most common use case for this is the implicit "or"; there are situations where keys may have a different name between releases or types of configuration (as is the case with LLDP on ELS and non-ELS switches).

If there are multiple keys (of fields) listed with pipes that are found in the RPC reply they will be added to the list.

```
key: lldp-local-interface | lldp-remote-chassis-id

lldp.keys()
['me0.0', '5c:5e:ab:79:42:80', 'me0.0', '74:99:75:5d:e5:00', 'me0.0', '74:99:75:69:59:00', 'me0.0', '78:fe:3d:6a:67:c0', 'xe-0/1/0.0', 'ac:4b:c8:46:17:c0']
```
