### PR TITLE
Use XSLT to strip RPC XML Comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: python
-cache: apt
+sudo: false
 
 python:
   - "2.6"
   - "2.7"
 
-before_install:
-  - sudo apt-get install -qq python-dev libxml2-dev libxslt-dev
+addons:
+  apt:
+    packages:
+    - python-dev
+    - libxml2-dev
+    - libxslt1-dev
 
 install:
   - "pip install -r development.txt"

--- a/lib/jnpr/junos/factory/to_json.py
+++ b/lib/jnpr/junos/factory/to_json.py
@@ -1,5 +1,7 @@
+from jnpr.junos.jxml import strip_comments_transform
 import json
 from lxml import etree
+from copy import deepcopy
 
 
 class TableJSONEncoder(json.JSONEncoder):
@@ -46,10 +48,9 @@ class PyEzJSONEncoder(json.JSONEncoder):
             obj = obj.v_dict
         elif isinstance(obj, etree._Element):
             def recursive_dict(element):
-                # JSON does not support comments - pass over them
-                if isinstance(element, etree._Comment):
-                    element = element.getnext()
                 return element.tag, dict(map(recursive_dict, element)) or element.text
+            # JSON does not support comments - strip them
+            obj = strip_comments_transform(deepcopy(obj)).getroot()
             _, obj = recursive_dict(obj)
         else:
             obj = super(PyEzJSONEncoder, self).default(obj)

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -113,6 +113,25 @@ normalize_xslt = '''\
         </xsl:stylesheet>'''
 
 
+# XSLT to strip comments
+strip_comments_xslt = '''\
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="node()|@*" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+   </xsl:template>
+   <xsl:template match="comment()"/>
+</xsl:stylesheet>'''
+
+strip_xslt_root = etree.XML(strip_comments_xslt)
+strip_comments_transform = etree.XSLT(strip_xslt_root)
+
+
 def remove_namespaces(xml):
     for elem in xml.getiterator():
         i = elem.tag.find('}')


### PR DESCRIPTION
A more robust solution to dealing with the XML comments is to clear them out using XSLT.  (This also introduces the new Travis container based build).