### PR TITLE
Added error information for CommitError

### DIFF
--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -35,6 +35,15 @@ class CommitError(RpcError):
     def __init__(self, cmd=None, rsp=None, errs=None):
         RpcError.__init__(self, cmd, rsp, errs)
         self.rpc_error = jxml.rpc_error(rsp)
+        if self.errs is None:
+            self.errs = self.rpc_error
+
+    def __repr__(self):
+        return "{0}({1},{2},{3})".format(self.__class__.__name__,
+                                         self.rpc_error['edit_path'], self.rpc_error['bad_element'],
+                                         self.rpc_error['message'])
+
+    __str__ = __repr__
 
 
 class LockError(RpcError):

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -48,7 +48,7 @@ class Config(Util):
             * ``True`` when successful
 
         :raises CommitError: When errors detected in candidate configuration.
-                             You can use the Exception variable (XML)
+                             You can use the Exception errs variable
                              to identify the specific problems
 
         .. warning::
@@ -111,11 +111,13 @@ class Config(Util):
         """
         Perform a commit check.  If the commit check passes, this function
         will return ``True``.  If the commit-check results in warnings, they
-        are not reported (at this time).
+        are reported and available in the Exception errs.
 
         :returns: ``True`` if commit-check is successful (no errors)
-        :raises RpcError: when commit-check fails and resulting
-                          exception contains XML data.
+        :raises CommitError: When errors detected in candidate configuration.
+                             You can use the Exception errs variable
+                             to identify the specific problems
+        :raises RpcError: When underlying ncclient has an error
         """
         try:
             self.rpc.commit_configuration(check=True)

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -8,6 +8,21 @@ from jnpr.junos import Device
 from lxml import etree
 
 
+commit_xml = '''
+        <rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+        <error-severity>error</error-severity>
+        <source-daemon>dcd</source-daemon>
+        <error-path>[edit interfaces ge-0/0/1]</error-path>
+        <error-info>
+        <bad-element>unit 2</bad-element>
+        </error-info>
+        <error-message>
+        Only unit 0 is valid for this encapsulation
+        </error-message>
+        </rpc-error>
+    '''
+
+
 @attr('unit')
 class Test_RpcError(unittest.TestCase):
 
@@ -19,9 +34,9 @@ class Test_RpcError(unittest.TestCase):
 
     def test_rpcerror_jxml_check(self):
         # this test is intended to hit jxml code
-        rsp = etree.XML('<rpc-reply><a>test</a></rpc-reply>')
+        rsp = etree.XML(commit_xml)
         obj = CommitError(rsp=rsp)
-        self.assertEqual(type(obj.rpc_error), dict)
+        self.assertEqual(obj.rpc_error['bad_element'], 'unit 2')
 
     def test_ConnectError(self):
         self.dev = Device(host='1.1.1.1', user='rick', password='password123',
@@ -31,3 +46,9 @@ class Test_RpcError(unittest.TestCase):
         self.assertEqual(obj.host, '1.1.1.1')
         self.assertEqual(obj.port, 830)
         self.assertEqual(repr(obj), 'ConnectError(1.1.1.1)')
+
+    def test_CommitError_repr(self):
+        rsp = etree.XML(commit_xml)
+        obj = CommitError(rsp=rsp)
+        self.assertEqual(obj.__repr__(),
+                         'CommitError([edit interfaces ge-0/0/1],unit 2,Only unit 0 is valid for this encapsulation)')


### PR DESCRIPTION
CommitError now contains and displays the error information.

`CommitError([edit interfaces ge-0/0/1],unit 2,Only unit 0 is valid for this encapsulation)`

The information is stored in the errs variable as a dictionary and can be accessed by key:

```
e.errs
{'source': 'dcd', 'message': 'Only unit 0 is valid for this encapsulation', 'bad_element': 'unit 2', 'severity': 'error', 'edit_path': '[edit interfaces ge-0/0/1]'}

e.errs['edit_path']
'[edit interfaces ge-0/0/1]'
```
