### PR TITLE
Use xpath expression to find 'directory' element.

### DIFF
--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -203,7 +203,7 @@ class FS(Util):
         if rsp.find('output') is not None:
             return None
 
-        xdir = rsp.find('directory')
+        xdir = rsp.find('.//directory')
 
         # check to see if the directory element has a :name:
         # attribute, and if it does not, then this is a file, and


### PR DESCRIPTION
Fix exception when path contains routing engine 're1:/var/tmp'.
>>> from jnpr.junos.utils.fs import FS
>>> fs = FS(dev)
>>> x = fs.ls('re1:/var/tmp')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/serg/src/venv/local/lib/python2.7/site-packages/jnpr/junos/utils/fs.py", line 213, in ls
    if not xdir.get('name'):
AttributeError: 'NoneType' object has no attribute 'get'
