### PR TITLE
Prevented AttributeError upon XML comment. Fixes #446

### DIFF
--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -134,6 +134,8 @@ strip_comments_transform = etree.XSLT(strip_xslt_root)
 
 def remove_namespaces(xml):
     for elem in xml.getiterator():
+        if elem.tag is etree.Comment:
+            continue
         i = elem.tag.find('}')
         if i > 0:
             elem.tag = elem.tag[i + 1:]

--- a/tests/unit/test_jxml.py
+++ b/tests/unit/test_jxml.py
@@ -2,6 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
+from io import StringIO
 from nose.plugins.attrib import attr
 from jnpr.junos.jxml import NAME, INSERT, remove_namespaces
 
@@ -19,14 +20,16 @@ class Test_JXML(unittest.TestCase):
 
     def test_remove_namespaces(self):
         xmldata = \
-            """<xsl:stylesheet xmlns:xsl="http://xml.juniper.net/junos">
+            u"""<xsl:stylesheet xmlns:xsl="http://xml.juniper.net/junos">
                     <xsl:template>
+                        <!-- Handle comments properly -->
                         <xsl:attribute name="{myname}">
                         </xsl:attribute>
                     </xsl:template>
                 </xsl:stylesheet>"""
         import xml.etree.ElementTree as ET
-        root = ET.fromstring(xmldata)
+        parser = ET.XMLParser()
+        root   = ET.parse(StringIO(xmldata), parser)
         test = remove_namespaces(root)
         for elem in test.getiterator():
             i = elem.tag.find('}')


### PR DESCRIPTION
The ```remove_namespace``` function in jxml.py would previously raise an Attribute error if it encountered an XML comment. This change adds a check for a comment before doing the ```tag.find```.