### PR TITLE
adding support for qfabric

### DIFF
--- a/lib/jnpr/junos/facts/chassis.py
+++ b/lib/jnpr/junos/facts/chassis.py
@@ -33,8 +33,8 @@ def facts_chassis(junos, facts):
         facts['serialnumber'] = x_ch.find('serial-number').text
     except:
         # if the toplevel chassis does not have a serial-number, then
-        # check the Backplane chassis-module
+        # check the Backplane/Midplane chassis-module
         facts['serialnumber'] = x_ch.xpath(
-            'chassis-module[name="Backplane"]/serial-number')[0].text
+            '//chassis-module[name="Backplane" or name="Midplane"]/serial-number')[0].text
 
 

--- a/lib/jnpr/junos/facts/routing_engines.py
+++ b/lib/jnpr/junos/facts/routing_engines.py
@@ -1,4 +1,5 @@
 import re as RE
+import pdb
 
 def facts_routing_engines(junos, facts):
 
@@ -8,7 +9,10 @@ def facts_routing_engines(junos, facts):
         'model',
         'up-time',
         'last-reboot-reason']
-    re_info = junos.rpc.get_route_engine_information()
+    try:
+        re_info = junos.rpc.get_route_engine_information()
+    except:
+        re_info = junos.rpc.get_route_engine_information(infrastructure="FM-0")
 
     master = []
     re_list = re_info.xpath('.//route-engine')
@@ -38,7 +42,7 @@ def facts_routing_engines(junos, facts):
                 re_fd[factoid.replace('-', '_')] = x_f.text
 
         if 'mastership_state' in re_fd:
-            if facts[re_name]['mastership_state'] == 'master':
+            if facts[re_name]['mastership_state'].find('master') > 0:
                 master.append(re_name)
 
     # --[ end for-each 're' ]-------------------------------------------------

--- a/lib/jnpr/junos/facts/routing_engines.py
+++ b/lib/jnpr/junos/facts/routing_engines.py
@@ -8,6 +8,8 @@ def facts_routing_engines(junos, facts):
         'model',
         'up-time',
         'last-reboot-reason']
+    """QFabric requires an 'infrastructure' argument. Try getting RE info. If an exception is raised it's probably a QFabric so try again with the argument.
+    """
     try:
         re_info = junos.rpc.get_route_engine_information()
     except:

--- a/lib/jnpr/junos/facts/routing_engines.py
+++ b/lib/jnpr/junos/facts/routing_engines.py
@@ -1,5 +1,4 @@
 import re as RE
-import pdb
 
 def facts_routing_engines(junos, facts):
 

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,6 +1,6 @@
 #import time
 #__date__ = time.strftime("%Y-%b-%d")
 
-VERSION = "0.1.2"
-DATE = "2014-May-07"
+VERSION = "1.1.2"
+DATE = "2015-Feb-02"
 


### PR DESCRIPTION
the updates should allow for support of a Qfabric while not impacting support for existing supported devices.

The code returns the following facts about a Qfabric:

(Pdb) pprint(dev.facts)
{'2RE': True,
 'HOME': '/pbdata/packages',
 'RE0': {'last_reboot_reason': '0x200:normal shutdown',
         'mastership_state': 'Protocol backup',
         'model': 'QFX Routing Engine',
         'status': 'Absent',
         'up_time': '4 days, 15 hours, 45 minutes, 44 seconds'},
 'RE1': {'last_reboot_reason': '0x200:normal shutdown',
         'mastership_state': 'Protocol master',
         'model': 'QFX Routing Engine',
         'status': 'Absent',
         'up_time': '4 days, 15 hours, 46 minutes, 35 seconds'},
 'domain': None,
 'fqdn': '<removed>',
 'hostname': '<removed>',
 'ifd_style': 'SWITCH',
 'master': 'RE1',
 'model': 'Virtual Chassis',
 'personality': 'SWITCH',
 'serialnumber': '<removed>',
 'switch_style': 'VLAN',
 'vc_capable': False,
 'version': '13.2X52-D20.51',
 'version_info': junos.version_info(major=(13, 2), type=X, minor=(52, 'D', 20), build=51)}

FYI I have "<removed>" host identifying data.