### PR TITLE
Move _scp_progress to SCP and enable by default

### DIFF
--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -17,8 +17,8 @@ class SCP(object):
 
         from jnpr.junos.utils.scp import SCP
 
-        with SCP( dev, progress=_scp_progress ) as scp:
-            scp.put( package, remote_path )
+        with SCP(dev, progress=True) as scp:
+            scp.put(package, remote_path)
 
     """
     def __init__(self, junos, **scpargs):
@@ -30,6 +30,27 @@ class SCP(object):
         """
         self._junos = junos
         self._scpargs = scpargs
+        if 'progress' not in self._scpargs or self._scpargs['progress'] is True:
+            self._scpargs['progress'] = self._scp_progress
+
+    def _progress(self, report):
+        """ simple progress report function """
+        print self._junos.hostname + ": " + report
+
+    def _scp_progress(self, _path, _total, _xfrd):
+        # init static variable
+        if 'by10pct' not in locals():
+            by10pct = 0
+
+        # calculate current percentage xferd
+        pct = int(float(_xfrd) / float(_total) * 100)
+
+        # if 10% more has been copied, then print a message
+        if 0 == (pct % 10) and pct != by10pct:
+            by10pct = pct
+            self._progress(
+                "%s: %s / %s (%s%%)" %
+                (_path, _xfrd, _total, str(pct)))
 
     def open(self, **scpargs):
         """

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -112,7 +112,7 @@ class SW(Util):
     # put - SCP put the image onto the device
     # -------------------------------------------------------------------------
 
-    def put(self, package, remote_path='/var/tmp', progress=None):
+    def put(self, package, remote_path='/var/tmp', progress=True):
         """
         SCP 'put' the package file from the local server to the remote device.
 
@@ -123,31 +123,11 @@ class SW(Util):
           The directory on the device where the package will be copied to.
 
         :param func progress:
-          Callback function to indicate progress.  You can use :meth:`SW.progress`
-          for basic reporting.  See that class method for details.
+          Callback function to indicate progress.  If set to True uses :meth:`scp._scp_progress`
+          for basic reporting by default.  See that class method for details.
         """
-        def _progress(report):
-            # report progress only if a progress callback was provided
-            if progress is not None:
-                progress(self._dev, report)
-
-        def _scp_progress(_path, _total, _xfrd):
-            # init static variable
-            if not hasattr(_scp_progress, 'by10pct'):
-                _scp_progress.by10pct = 0
-
-            # calculate current percentage xferd
-            pct = int(float(_xfrd) / float(_total) * 100)
-
-            # if 10% more has been copied, then print a message
-            if 0 == (pct % 10) and pct != _scp_progress.by10pct:
-                _scp_progress.by10pct = pct
-                _progress(
-                    "%s: %s / %s (%s%%)" %
-                    (_path, _xfrd, _total, str(pct)))
-
         # execute the secure-copy with the Python SCP module
-        with SCP(self._dev, progress=_scp_progress) as scp:
+        with SCP(self._dev, progress=progress) as scp:
             scp.put(package, remote_path)
 
     # -------------------------------------------------------------------------

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -1,6 +1,10 @@
 __author__ = "Rick Sherman"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
+import sys
+from cStringIO import StringIO
+from contextlib import contextmanager
+
 import unittest
 from nose.plugins.attrib import attr
 
@@ -43,3 +47,15 @@ class TestScp(unittest.TestCase):
         with SCP(self.dev) as scp:
             scp.get('addrbook.conf')
         mock_proxy.assert_called_any()
+
+    def test_scp_progress(self):
+        scp = SCP(self.dev)
+        print scp._scp_progress('test', 100, 50)
+
+    @contextmanager
+    def capture(self, command, *args, **kwargs):
+        out, sys.stdout = sys.stdout, StringIO()
+        command(*args, **kwargs)
+        sys.stdout.seek(0)
+        yield sys.stdout.read()
+        sys.stdout = out

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -116,8 +116,8 @@ class TestSW(unittest.TestCase):
     def test_sw_put_progress(self, mock_enter, mock_scp, mock_exit):
         package = 'test.tgz'
         mock_scp.side_effect = self._fake_scp
-        self.sw.put(package, progress=self._myprogress)
-        self.assertEqual(mock_scp.call_args_list[0][1]['progress'].by10pct, 50)
+        with self.capture(self.sw.put, package, progress=self._my_scp_progress) as output:
+            self.assertEqual('test.tgz 100 50\n', output)
 
     def _fake_scp(self, *args, **kwargs):
         progress = kwargs['progress']
@@ -397,6 +397,9 @@ class TestSW(unittest.TestCase):
 
     def _myprogress(self, dev, report):
         pass
+
+    def _my_scp_progress(self, _path, _total, _xfrd):
+        print _path, _total, _xfrd
 
     @contextmanager
     def capture(self, command, *args, **kwargs):


### PR DESCRIPTION
This moves the _scp_progress function from sw.put into SCP.

By default this will be used for any SCP get/put and can be disabled with `progress=False` or `progress=None`

```python
from jnpr.junos.utils.sw import SW
from jnpr.junos.utils.scp import SCP

# This is an example custom progress function
def test(a, b, c):
    print a,b,c

with SCP(dev) as scp:
    scp.put('ut.xml', '/var/tmp')
>>>192.168.74.31: ut.xml: 673 / 673 (100%)

with SCP(dev, progress=test) as scp:
    scp.put('ut.xml', '/var/tmp')
>>>ut.xml 673 0
>>>ut.xml 673 673

sw = SW(dev)
sw.put('ut.xml')
>>>192.168.74.31: ut.xml: 673 / 673 (100%)

sw.put('ut.xml', progress=test)
>>>ut.xml 673 0
>>>ut.xml 673 673
```

Resolves #362