### PR TITLE
Added op files to get transceiver light levels, temperature, etc

### DIFF
--- a/lib/jnpr/junos/op/intopticdiag.py
+++ b/lib/jnpr/junos/op/intopticdiag.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for IntOpticDiag Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/intopticdiag.yml
+++ b/lib/jnpr/junos/op/intopticdiag.yml
@@ -1,0 +1,22 @@
+---
+
+PhyPortDiagTable:
+  rpc: get-interface-optics-diagnostics-information
+  args:
+    interface_name: '[fgx]e*'
+  args_key: interface_name
+  item: physical-interface
+  view: PhyPortDiagView
+
+PhyPortDiagView:
+  groups:
+    diag: optics-diagnostics
+
+  # fields that are part of groups are called
+  # "fields_<group-name>"
+
+  fields_diag:
+    rx_optic_power : rx-signal-avg-optical-power-dbm
+    tx_optic_power : laser-output-power-dbm
+    module_temperature : module-temperature
+    module_voltage : module-voltage


### PR DESCRIPTION
Simple addition to lib/jnpr/junos/op/ to add support for gathering transmit/receive light level, temperature and voltage.  Can easily be expanded in fields_diag for thresholds if desired.