### PR TITLE
facts gathering should not raise and break scripts

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -3,6 +3,7 @@ import os
 import types
 import platform
 import warnings
+import traceback
 
 # stdlib, in support of the the 'probe' method
 import socket
@@ -764,12 +765,25 @@ class Device(object):
     # facts
     # ------------------------------------------------------------------------
 
-    def facts_refresh(self):
+    def facts_refresh(self, exception_on_failure=False):
         """
         Reload the facts from the Junos device into :attr:`facts` property.
+
+        :param bool exception_on_failure: To raise exception or warning when
+                             facts gathering errors out.
+
         """
         for gather in FACT_LIST:
-            gather(self, self._facts)
+            try:
+                gather(self, self._facts)
+            except:
+                if exception_on_failure:
+                    raise
+                warnings.warn('Facts gathering is incomplete. '
+                              'To know the reason call "dev.facts_refresh(exception_on_failure=True)"', RuntimeWarning)
+                return
+
+
 
     # ------------------------------------------------------------------------
     # probe

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -393,7 +393,7 @@ class SW(Util):
 
         if no_copy is False:
             copy_ok = True
-            if isinstance(package, str):
+            if isinstance(package, (str, unicode)):
                 copy_ok = self.safe_copy(package, remote_path=remote_path,
                                          progress=progress, cleanfs=cleanfs,
                                          checksum=checksum)

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -34,6 +34,7 @@ facts = {'domain': None, 'hostname': 'firefly', 'ifd_style': 'CLASSIC',
 
 @attr('unit')
 class Test_MyTemplateLoader(unittest.TestCase):
+
     def setUp(self):
         from jnpr.junos.device import _MyTemplateLoader
         self.template_loader = _MyTemplateLoader()
@@ -83,7 +84,8 @@ class TestDevice(unittest.TestCase):
     @patch('jnpr.junos.device.netconf_ssh')
     @patch('jnpr.junos.device.datetime')
     def test_device_ConnectTimeoutError(self, mock_datetime, mock_manager):
-        mock_manager.connect.side_effect = NcErrors.SSHError("Could not open socket to 1.1.1.1:830")
+        mock_manager.connect.side_effect = NcErrors.SSHError(
+            "Could not open socket to 1.1.1.1:830")
         from datetime import timedelta, datetime
         currenttime = datetime.now()
         mock_datetime.datetime.now.side_effect = [currenttime,
@@ -195,7 +197,10 @@ class TestDevice(unittest.TestCase):
             """
             mock_connect.side_effect = self._mock_manager
             mock_execute.side_effect = self._mock_manager
-            self.dev2 = Device(host='2.2.2.2', user='rick', password='password123')
+            self.dev2 = Device(
+                host='2.2.2.2',
+                user='rick',
+                password='password123')
             self.dev2.open()
             self.assertEqual(self.dev2.connected, True)
 
@@ -210,6 +215,15 @@ class TestDevice(unittest.TestCase):
             """
             self.dev.facts_refresh()
             assert self.dev.facts['version'] == facts['version']
+
+    @patch('jnpr.junos.Device.execute')
+    @patch('jnpr.junos.device.warnings')
+    def test_device_facts_error(self, mock_warnings, mock_execute):
+        with patch('jnpr.junos.utils.fs.FS.cat') as mock_cat:
+            mock_execute.side_effect = self._mock_manager
+            mock_cat.side_effect = IOError('File cant be handled')
+            self.dev.facts_refresh()
+            self.assertTrue(mock_warnings.warn.called)
 
     def test_device_hostname(self):
         self.assertEqual(self.dev.hostname, '1.1.1.1')
@@ -278,17 +292,25 @@ class TestDevice(unittest.TestCase):
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_rpc(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.assertEqual(self.dev.display_xml_rpc('show system uptime ').tag, 'get-system-uptime-information')
+        self.assertEqual(
+            self.dev.display_xml_rpc('show system uptime ').tag,
+            'get-system-uptime-information')
 
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_rpc_text(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.assertIn('<get-system-uptime-information>', self.dev.display_xml_rpc('show system uptime ', format='text'))
+        self.assertIn(
+            '<get-system-uptime-information>',
+            self.dev.display_xml_rpc(
+                'show system uptime ',
+                format='text'))
 
     @patch('jnpr.junos.Device.execute')
     def test_device_display_xml_exception(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.assertEqual(self.dev.display_xml_rpc('show foo'), 'invalid command: show foo| display xml rpc')
+        self.assertEqual(
+            self.dev.display_xml_rpc('show foo'),
+            'invalid command: show foo| display xml rpc')
 
     def test_device_execute(self):
         self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
@@ -319,7 +341,9 @@ class TestDevice(unittest.TestCase):
 
     def test_device_execute_permission_error(self):
         self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
-        self.assertRaises(EzErrors.PermissionError, self.dev.rpc.get_permission_denied)
+        self.assertRaises(
+            EzErrors.PermissionError,
+            self.dev.rpc.get_permission_denied)
 
     def test_device_execute_index_error(self):
         self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
@@ -334,11 +358,15 @@ class TestDevice(unittest.TestCase):
 
     def test_device_execute_timeout(self):
         self.dev._conn.rpc = MagicMock(side_effect=TimeoutExpiredError)
-        self.assertRaises(EzErrors.RpcTimeoutError, self.dev.rpc.get_rpc_timeout)
+        self.assertRaises(
+            EzErrors.RpcTimeoutError,
+            self.dev.rpc.get_rpc_timeout)
 
     def test_device_execute_closed(self):
         self.dev._conn.rpc = MagicMock(side_effect=NcErrors.TransportError)
-        self.assertRaises(EzErrors.ConnectClosedError, self.dev.rpc.get_rpc_close)
+        self.assertRaises(
+            EzErrors.ConnectClosedError,
+            self.dev.rpc.get_rpc_close)
         self.assertFalse(self.dev.connected)
 
     def test_device_rpcmeta(self):
@@ -400,7 +428,8 @@ class TestDevice(unittest.TestCase):
     def test_device_template(self):
         # Try to load the template relative to module base
         try:
-            template = self.dev.Template('tests/unit/templates/config-example.xml')
+            template = self.dev.Template(
+                'tests/unit/templates/config-example.xml')
         except:
             # Try to load the template relative to test base
             try:


### PR DESCRIPTION
handle facts gathering and raise only warning in case of exception. So that script can continue with activities say if its not dependent on facts. For ex dev.rpc.rpc_calls() are not dependent on facts.