### PR TITLE
Fix dev.cu.load() to throw RpcTimeoutError when encountered

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -341,6 +341,8 @@ class Config(Util):
         def try_load(rpc_contents, rpc_xattrs):
             try:
                 got = self.rpc.load_config(rpc_contents, **rpc_xattrs)
+            except RpcTimeoutError as err:
+                raise err
             except RpcError as err:
                 raise ConfigLoadError(cmd=err.cmd, rsp=err.rsp, errs=err.errs)
             # Something unexpected happened - raise it up

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -222,6 +222,12 @@ class TestConfig(unittest.TestCase):
         self.assertRaises(ConfigLoadError, self.conf.load, path='config.conf')
 
     @patch('__builtin__.open')
+    def test_config_load_try_load_rpctimeouterror(self, mock_open):
+        ex = RpcTimeoutError(self.dev, None, 10)
+        self.conf.rpc.load_config = MagicMock(side_effect=ex)
+        self.assertRaises(RpcTimeoutError, self.conf.load, path='config.conf')
+
+    @patch('__builtin__.open')
     def test_config_try_load_exception(self, mock_open):
         class OtherException(Exception):
             pass


### PR DESCRIPTION
fixes #443 