### PR TITLE
Support 'proxycommand' from ssh_config in utils/scp

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -231,7 +231,7 @@ class Device(object):
 
     def _sshconf_lkup(self):
         if self._ssh_config:
-            sshconf_path = self._ssh_config
+            sshconf_path = os.path.expanduser(self._ssh_config)
         else:
             home = os.getenv('HOME')
             if not home:

--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -55,6 +55,17 @@ class SCP(object):
         # use junos._hostname since this will be correct if we are going
         # through a jumphost.
 
+        config = {}
+        ssh_config = getattr(junos,'_sshconf_path')
+        if ssh_config:
+            config = paramiko.SSHConfig()
+            config.parse(open(ssh_config))
+            config = config.lookup(junos._hostname)
+        sock = None
+        if config.get("proxycommand"):
+            sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
+
+
         self._ssh.connect(hostname=junos._hostname,
                           port=(
                               22, int(
@@ -62,6 +73,7 @@ class SCP(object):
                               junos._hostname == 'localhost'],
                           username=junos._auth_user,
                           password=junos._auth_password,
+                          sock=sock
                           )
         return SCPClient(self._ssh.get_transport(), **scpargs)
 


### PR DESCRIPTION
I would like to propose support for proxycommand from ssh config for copying files via jumphost.
os.path.expanduser resolve an issue if path to ssh_config specified as following '~/.ssh/config'