### PR TITLE
Properly suppress Paramiko logger warnings

### DIFF
--- a/lib/jnpr/junos/__init__.py
+++ b/lib/jnpr/junos/__init__.py
@@ -8,6 +8,7 @@ from . import exception
 
 import json
 import yaml
+import logging
 
 __version__ = version.VERSION
 __date__ = version.DATE
@@ -25,3 +26,14 @@ yaml.dumper.Dumper.ignore_aliases = lambda self, data: True
 # Add YAML representer for version_info
 yaml.Dumper.add_multi_representer(version_info, version_yaml_representer)
 yaml.SafeDumper.add_multi_representer(version_info, version_yaml_representer)
+
+
+# Suppress Paramiko logger warnings
+plog = logging.getLogger('paramiko')
+if not plog.handlers:
+    class NullHandler(logging.Handler):
+
+        def emit(self, record):
+            pass
+
+    plog.addHandler(NullHandler())

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -2,7 +2,6 @@
 import hashlib
 import re
 from os import path
-import logging
 
 # 3rd-party modules
 from lxml.builder import E
@@ -146,16 +145,6 @@ class SW(Util):
                 _progress(
                     "%s: %s / %s (%s%%)" %
                     (_path, _xfrd, _total, str(pct)))
-
-        # check for the logger barncale for 'paramiko.transport'
-        plog = logging.getLogger('paramiko.transport')
-        if not plog.handlers:
-            class NullHandler(logging.Handler):
-
-                def emit(self, record):
-                    pass
-
-            plog.addHandler(NullHandler())
 
         # execute the secure-copy with the Python SCP module
         with SCP(self._dev, progress=_scp_progress) as scp:


### PR DESCRIPTION
Moved Paramiko logger warning suppression to library init.
Python logging is hierarchical so root logger of 'paramiko' should handle all instances of this.
Resolves #363 