### PR TITLE
Added SwRollbackError exception and logic to sw.rollback

### DIFF
--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -5,19 +5,21 @@ class RpcError(Exception):
     """
     Parent class for all junos-pyez RPC Exceptions
     """
-    def __init__(self, cmd=None, rsp=None, errs=None, dev=None, timeout=None):
+    def __init__(self, cmd=None, rsp=None, errs=None, dev=None, timeout=None, re=None):
         """
           :cmd: is the rpc command
           :rsp: is the rpc response (after <rpc-reply>)
           :errs: is a list of <rpc-error> elements
           :dev: is the device rpc was executed on
           :timeout: is the timeout value of the device
+          :re: is the RE or member exception occured on
         """
         self.cmd = cmd
         self.rsp = rsp
         self.errs = errs
         self.dev = dev
         self.timeout = timeout
+        self.re = re
 
     def __repr__(self):
         """
@@ -113,6 +115,24 @@ class RpcTimeoutError(RpcError):
     def __repr__(self):
         return "{0}(host: {1}, cmd: {2}, timeout: {3})"\
             .format(self.__class__.__name__, self.dev.hostname, self.cmd, self.timeout)
+
+    __str__ = __repr__
+
+
+class SwRollbackError(RpcError):
+    """
+    Generated in response to a SW rollback error.
+    """
+    def __init__(self, re=None, rsp=None):
+        RpcError.__init__(self, re=re, rsp=rsp)
+
+    def __repr__(self):
+        if self.re:
+            return "{0}(re: {1}, output: {2})"\
+                .format(self.__class__.__name__, self.re, self.rsp)
+        else:
+            return "{0}(output: {1})".format(self.__class__.__name__,
+                                             self.rsp)
 
     __str__ = __repr__
 

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -4,7 +4,7 @@ __credits__ = "Jeremy Schulman"
 import unittest
 from nose.plugins.attrib import attr
 from jnpr.junos.exception import RpcError, CommitError, \
-    ConnectError, ConfigLoadError, RpcTimeoutError
+    ConnectError, ConfigLoadError, RpcTimeoutError, SwRollbackError
 from jnpr.junos import Device
 from lxml import etree
 
@@ -91,4 +91,14 @@ class Test_RpcError(unittest.TestCase):
         dev = Device('test')
         obj = RpcTimeoutError(dev=dev, cmd='test', timeout=50)
         err = 'RpcTimeoutError(host: test, cmd: test, timeout: 50)'
+        self.assertEqual(obj.__repr__(), err)
+
+    def test_SwRollbackError_repr(self):
+        obj = SwRollbackError(rsp="Single RE exception")
+        err = 'SwRollbackError(output: Single RE exception)'
+        self.assertEqual(obj.__repr__(), err)
+
+    def test_SwRollbackError_repr_multi(self):
+        obj = SwRollbackError(re='test1', rsp="Multi RE exception")
+        err = 'SwRollbackError(re: test1, output: Multi RE exception)'
         self.assertEqual(obj.__repr__(), err)

--- a/tests/unit/utils/rpc-reply/request-package-rollback-multi-error.xml
+++ b/tests/unit/utils/rpc-reply/request-package-rollback-multi-error.xml
@@ -1,0 +1,24 @@
+﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
+    <multi-routing-engine-results>
+
+		<multi-routing-engine-item>
+
+			<re-name>fpc0</re-name>
+
+			<output>JUNOS version "D10.2" will become active at next reboot</output>
+			<package-result>0</package-result>
+		</multi-routing-engine-item>	
+        
+        <multi-routing-engine-item>
+            
+            <re-name>member1</re-name>
+            
+            <output>ERROR: cannot locate jroute-14.2I20140424_0657_ramas: rollback aborted</output>
+            <package-result>1</package-result>
+        </multi-routing-engine-item>
+        
+    </multi-routing-engine-results>
+    <cli>
+        <banner>{master:member1-re0}</banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/utils/rpc-reply/request-package-rollback.xml
+++ b/tests/unit/utils/rpc-reply/request-package-rollback.xml
@@ -1,16 +1,24 @@
 <rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
-    <multi-routing-engine-results>
-        
-        <multi-routing-engine-item>
-            
-            <re-name>member1</re-name>
-            
-            <output>ERROR: cannot locate jroute-14.2I20140424_0657_ramas: rollback aborted</output>
-            <package-result>1</package-result>
-        </multi-routing-engine-item>
-        
-    </multi-routing-engine-results>
-    <cli>
-        <banner>{master:member1-re0}</banner>
-    </cli>
+	<multi-routing-engine-results>
+
+		<multi-routing-engine-item>
+
+			<re-name>fpc0</re-name>
+
+			<output>JUNOS version "D10.2" will become active at next reboot</output>
+			<package-result>0</package-result>
+		</multi-routing-engine-item>
+
+		<multi-routing-engine-item>
+
+			<re-name>fpc1</re-name>
+
+			<output>Junos version 'D10.2' will become active at next reboot</output>
+			<package-result>0</package-result>
+		</multi-routing-engine-item>
+
+	</multi-routing-engine-results>
+	<cli>
+		<banner>{master:member1-re0}</banner>
+	</cli>
 </rpc-reply>


### PR DESCRIPTION
The sw.rollback() function previously did not return the correct information.
Added proper output for single and multi-re/vc systems and new SwRollbackError exception.
Resolves #356 