### PR TITLE
Added ConnectClosedError exception to handled closed/unopened devices

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -429,7 +429,7 @@ class Device(object):
             # at this point, we assume that the connection
             # has timeed out due to ip-reachability issues
 
-            if err.message.find('not open') > 0:
+            if str(err).find('not open') > 0:
                 raise EzErrors.ConnectTimeoutError(self)
             else:
                 # otherwise raise a generic connection
@@ -499,6 +499,9 @@ class Device(object):
             native python data-types (e.g. ``dict``).
         """
 
+        if self.connected is not True:
+            raise EzErrors.ConnectClosedError(self)
+
         if isinstance(rpc_cmd, str):
             rpc_cmd_e = etree.XML(rpc_cmd)
         elif isinstance(rpc_cmd, etree._Element):
@@ -518,6 +521,8 @@ class Device(object):
             # err is a TimeoutExpiredError from ncclient,
             # which has no such attribute as xml.
             raise EzErrors.RpcTimeoutError(self, rpc_cmd_e.tag, self.timeout)
+        except NcErrors.TransportError:
+            raise EzErrors.ConnectClosedError(self)
         except RPCError as err:
             # err is an NCError from ncclient
             rsp = JXML.remove_namespaces(err.xml)

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -209,3 +209,12 @@ class ConnectNotMasterError(ConnectError):
     device, or a virtual-chassis member (linecard), for example
     """
     pass
+
+
+class ConnectClosedError(ConnectError):
+    """
+    Generated if connection unexpectedly closed
+    """
+    def __init__(self, dev):
+        ConnectError.__init__(self, dev=dev)
+        dev.connected = False


### PR DESCRIPTION
Added exception for devices that are unexpectedly closed or never opened.
```python
jnpr.junos.exception.ConnectClosedError: ConnectClosedError(192.168.74.31)
```
When this exception is thrown `device.connected` is set to `False`

If the user tries to execute a RPC prior to opening a device this same exception is thrown (as opposed to failing to find the bound rpc object.

This resolves #339 