### PR TITLE
Raise RpcTimeoutError in commit_check

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -121,7 +121,7 @@ class Config(Util):
         except RpcTimeoutError:
             raise
         except RpcError as err:        # jnpr.junos exception
-            if err.rsp.find('ok') is not None:
+            if err.rsp is not None and err.rsp.find('ok') is not None:
                 # this means there are warnings, but no errors
                 return True
             else:
@@ -157,8 +157,10 @@ class Config(Util):
         """
         try:
             self.rpc.commit_configuration(check=True)
+        except RpcTimeoutError:
+            raise
         except RpcError as err:        # jnpr.junos exception
-            if err.rsp.find('ok') is not None:
+            if err.rsp is not None and err.rsp.find('ok') is not None:
                 # this means there is a warning, but no errors
                 return True
             else:

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -399,3 +399,8 @@ class TestConfig(unittest.TestCase):
         ex = RpcTimeoutError(self.dev, None, 10)
         self.dev.rpc.commit_configuration = MagicMock(side_effect=ex)
         self.assertRaises(RpcTimeoutError, self.conf.commit)
+
+    def test_commit_check_RpcTimeoutError(self):
+        ex = RpcTimeoutError(self.dev, None, 10)
+        self.dev.rpc.commit_configuration = MagicMock(side_effect=ex)
+        self.assertRaises(RpcTimeoutError, self.conf.commit_check)


### PR DESCRIPTION
If your going to raise the RPCTimeoutError in commit, you should probably also do it in commit check.

Also, added a None check to err.rsp to avoid throwing an AttributeError