### PR TITLE
Normalize OpTables by default via decorator

### DIFF
--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -52,7 +52,7 @@ class OpTable(Table):
 
         argkey = vargs[0] if len(vargs) else None
 
-        rpc_args = {}                     # create empty <dict>
+        rpc_args = {'normalize': True}    # create default <dict>
         rpc_args.update(self.GET_ARGS)    # copy default args
         rpc_args.update(kvargs)           # copy caller provided args
 

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -294,7 +294,7 @@ class Table(object):
 
         def get_xpath(find_value):
             namekey_xpath, item_xpath = self._keyspec()
-            xnkv = '[normalize-space({0})="{1}"]'
+            xnkv = '[{0}="{1}"]'
 
             if isinstance(find_value, str):
                 # find by name, simple key

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -102,6 +102,8 @@ class TestFactoryOpTable(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
+            if 'normalize' in kwargs and args:
+                return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)
             session = SSHSession(device_handler)

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -146,6 +146,8 @@ class TestFactoryTable(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
+            if 'normalize' in kwargs and args:
+                return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)
             session = SSHSession(device_handler)

--- a/tests/unit/factory/test_to_json.py
+++ b/tests/unit/factory/test_to_json.py
@@ -80,6 +80,8 @@ class TestToJson(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
+            if 'normalize' in kwargs and args:
+                return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)
             session = SSHSession(device_handler)


### PR DESCRIPTION
OpTables by default used normalize-space on Keys.  Values however did not and issues were encountered. 

Updated code to use Normalize decorator by default, and can be disabled in either the definition or get:

```yaml
SessionTable:
  rpc:  get-flow-session-information
  item:  .//flow-session
  key:  session-identifier
  args:
    normalize: False
  view:  SessionView
```

```python
session_table.get(normalize=False)
```

