### PR TITLE
Prefer explicitly defined ssh_private_key_file to sshconfig

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -267,7 +267,7 @@ class Device(object):
             self._hostname = found.get('hostname', self._hostname)
             self._port = found.get('port', self._port)
             self._conf_auth_user = found.get('user')
-            self._ssh_private_key_file = found.get('identityfile')
+            self._conf_ssh_private_key_file = found.get('identityfile')
             return sshconf_path
 
     def __init__(self, *vargs, **kvargs):
@@ -348,11 +348,10 @@ class Device(object):
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
             self._sshconf_path = self._sshconf_lkup()
-            # but if user is explit from call, then use it.
+            # but if user or private key is explit from call, then use it.
             self._auth_user = kvargs.get('user') or self._conf_auth_user or self._auth_user
+            self._ssh_private_key_file = kvargs.get('ssh_private_key_file') or self._conf_ssh_private_key_file
             self._auth_password = kvargs.get('password') or kvargs.get('passwd')
-            if not hasattr(self, '_ssh_private_key_file'):
-                self._ssh_private_key_file = kvargs.get('ssh_private_key_file')
 
         # -----------------------------
         # initialize instance variables

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -345,6 +345,7 @@ class Device(object):
             # user will default to $USER
             self._auth_user = os.getenv('USER')
             self._conf_auth_user = None
+            self._conf_ssh_private_key_file = None
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
             self._sshconf_path = self._sshconf_lkup()


### PR DESCRIPTION
The previous implementation had two issues:

1) Even if ssh_private_key_file is explicitly passed to the Device constructor, this would be overridden if identityfile was set in sshconfig, contrary to the many in which "user" was handled whereby the value passed to the constructor is preferred

2) If a matching statement was found in sshconfig then even in the case where identityfile had not been set, the value explicitly passed to the constructor would be ignored

This change makes the way in which ssh_private_key_file is handled the same as the way "user" is handled by always preferring a value explicitly passed

I have the same 6 tests failing before and after this patch (mostly related to being unable to reach the *.englab.juniper.net hosts)

I think the test for ssh_private_key_file would not have actually tested the correct behaviour before as if valid credentials were found in sshconfig then these would always have been used to open the connection