### PR TITLE
Add information to ConnectError

### DIFF
--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -1,4 +1,3 @@
-from lxml import etree
 from jnpr.junos import jxml
 
 
@@ -129,6 +128,9 @@ class ConnectError(Exception):
     """
     Parent class for all connection related exceptions
     """
+    def __init__(self, dev, msg=None):
+        self.dev = dev
+        self._orig = msg
 
     @property
     def user(self):
@@ -145,15 +147,18 @@ class ConnectError(Exception):
         """ login SSH port """
         return self.dev._port
 
-    def __init__(self, dev):
-        self.dev = dev
-        # @@@ need to attach attributes for each access
-        # @@@ to user-name, host, jump-host, etc.
+    @property
+    def msg(self):
+        """ login SSH port """
+        return self._orig
 
     def __repr__(self):
-        return "{0}({1})".format(
-            self.__class__.__name__,
-            self.dev.hostname)
+        if self._orig:
+            return "{0}(host: {1}, msg: {2})".format(self.__class__.__name__,
+                                                     self.dev.hostname, self._orig)
+        else:
+            return "{0}({1})".format(self.__class__.__name__,
+                                     self.dev.hostname)
 
     __str__ = __repr__
 

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -61,13 +61,18 @@ class Test_RpcError(unittest.TestCase):
         self.assertEqual(obj.rpc_error['bad_element'], 'unit 2')
 
     def test_ConnectError(self):
-        self.dev = Device(host='1.1.1.1', user='rick', password='password123',
-                          gather_facts=False)
+        self.dev = Device(host='1.1.1.1', user='rick')
         obj = ConnectError(self.dev)
         self.assertEqual(obj.user, 'rick')
         self.assertEqual(obj.host, '1.1.1.1')
         self.assertEqual(obj.port, 830)
         self.assertEqual(repr(obj), 'ConnectError(1.1.1.1)')
+
+    def test_ConnectError_msg(self):
+        self.dev = Device(host='1.1.1.1', user='rick')
+        obj = ConnectError(self.dev, msg='underlying exception info')
+        self.assertEqual(obj.msg, 'underlying exception info')
+        self.assertEqual(repr(obj), 'ConnectError(host: 1.1.1.1, msg: underlying exception info)')
 
     def test_CommitError_repr(self):
         rsp = etree.XML(commit_xml)


### PR DESCRIPTION
Add underlying exception information to ConnectError and repr when present.

```python
>>> dev.open()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/tmp/conex/lib/python2.7/site-packages/jnpr/junos/device.py", line 451, in open
    raise cnx_err
jnpr.junos.exception.ConnectError: ConnectError(host: 1.1.1.1, msg: ('192.168.74.31 ecdsa-sha2-nistp256 badkeysl;kj23o09a;dihads;l', Error('Incorrect padding',)))

>>> try:
...     dev.open()
... except Exception as e:
...     print e
...
ConnectError(host: 1.1.1.1, msg: ('192.168.74.31 ecdsa-sha2-nistp256 badkeysl;kj23o09a;dihads;l', Error('Incorrect padding',)))
>>>
>>> e.msg
InvalidHostKey('192.168.74.31 ecdsa-sha2-nistp256 badkeysl;kj23o09a;dihads;l', Error('Incorrect padding',))
>>> e.port
830
>>> e.user
'rsherman'

>>> dev.open()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/var/tmp/conex/lib/python2.7/site-packages/jnpr/junos/device.py", line 433, in open
    raise EzErrors.ConnectTimeoutError(self)
jnpr.junos.exception.ConnectTimeoutError: ConnectTimeoutError(1.1.1.1)
```

This resolves #349 