### PR TITLE
Add normalize decorator

### DIFF
--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -13,8 +13,7 @@ def timeoutDecorator(function):
             except:
                 dev = args[0]
             restore_timeout = dev.timeout
-            dev.timeout = kwargs['dev_timeout']
-            kwargs.pop('dev_timeout', None)
+            dev.timeout = kwargs.pop('dev_timeout', None)
             try:
                 result = function(*args, **kwargs)
                 dev.timeout = restore_timeout
@@ -35,8 +34,7 @@ def normalizeDecorator(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         if 'normalize' in kwargs:
-            normalize = kwargs['normalize']
-            kwargs.pop('normalize', None)
+            normalize = kwargs.pop('normalize', None)
             try:
                 dev = args[0].dev
             except:
@@ -56,7 +54,7 @@ def normalizeDecorator(function):
                         raise
                 else:
                     try:
-                        dev.transform = normalize_xslt
+                        dev.transform = dev._norm_transform
                         result = function(*args, **kwargs)
                         dev.transform = restore_transform
                         return result

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -1,6 +1,8 @@
 # stdlib
 from functools import wraps
 
+from jnpr.junos.jxml import normalize_xslt
+
 
 def timeoutDecorator(function):
     @wraps(function)
@@ -20,6 +22,52 @@ def timeoutDecorator(function):
             except Exception:
                 dev.timeout = restore_timeout
                 raise
+        else:
+            try:
+                return function(*args, **kwargs)
+            except Exception:
+                raise
+
+    return wrapper
+
+
+def normalizeDecorator(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if 'normalize' in kwargs:
+            normalize = kwargs['normalize']
+            kwargs.pop('normalize', None)
+            try:
+                dev = args[0].dev
+            except:
+                dev = args[0]
+
+            if dev._normalize != normalize:
+                restore_transform = dev.transform
+
+                if normalize is False:
+                    try:
+                        dev.transform = dev._nc_transform
+                        result = function(*args, **kwargs)
+                        dev.transform = restore_transform
+                        return result
+                    except Exception:
+                        dev.transform = restore_transform
+                        raise
+                else:
+                    try:
+                        dev.transform = normalize_xslt
+                        result = function(*args, **kwargs)
+                        dev.transform = restore_transform
+                        return result
+                    except Exception:
+                        dev.transform = restore_transform
+                        raise
+            else:
+                try:
+                    return function(*args, **kwargs)
+                except Exception:
+                    raise
         else:
             try:
                 return function(*args, **kwargs)

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -311,8 +311,8 @@ class Device(object):
             By default ~/.ssh/config is queried.
 
         :param bool normalize:
-            *OPTIONAL* default is ``True``.  If ``False`` then the
-            XML returned by :meth:`open` does not have whitespace normalized
+            *OPTIONAL* default is ``False``.  If ``True`` then the
+            XML returned by :meth:`execute` will have whitespace normalized
         """
 
         # ----------------------------------------
@@ -323,7 +323,7 @@ class Device(object):
 
         self._port = kvargs.get('port', 830)
         self._gather_facts = kvargs.get('gather_facts', True)
-        self._normalize = kvargs.get('normalize', True)
+        self._normalize = kvargs.get('normalize', False)
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
 
         if self.__class__.ON_JUNOS is True and hostname is None:
@@ -384,6 +384,10 @@ class Device(object):
         :param bool auto_probe:
             If non-zero then this enables auto_probe and defines the amount
             of time/seconds for the probe timeout
+
+        :param bool normalize:
+            If set to ``True``/``False`` will override the device
+            instance value for only this open process
 
         :returns Device: Device instance (*self*).
 
@@ -479,10 +483,11 @@ class Device(object):
         self.connected = True
 
         self._nc_transform = self.transform
+        self._norm_transform = lambda: JXML.normalize_xslt
 
         normalize = kvargs.get('normalize', self._normalize)
         if normalize is True:
-            self.transform = lambda: JXML.normalize_xslt
+            self.transform = self._norm_transform
 
         gather_facts = kvargs.get('gather_facts', self._gather_facts)
         if gather_facts is True:

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -42,6 +42,34 @@ INHERIT_GROUPS = {'inherit': 'inherit', 'groups': 'groups'}
 INHERIT_DEFAULTS = {'inherit': 'defaults', 'groups': 'groups'}
 
 
+normalize_xslt = '''\
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:output method="xml" indent="no"/>
+
+            <xsl:template match="/|comment()|processing-instruction()">
+                <xsl:copy>
+                    <xsl:apply-templates/>
+                </xsl:copy>
+            </xsl:template>
+
+            <xsl:template match="*">
+                <xsl:element name="{local-name()}">
+                    <xsl:apply-templates select="@*|node()"/>
+                </xsl:element>
+            </xsl:template>
+
+            <xsl:template match="@*">
+                <xsl:attribute name="{local-name()}">
+                    <xsl:value-of select="."/>
+                </xsl:attribute>
+            </xsl:template>
+
+            <xsl:template match="text()">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:template>
+        </xsl:stylesheet>'''
+
+
 def remove_namespaces(xml):
     for elem in xml.getiterator():
         i = elem.tag.find('}')

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -108,7 +108,7 @@ class _RpcMetaExec(object):
             # kvargs are the command parameter/values
             if kvargs:
                 for arg_name, arg_value in kvargs.items():
-                    if arg_name != 'dev_timeout':
+                    if arg_name not in ['dev_timeout', 'normalize']:
                         arg_name = re.sub('_', '-', arg_name)
                         if isinstance(arg_value, (tuple, list)):
                             for a in arg_value:
@@ -126,15 +126,21 @@ class _RpcMetaExec(object):
                     if v is not True:
                         rpc.attrib[k] = v
 
+            # gather any decorator keywords
+            timeout = kvargs.get('dev_timeout')
+            normalize = kvargs.get('normalize')
+
+            dec_args = {}
+
+            if timeout is not None:
+                dec_args['dev_timeout'] = timeout
+            if normalize is not None:
+                dec_args['normalize'] = normalize
+
             # now invoke the command against the
             # associated :junos: device and return
             # the results per :junos:execute()
-            timeout = kvargs.get('dev_timeout')
-
-            if timeout:
-                return self._junos.execute(rpc, dev_timeout=timeout)
-            else:
-                return self._junos.execute(rpc)
+            return self._junos.execute(rpc, **dec_args)
 
         # metabind help() and the function name to the :rpc_cmd_name:
         # provided by the caller ... that's about all we can do, yo!

--- a/tests/functional/test_core.py
+++ b/tests/functional/test_core.py
@@ -44,3 +44,11 @@ class TestCore(unittest.TestCase):
     def test_device_rpc_timeout(self):
         with self.assertRaises(RpcTimeoutError):
             self.dev.rpc.traceroute(noresolve=True, host='8.8.8.8', dev_timeout=1)
+
+    def test_device_rpc_normalize_true(self):
+        rsp = self.dev.rpc.get_interface_information(interface_name='ge-0/0/0', normalize=True)
+        self.assertEqual(rsp.xpath('physical-interface/name')[0].text, 'ge-0/0/0')
+
+    def test_device_rpc_normalize_false(self):
+        rsp = self.dev.rpc.get_interface_information(interface_name='ge-0/0/0', normalize=False)
+        self.assertEqual(rsp.xpath('physical-interface/name')[0].text, '\nge-0/0/0\n')

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -5,7 +5,6 @@ from nose.plugins.attrib import attr
 
 from jnpr.junos.device import Device
 from jnpr.junos.decorators import timeoutDecorator, normalizeDecorator
-from jnpr.junos.jxml import normalize_xslt
 
 from mock import patch, PropertyMock, call
 
@@ -26,7 +25,9 @@ class Test_Decorators(unittest.TestCase):
     def test_timeout(self):
         with patch('jnpr.junos.Device.timeout', new_callable=PropertyMock) as mock_timeout:
             mock_timeout.return_value = 30
-            function = lambda x: x
+
+            def function(x):
+                return x
             decorator = timeoutDecorator(function)
             decorator(self.dev, dev_timeout=10)
             calls = [call(), call(10), call(30)]
@@ -50,7 +51,9 @@ class Test_Decorators(unittest.TestCase):
     def test_normalize_true_true(self):
         with patch('jnpr.junos.Device.transform', new_callable=PropertyMock) as mock_transform:
             self.dev._normalize = True
-            function = lambda x: x
+
+            def function(x):
+                return x
             decorator = normalizeDecorator(function)
             decorator(self.dev, normalize=True)
             self.assertFalse(mock_transform.called)
@@ -72,7 +75,9 @@ class Test_Decorators(unittest.TestCase):
         with patch('jnpr.junos.Device.transform', new_callable=PropertyMock) as mock_transform:
             mock_transform.return_value = 'o.g.'
             self.dev._normalize = True
-            function = lambda x: x
+
+            def function(x):
+                return x
             decorator = normalizeDecorator(function)
             decorator(self.dev, normalize=False)
             calls = [call(), call(self.dev._nc_transform), call('o.g.')]
@@ -97,10 +102,12 @@ class Test_Decorators(unittest.TestCase):
         with patch('jnpr.junos.Device.transform', new_callable=PropertyMock) as mock_transform:
             mock_transform.return_value = 'o.g.'
             self.dev._normalize = False
-            function = lambda x: x
+
+            def function(x):
+                return x
             decorator = normalizeDecorator(function)
             decorator(self.dev, normalize=True)
-            calls = [call(), call(normalize_xslt), call('o.g.')]
+            calls = [call(), call(self.dev._norm_transform), call('o.g.')]
             #print mock_transform.call_args_list
             mock_transform.assert_has_calls(calls)
 
@@ -115,7 +122,7 @@ class Test_Decorators(unittest.TestCase):
             decorator = normalizeDecorator(function)
             with self.assertRaises(Exception):
                 decorator(self.dev, normalize=True)
-            calls = [call(), call(normalize_xslt), call('o.g.')]
+            calls = [call(), call(self.dev._norm_transform), call('o.g.')]
             #print mock_transform.call_args_list
             mock_transform.assert_has_calls(calls)
 
@@ -123,7 +130,9 @@ class Test_Decorators(unittest.TestCase):
     def test_normalize_false_false(self):
         with patch('jnpr.junos.Device.transform', new_callable=PropertyMock) as mock_transform:
             self.dev._normalize = False
-            function = lambda x: x
+
+            def function(x):
+                return x
             decorator = normalizeDecorator(function)
             decorator(self.dev, normalize=False)
             self.assertFalse(mock_transform.called)

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -234,6 +234,14 @@ class TestDevice(unittest.TestCase):
         self.assertEqual(self.dev.manages, [],
                          'By default manages will be empty list')
 
+    @patch('ncclient.manager.connect')
+    @patch('jnpr.junos.Device.execute')
+    def test_device_open_normalize(self, mock_connect, mock_execute):
+        mock_connect.side_effect = self._mock_manager
+        self.dev2 = Device(host='2.2.2.2', user='rick', password='password123')
+        self.dev2.open(gather_facts=False, normalize=True)
+        self.assertEqual(self.dev2.transform, self.dev2._norm_transform)
+
     def test_device_set_facts_exception(self):
         try:
             self.dev.facts = 'test'
@@ -274,7 +282,7 @@ class TestDevice(unittest.TestCase):
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_rpc_text(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.assertIn('<get-system-uptime-information/>', self.dev.display_xml_rpc('show system uptime ', format='text'))
+        self.assertIn('<get-system-uptime-information>', self.dev.display_xml_rpc('show system uptime ', format='text'))
 
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_exception(self, mock_execute):

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -274,7 +274,7 @@ class TestDevice(unittest.TestCase):
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_rpc_text(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.assertIn('<get-system-uptime-information>', self.dev.display_xml_rpc('show system uptime ', format='text'))
+        self.assertIn('<get-system-uptime-information/>', self.dev.display_xml_rpc('show system uptime ', format='text'))
 
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_exception(self, mock_execute):

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -69,6 +69,11 @@ class Test_RpcMetaExec(unittest.TestCase):
                          'test')
 
     @patch('jnpr.junos.device.Device.execute')
+    def test_rpcmeta_exec_rpc_normalize(self, mock_execute_fn):
+        self.rpc.any_ole_rpc(normalize=True)
+        self.assertEqual(mock_execute_fn.call_args[1], {'normalize': True})
+
+    @patch('jnpr.junos.device.Device.execute')
     def test_rpcmeta_get_config(self, mock_execute_fn):
         root = etree.XML('<root><a>test</a></root>')
         self.rpc.get_config(root)


### PR DESCRIPTION
This feature adds the ability to override the ncclient XML transform with one that will normalize whitespace.

Currently this feature is is disabled by default and must be enabled at either the device or RPC level

```python
dev = Device(host='1.1.1.1', normalize=True)
dev.open(normalize=True)
dev.rpc.any_rpc(normalize=True)
```

This may be turned on by default in 2.0+
#342
