### PR TITLE
routes.yml: add default destination ('0.0.0.0/0')

### DIFF
--- a/lib/jnpr/junos/op/routes.yml
+++ b/lib/jnpr/junos/op/routes.yml
@@ -6,6 +6,8 @@
 
 RouteTable:
   rpc: get-route-information
+  args:
+    destination: '0.0.0.0/0'
   args_key: destination
   item: route-table/rt 
   key: rt-destination


### PR DESCRIPTION
Default ```destination``` will allow to make specific queries in a more natural way.

```
>>> prefixes = routes.get(community="1:2...$")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/junos_eznc-1.2.0.dev-py2.7.egg/jnpr/junos/factory/optable.py", line 63, in get
    self.xml = getattr(self.RPC, self.GET_RPC)(**rpc_args)
  File "/usr/local/lib/python2.7/dist-packages/junos_eznc-1.2.0.dev-py2.7.egg/jnpr/junos/rpcmeta.py", line 137, in _exec_rpc
    return self._junos.execute(rpc)
  File "/usr/local/lib/python2.7/dist-packages/junos_eznc-1.2.0.dev-py2.7.egg/jnpr/junos/decorators.py", line 25, in wrapper
    return function(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/junos_eznc-1.2.0.dev-py2.7.egg/jnpr/junos/device.py", line 531, in execute
    raise e(cmd=rpc_cmd_e, rsp=rsp)
jnpr.junos.exception.RpcError: RpcError(severity: error, bad_element: community, message: syntax error, expecting <rpc> or </rpc>)
>>> 
```