### PR TITLE
Change the return value of start_shell.run() to comply with docs

### DIFF
--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -394,8 +394,7 @@ class FS(Util):
     def _ssh_exec(self, command):
         with StartShell(self._dev) as sh:
             got = sh.run(command)
-            ok = sh.last_ok
-        return (ok, got)
+        return got
 
     def rmdir(self, path):
         """

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -17,8 +17,7 @@ class StartShell(object):
         def _ssh_exec(self, command):
             with StartShell(self._dev) as sh:
                 got = sh.run(command)
-                ok = sh.last_ok
-            return (ok, got)
+            return got
 
     """
 
@@ -110,14 +109,14 @@ class StartShell(object):
         """
         # run the command and capture the output
         self.send(command)
-        got = self.wait_for(this)
+        got = ''.join(self.wait_for(this))
 
         # use $? to get the exit code of the command
         self.send('echo $?')
         rc = ''.join(self.wait_for(this))
         self.last_ok = True if rc.find('0') > 0 else False
 
-        return got
+        return (self.last_ok,got)
 
     # -------------------------------------------------------------------------
     # CONTEXT MANAGER


### PR DESCRIPTION
Addresses #432

Change the return value of start_shell.run() to comply with the documentation:

    "The return is a tuple. The first item is True/False if
     exit-code is 0.  The second item is the output of the command."

Change a couple of places that were expecting the old return value.