### PR TITLE
Add options to CfgTable yaml

### DIFF
--- a/lib/jnpr/junos/factory/cfgtable.py
+++ b/lib/jnpr/junos/factory/cfgtable.py
@@ -20,6 +20,7 @@ class CfgTable(Table):
         self.ITEM_NAME_XPATH = self._data_dict.get('key', 'name')
         self.ITEM_XPATH = self._data_dict['get']
         self.view = self._data_dict.get('view')
+        self._options = self._data_dict.get('options')
 
     # -----------------------------------------------------------------------
     # PROPERTIES
@@ -210,7 +211,10 @@ class CfgTable(Table):
         if 'options' in kvargs:
             options = kvargs.get('options') or {}
         else:
-            options = jxml.INHERIT_GROUPS
+            if self._options is not None:
+                options = self._options
+            else:
+                options = jxml.INHERIT_GROUPS
 
         # for debug purposes
         self._get_cmd = get_cmd

--- a/tests/unit/factory/test_cfgtable.py
+++ b/tests/unit/factory/test_cfgtable.py
@@ -46,6 +46,12 @@ yaml_data = \
         fullgroup: { full-name: group }
       fields_auth:
         pass: encrypted-password
+
+    GroupTable:
+        get: groups
+        item:
+        args_key: name
+        options: {}
       """
 globals().update(FactoryLoader().load(yaml.load(yaml_data)))
 
@@ -85,6 +91,13 @@ class TestFactoryCfgTable(unittest.TestCase):
         mock_execute.side_effect = self._mock_manager
         self.zit.get(security_zone='untrust', options={'inherit': 'defaults', 'groups': 'groups'})
         self.assertEqual(self.zit._get_opt, {'inherit': 'defaults', 'groups': 'groups'})
+
+    @patch('jnpr.junos.Device.execute')
+    def test_cfgtable_table_options(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        gt = GroupTable(self.dev)
+        gt.get()
+        self.assertEqual(gt._get_opt, {})
 
     def test_optable_get_key_required_error(self):
         self.assertRaises(ValueError, self.zit.get)


### PR DESCRIPTION
Adds the ability to specify options directly in CfgTable yaml

```yaml
ConfigTable:
    get: groups
    item:
    args_key: name
    options: {}
    view: ConfigView
```

```yaml
ConfigTable:
    get: groups
    item:
    args_key: name
    options: {'inherit': 'defaults', 'groups': 'groups'}
    view: ConfigView
```

Resolves #387 