### PR TITLE
Fix situation where multiple RpcError objects were returned causing err.xml return a list.

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -564,7 +564,12 @@ class Device(object):
             raise EzErrors.ConnectClosedError(self)
         except RPCError as err:
             # err is an NCError from ncclient
-            rsp = JXML.remove_namespaces(err.xml)
+            # This can sometimes be multiple RPCerrors packaged in one
+            # so it needs to be unpacked before returning
+            if isinstance(err.xml, list):
+                rsp = JXML.remove_namespaces(err.xml[0].xml)
+            else:
+            	rsp = JXML.remove_namespaces(err.xml)
             # see if this is a permission error
             e = EzErrors.PermissionError if rsp.findtext('error-message') == 'permission denied' else EzErrors.RpcError
             raise e(cmd=rpc_cmd_e, rsp=rsp)


### PR DESCRIPTION
If a syntax error is encountered loading a configuration in device.py, err.xml ends up returning a list of RPCError objects, as opposed to an XML object. This confuses the exception handling logic, which then throws a generic exception, obscuring the actual syntax error.

I've added code to detect this situation and pick the first of the RPC errors, which then allows the exception logic to function correctly and a useful error be returned.

