### PR TITLE
implement context manager for Device

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -799,3 +799,15 @@ class Device(object):
             probe_ok = False
 
         return probe_ok
+
+    # -----------------------------------------------------------------------
+    # Context Manager
+    # -----------------------------------------------------------------------
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not isinstance(exc_val, EzErrors.ConnectError):
+            self.close()

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -809,5 +809,5 @@ class Device(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if not isinstance(exc_val, EzErrors.ConnectError):
+        if self.connected and not isinstance(exc_val, EzErrors.ConnectError):
             self.close()

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -809,5 +809,6 @@ class Device(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.connected and not isinstance(exc_val, EzErrors.ConnectError):
+        if self._conn.connected and \
+                not isinstance(exc_val, EzErrors.ConnectError):
             self.close()

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -426,6 +426,8 @@ class TestDevice(unittest.TestCase):
             with Device(host='3.3.3.3', user='gic',
                         password='password123', gather_facts=False) as dev:
                 self.assertTrue(dev.connected)
+                dev._conn = MagicMock(name='_conn')
+                dev._conn.connected = True
 
                 def close_conn():
                     dev.connected = False


### PR DESCRIPTION
Implementation of context manager for Device (e.g. `with Device(...) as dev:`). 

```
>>> from jnpr.junos import Device
>>>
>>> with Device(host="1.2.3.4", user="user", port=22) as dev:
...     print "conntected to %s" % dev._facts["hostname"]
...     chassis = dev.rpc.get_chassis_inventory()
...     print "device: %s " % chassis.findtext(".//chassis/description")
...
conntected to BNGJMX3
device: MX960
```
The `__enter__` method will open the connection of the device and `__exit__` close the connection except a `ConnectError`exception was raised. The assumption is that the connection was already closed in this case and an additional close raises another exception. 