### PR TITLE
Move rpc_error to RpcError init & add timeout to remote_checksum

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -129,8 +129,10 @@ class Config(Util):
         except Exception as err:
             # so the ncclient gives us something I don't want.  I'm going to
             # convert it and re-raise the commit error
-            JXML.remove_namespaces(err.xml)
-            raise CommitError(rsp=err.xml)
+            if hasattr(err, 'xml') and isinstance(err.xml, etree._Element):
+                raise CommitError(rsp=err.xml)
+            else:
+                raise
 
         if detail:
             return rsp

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -80,12 +80,19 @@ class TestConfig(unittest.TestCase):
                                 **{'synchronize': True, 'full': True, 'force-synchronize': True})
 
     @patch('jnpr.junos.utils.config.JXML.remove_namespaces')
-    def test_config_commit_exception(self, mock_jxml):
+    def test_config_commit_xml_exception(self, mock_jxml):
         class MyException(Exception):
-            xml = 'test'
+            xml = etree.fromstring('<test/>')
         self.conf.rpc.commit_configuration = \
             MagicMock(side_effect=MyException)
-        self.assertRaises(AttributeError, self.conf.commit)
+        self.assertRaises(CommitError, self.conf.commit)
+
+    def test_config_commit_exception(self):
+        class MyException(Exception):
+            pass
+        self.conf.rpc.commit_configuration = \
+            MagicMock(side_effect=MyException)
+        self.assertRaises(MyException, self.conf.commit)
 
     def test_config_commit_exception_RpcError(self):
         ex = RpcError(rsp='ok')


### PR DESCRIPTION
rpc_error was previously instantiated only during repr of RpcError, moved to init so that it is available as part of the exception itself.

Added timeout with value of 5 mins to remote_checksum
Resolves #384