### PR TITLE
Working config tables

### DIFF
--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -85,6 +85,11 @@ class FactoryLoader(object):
         # will be enhaced, yo!
 
         xpath, opt = f_dict.items()[0]       # get first/only key,value
+
+        if opt == 'group':
+            fields.group(f_name, xpath)
+            return
+
         if 'flag' == opt:
             opt = 'bool'       # flag is alias for bool
 

--- a/lib/jnpr/junos/factory/view.py
+++ b/lib/jnpr/junos/factory/view.py
@@ -220,7 +220,10 @@ class View(object):
         # otherwise, not a sub-table, and handle the field
         astype = item.get('astype', str)
         if 'group' in item:
-            found = self._groups[item['group']].xpath(item['xpath'])
+            if item['group'] in self._groups:
+                found = self._groups[item['group']].xpath(item['xpath'])
+            else:
+                return
         else:
             found = self._xml.xpath(item['xpath'])
 

--- a/lib/jnpr/junos/factory/viewfields.py
+++ b/lib/jnpr/junos/factory/viewfields.py
@@ -58,6 +58,14 @@ class ViewFields(object):
         """
         return self.astype(name, xpath, bool, **kvargs)
 
+    def group(self, name, xpath=None, **kvargs):
+        """
+        field is an apply group, results in value of group attr if the xpath
+        element has the associated group attribute.
+        """
+        xpath = './{0}/@group'.format(xpath)
+        return self.astype(name, xpath, str, **kvargs)
+
     def table(self, name, table):
         """ field is a RunstatTable """
         self._fields.update({

--- a/tests/unit/factory/rpc-reply/get-configuration-user.xml
+++ b/tests/unit/factory/rpc-reply/get-configuration-user.xml
@@ -1,0 +1,21 @@
+﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos">
+	<configuration junos:commit-seconds="1400665891" junos:commit-localtime="2014-05-21 09:51:31 UTC" junos:commit-user="rick">
+		<system>
+			<login>
+				<user group="global">
+					<name group="global">test</name>
+					<full-name group="member0">Test User</full-name>
+					<uid group="global">928</uid>
+					<class group="global">superuser</class>
+					<undocumented><shell group="global">csh</shell></undocumented>
+					<authentication group="global">
+						<encrypted-password group="global">$encryptedpass.</encrypted-password>
+					</authentication>
+				</user>
+			</login>
+		</system>
+	</configuration>
+    <cli>
+        <banner></banner>
+    </cli>	
+</rpc-reply>


### PR DESCRIPTION
Updated Configuration tables for production use.

By default `{'inherit': 'inherit', 'groups': 'groups'}` and full child values are retrieved.  (This is opposite of before).

`get` now has kwargs of `namesonly` and `options`.

group operator has also been added to simplify the gathering of apply-group inheritance.

```yaml
---
UserTable:
  get: system/login/user
  required_keys:
	user: name
  view: userView

userView:
  groups:
	auth: authentication
  fields:
	uid: uid
	class: class
	uidgroup: { uid: group }
	fullgroup: { full-name: group }
  fields_auth:
	pass: encrypted-password
```

Lastly fixed uncaught exception when a group does not exist in a view.  Value of `None` is now returned.


