### PR TITLE
Catch case where X type minor build not hyphenated

### DIFF
--- a/lib/jnpr/junos/facts/swver.py
+++ b/lib/jnpr/junos/facts/swver.py
@@ -15,12 +15,20 @@ class version_info(object):
         if 'X' == self.type:
             # assumes form similar to "45-D10", so extract the bits from this
             xm = re.match("(\d+)-(\w)(\d+)", self.minor)
-            self.minor = tuple(
-                [int(xm.group(1)), xm.group(2), int(xm.group(3))])
-            if len(after_type) < 2:
-                self.build = None
+            if xm is not None:
+                self.minor = tuple(
+                    [int(xm.group(1)), xm.group(2), int(xm.group(3))])
+                if len(after_type) < 2:
+                    self.build = None
+                else:
+                    self.build = int(after_type[1])
+            # it's not hyphen form "45-D10", perhaps "11.4X12.1", just extract 12
             else:
-                self.build = int(after_type[1])
+                if len(after_type) < 2:
+                    self.build = None
+                else:
+                    self.build = int(after_type[1])
+
         elif ('I' == self.type) or ('-' == self.type):
             self.type = 'I'
             try:

--- a/lib/jnpr/junos/facts/swver.py
+++ b/lib/jnpr/junos/facts/swver.py
@@ -22,7 +22,7 @@ class version_info(object):
                     self.build = None
                 else:
                     self.build = int(after_type[1])
-            # it's not hyphen form "45-D10", perhaps "11.4X12.1", just extract 12
+            # X type not hyphen format, perhaps "11.4X12.1", just extract build rev or set None
             else:
                 if len(after_type) < 2:
                     self.build = None

--- a/tests/unit/facts/test_swver.py
+++ b/tests/unit/facts/test_swver.py
@@ -25,6 +25,11 @@ class TestVersionInfo(unittest.TestCase):
             version_info('11.4X12.2'),
             [('build', 2), ('major', (11, 4)), ('minor', '12'), ('type', 'X')])
 
+    def test_version_info_X_type_non_hyphenated_nobuild(self):
+        self.assertItemsEqual(
+            version_info('11.4X12'),
+            [('build', None), ('major', (11, 4)), ('minor', '12'), ('type', 'X')])
+
     def test_version_info_constructor_else_exception(self):
         self.assertEqual(version_info('11.4R7').build, '7')
 

--- a/tests/unit/facts/test_swver.py
+++ b/tests/unit/facts/test_swver.py
@@ -20,11 +20,6 @@ class TestVersionInfo(unittest.TestCase):
     def test_version_info_after_type_len_else(self):
         self.assertEqual(version_info('12.1X46-D10').build, None)
 
-    def test_version_info_X_type_non_hyphenated(self):
-        self.assertItemsEqual(
-            version_info('11.4X12.2'),
-            [('build', 2), ('major', (11, 4)), ('minor', '12'), ('type', 'X')])
-
     def test_version_info_constructor_else_exception(self):
         self.assertEqual(version_info('11.4R7').build, '7')
 

--- a/tests/unit/facts/test_swver.py
+++ b/tests/unit/facts/test_swver.py
@@ -20,6 +20,11 @@ class TestVersionInfo(unittest.TestCase):
     def test_version_info_after_type_len_else(self):
         self.assertEqual(version_info('12.1X46-D10').build, None)
 
+    def test_version_info_X_type_non_hyphenated(self):
+        self.assertItemsEqual(
+            version_info('11.4X12.2'),
+            [('build', 2), ('major', (11, 4)), ('minor', '12'), ('type', 'X')])
+
     def test_version_info_constructor_else_exception(self):
         self.assertEqual(version_info('11.4R7').build, '7')
 


### PR DESCRIPTION
This fix successfully fixes https://github.com/Juniper/py-junos-eznc/issues/463

`Device.open()` can now successfully connect and `Device.facts()` reports proper JUNOS swver facts

```
>>> pprint(dev.facts)
{'2RE': True,
 'HOME': '/var/home/ENG',
 'RE0': {'last_reboot_reason': '0x1:power cycle/failure ',
         'mastership_state': 'master',
         'model': 'RE-S-2000',
         'status': 'OK',
         'up_time': '979 days, 8 hours, 52 minutes, 51 seconds'},
 'RE1': {'last_reboot_reason': '0x1:power cycle/failure ',
         'mastership_state': 'backup',
         'model': 'RE-S-2000',
         'status': 'OK',
         'up_time': '979 days, 8 hours, 52 minutes, 46 seconds'},
 'domain': 'tbone.rr.com',
 'fqdn': '<REMOVED>',
 'hostname': '<REMOVED>',
 'ifd_style': 'CLASSIC',
 'master': 'RE0',
 'model': 'MX960',
 'personality': 'MX',
 'serialnumber': '<REMOVED>',
 'switch_style': 'BRIDGE_DOMAIN',
 'vc_capable': False,
 'version': '11.4X12.1',
 'version_RE0': '11.4X12.1',
 'version_RE1': '11.4X12.1',
 'version_info': junos.version_info(major=(11, 4), type=X, minor=12, build=1)}
>>>
```