### PR TITLE
look for resolv.conf file in /var/etc if its not present in /etc

### DIFF
--- a/lib/jnpr/junos/facts/domain.py
+++ b/lib/jnpr/junos/facts/domain.py
@@ -1,5 +1,6 @@
 from jnpr.junos.utils.fs import FS
 
+
 def facts_domain(junos, facts):
     """
     The following facts are required:
@@ -10,7 +11,9 @@ def facts_domain(junos, facts):
         facts['fqdn']
     """
     fs = FS(junos)
-    words = fs.cat('/etc/resolv.conf').split()
+    # changes done to fix issue #332
+    file_content = fs.cat('/etc/resolv.conf') or fs.cat('/var/etc/resolv.conf')
+    words = file_content.split() if file_content is not None else ''
     if 'domain' not in words:
         facts['domain'] = None
         facts['fqdn'] = facts['hostname']

--- a/lib/jnpr/junos/facts/swver.py
+++ b/lib/jnpr/junos/facts/swver.py
@@ -35,7 +35,11 @@ class version_info(object):
                 self.build = after_type[0]  # non-numeric
 
         self.as_tuple = self.major + tuple([self.minor, self.build])
-        self.v_dict = {'major': self.major, 'type': self.type, 'minor': self.minor, 'build': self.build}
+        self.v_dict = {
+            'major': self.major,
+            'type': self.type,
+            'minor': self.minor,
+            'build': self.build}
 
     def __iter__(self):
         for key in self.v_dict:
@@ -122,7 +126,8 @@ def facts_software_version(junos, facts):
 
         if isinstance(f_master, list):
             xpath = './multi-routing-engine-item[re-name="{0}"' \
-                    ']/software-information/host-name'.format(f_master[0].lower())
+                    ']/software-information/host-name'.format(
+                        f_master[0].lower())
         else:
             xpath = './multi-routing-engine-item[re-name="{0}"' \
                     ']/software-information/host-name'.format(f_master.lower())
@@ -143,15 +148,19 @@ def facts_software_version(junos, facts):
             # "FPC<n>" or "ndoe<n>", and normalize to "RE<n>".
             re_name = re.sub(r'(\w+)(\d+)', 'RE\\2', re_name)
 
-            pkginfo = re_sw.xpath(
-                'package-information[normalize-space(name)="junos"]/comment'
-            )[0].text
+            try:
+                pkginfo = re_sw.xpath(
+                    'package-information[normalize-space(name)="junos"]/comment'
+                )[0].text
+            except IndexError:
+                # occam and some build is not having tag <name>junos</name>
+                pkginfo = re_sw.findtext('junos-version')
 
             try:
                 versions.append(
                     (re_name.upper(),
                      re.findall(
-                         r'\[(.*)\]',
+                         r'\[?(.*)\]?',
                          pkginfo)[0]))
             except:
                 versions.append((re_name.upper(), "0.0I0.0"))

--- a/tests/unit/facts/rpc-reply/get-software-information_occam.xml
+++ b/tests/unit/facts/rpc-reply/get-software-information_occam.xml
@@ -1,0 +1,81 @@
+<rpc-reply xmlns:junos="abc">
+    <multi-routing-engine-results>
+
+    <multi-routing-engine-item>
+
+    <re-name>re0</re-name>
+
+    <software-information>
+    <host-name>R1_re0</host-name>
+    <product-model>mx240</product-model>
+    <product-name>mx240</product-name>
+    <junos-version>15.1I20141208_1545</junos-version>
+    <package-information>
+    <name>vmguest</name>
+    <comment>JUNOS Packet Forwarding Engine Trio Simulation Package [20141208.154550_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>os-kernel</name>
+    <comment>JUNOS OS Kernel 32-bit (WITNESS) [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    <package-information>
+    <name>os-runtime</name>
+    <comment>JUNOS OS runtime [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    <package-information>
+    <name>py-base</name>
+    <comment>JUNOS py base [20141208.154550_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>os-zoneinfo</name>
+    <comment>JUNOS OS time zone information [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    <package-information>
+    <name>os-crypto</name>
+    <comment>JUNOS OS crypto [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    <package-information>
+    <name>netstack</name>
+    <comment>JUNOS network stack and utilities [20141208.141758_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>junos-libs</name>
+    <comment>JUNOS libs [20141208.154550_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>junos-runtime</name>
+    <comment>JUNOS runtime [20141208.154550_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>junos-platform</name>
+    <comment>JUNOS platform support [20141208.141758_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    </software-information>
+    </multi-routing-engine-item>
+
+    <multi-routing-engine-item>
+
+    <re-name>re1</re-name>
+
+    <software-information>
+    <host-name>R1_re01</host-name>
+    <product-model>mx240</product-model>
+    <product-name>mx240</product-name>
+    <junos-version>15.1I20141208_1545_xyz</junos-version>
+    <package-information>
+    <name>vmguest</name>
+    <comment>JUNOS Packet Forwarding Engine Trio Simulation Package [20141208.154550_xyz_ib_15_1_psd]</comment>
+    </package-information>
+    <package-information>
+    <name>os-kernel</name>
+    <comment>JUNOS OS Kernel 32-bit (WITNESS) [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    <package-information>
+    <name>os-runtime</name>
+    <comment>JUNOS OS runtime [20141027.113735_fbsd-builder_10]</comment>
+    </package-information>
+    </software-information>
+    </multi-routing-engine-item>
+
+    </multi-routing-engine-results>
+</rpc-reply>

--- a/tests/unit/facts/test_domain.py
+++ b/tests/unit/facts/test_domain.py
@@ -40,3 +40,10 @@ class TestDomain(unittest.TestCase):
         facts_domain(self.dev, self.facts)
         self.assertEqual(self.facts['domain'], None)
         self.assertEqual(self.facts['fqdn'], 'test')
+
+    @patch('jnpr.junos.facts.domain.FS.cat')
+    def test_resolv_conf_file_absent_under_etc(self, mock_fs_cat):
+        mock_fs_cat.return_value = None
+        self.facts['hostname'] = 'test'
+        facts_domain(self.dev, self.facts)
+        mock_fs_cat.assert_called_with('/var/etc/resolv.conf')

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -103,9 +103,9 @@ class TestConfig(unittest.TestCase):
     def test_config_load(self):
         self.assertRaises(RuntimeError, self.conf.load)
 
-    def test_config_load_vargs_len(self):
-        self.assertRaises(RuntimeError, self.conf.load,
-                          'test.xml')
+    def test_config_load_path_err(self):
+        self.assertRaises(IOError, self.conf.load,
+                          path='test.xml')
 
     def test_config_load_len_with_format_set(self):
         self.conf.rpc.load_config = \
@@ -123,6 +123,44 @@ class TestConfig(unittest.TestCase):
         </snmp>"""
 
         self.assertEqual(self.conf.load(xmldata, format='xml'),
+                         'rpc_contents')
+
+    def test_config_load_len_without_format_text(self):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value='rpc_contents')
+        data = """routing-options {
+        static {
+            route 10.205.0.0/16 {
+                next-hop 10.0.200.1;
+                community [ 47000:660 ];
+            }
+        }
+        }"""
+
+        self.assertEqual(self.conf.load(data),
+                         'rpc_contents')
+
+    def test_config_load_len_without_format_set(self):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value='rpc_contents')
+        set_commands="""
+        set system host-name choc-mx240-b
+        set system domain-name englab.juniper.net
+        """
+
+        self.assertEqual(self.conf.load(set_commands),
+                         'rpc_contents')
+
+    def test_config_load_len_without_format(self):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value='rpc_contents')
+        xmldata = """<snmp>
+          <community>
+            <name>iBGP</name>
+          </community>
+        </snmp>"""
+
+        self.assertEqual(self.conf.load(xmldata),
                          'rpc_contents')
 
     @patch('__builtin__.open')


### PR DESCRIPTION
If resolv.conf is not present at both locations then domain & fqdn will be set to None as per old design when resolv.conf was present but didn't contained expected data.