### PR TITLE
FTP utility

### DIFF
--- a/docs/jnpr.junos.utils.rst
+++ b/docs/jnpr.junos.utils.rst
@@ -48,3 +48,11 @@ jnpr.junos.utils.util
     :members:
     :undoc-members:
     :show-inheritance:
+
+jnpr.junos.utils.ftp
+----------------------------
+
+.. automodule:: jnpr.junos.utils.ftp
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/lib/jnpr/junos/utils/ftp.py
+++ b/lib/jnpr/junos/utils/ftp.py
@@ -3,10 +3,10 @@ FTP utility
 """
 
 import re
-from ftplib import FTP
+import ftplib
 
 
-class Ftp:
+class FTP:
     """
     FTP utility can be used to transfer files to and from device.
     """
@@ -19,8 +19,8 @@ class Ftp:
 
         Supports python *context-manager* pattern.  For example::
 
-            from jnpr.junos.utils.ftp import Ftp
-            with Ftp(dev) as dev_ftp:
+            from jnpr.junos.utils.ftp import FTP
+            with FTP(dev) as dev_ftp:
                 dev_ftp.retrbinary('RETR ' + "/var/home/regress/file1",
                                     open("file1", 'wb').write)
                 dev_ftp.storbinary('STOR ' + "/var/home/regress/file11",
@@ -47,7 +47,7 @@ class Ftp:
         if 'passwd' not in ftpargs:
             ftpargs['passwd'] = self._junos._auth_password
 
-        self._ftp = FTP(self._junos.facts['hostname'])
+        self._ftp = ftplib.FTP(self._junos.facts['hostname'])
         self._ftp.login(**ftpargs)
 
         return self._ftp

--- a/lib/jnpr/junos/utils/ftp.py
+++ b/lib/jnpr/junos/utils/ftp.py
@@ -1,0 +1,112 @@
+"""
+FTP utility
+"""
+
+import re
+from ftplib import FTP
+
+
+class Ftp:
+    """
+    FTP utility can be used to transfer files to and from device.
+    """
+
+    def __init__(self, junos, **ftpargs):
+        """
+
+        :param Device junos: Device object
+        :param kvargs ftpargs: any additional args to be passed to ftplib FTP
+
+        Supports python *context-manager* pattern.  For example::
+
+            from jnpr.junos.utils.ftp import Ftp
+            with Ftp(dev) as dev_ftp:
+                dev_ftp.retrbinary('RETR ' + "/var/home/regress/file1",
+                                    open("file1", 'wb').write)
+                dev_ftp.storbinary('STOR ' + "/var/home/regress/file11",
+                                    open("file11", 'rb'))
+        """
+
+        self._junos = junos
+        self._ftpargs = ftpargs
+
+    def open(self, **ftpargs):
+        """
+        Creates an instance of the FTP object and returns to caller for use.
+
+        .. note:: This method uses the same username/password authentication
+                   credentials as used by :class:`jnpr.junos.device.Device`.
+
+        :returns: ftplib.FTP object
+        """
+        if not self._junos.facts.get('hostname', None):
+            raise RuntimeError('Could not hostname of the device')
+
+        if 'user' not in ftpargs:
+            ftpargs['user'] = self._junos._auth_user
+        if 'passwd' not in ftpargs:
+            ftpargs['passwd'] = self._junos._auth_password
+
+        self._ftp = FTP(self._junos.facts['hostname'])
+        self._ftp.login(**ftpargs)
+
+        return self._ftp
+
+    def upload_file(self, local_file, remote_file=None):
+        """
+        This function is used to upload file to the router from local
+        execution server/shell.
+        :param local_file: Full path along with filename which has to
+        be copied to router
+        :param remote_file: Full path along with filename to which the FILE
+        has to be copied the router. If ignored FILE will be copied to "tmp"
+        :return: True if the transfer succeeds, else False
+
+        """
+
+        try:
+            if not remote_file:
+                mat = re.search('^.*/(.*)$', local_file)
+                if mat:
+                    remote_file = '/tmp/' + mat.group(1)
+                else:
+                    remote_file = '/tmp/' + local_file
+            self._ftp.storbinary('STOR ' + remote_file, open(local_file, 'rb'))
+        except Exception as exp:
+            return False
+        return True
+
+    def dnload_file(self, local_file, remote_file):
+        """
+        This function is used to download file from router to local execution
+         server/shell.
+        :param local_file: Full path along with filename to which the FILE
+        has to be copied
+        :param remote_file: Full path along with filename on the router.
+        If ignored FILE will be copied to "tmp"
+        :return: True if the transfer succeeds, else False
+
+        """
+
+        try:
+            self._ftp.retrbinary('RETR ' + remote_file,
+                                 open(local_file, 'wb').write)
+        except Exception as exp:
+            return False
+        return True
+
+    def close(self):
+        """
+        Closes the FTP connection to the device
+        """
+        self._ftp.close()
+
+    # -------------------------------------------------------------------------
+    # CONTEXT MANAGER
+    # -------------------------------------------------------------------------
+
+    def __enter__(self):
+        return self.open(**self._ftpargs)
+
+    def __exit__(self, exc_ty, exc_val, exc_tb):
+        return self.close()

--- a/lib/jnpr/junos/utils/ftp.py
+++ b/lib/jnpr/junos/utils/ftp.py
@@ -56,11 +56,12 @@ class Ftp:
         """
         This function is used to upload file to the router from local
         execution server/shell.
-        :param local_file: Full path along with filename which has to
-        be copied to router
+
+        :param local_file: Full path along with filename which has to be
+            copied to router
         :param remote_file: Full path along with filename to which the FILE
-        has to be copied the router. If ignored FILE will be copied to "tmp"
-        :return: True if the transfer succeeds, else False
+            has to be copied the router. If ignored FILE will be copied to "tmp"
+        :returns: True if the transfer succeeds, else False
 
         """
 
@@ -79,13 +80,15 @@ class Ftp:
     def dnload_file(self, local_file, remote_file):
         """
         This function is used to download file from router to local execution
-         server/shell.
-        :param local_file: Full path along with filename to which the FILE
-        has to be copied
-        :param remote_file: Full path along with filename on the router.
-        If ignored FILE will be copied to "tmp"
-        :return: True if the transfer succeeds, else False
+        server/shell.
 
+        :param local_file: Full path along with filename to which the FILE has
+            to be copied
+
+        :param remote_file: Full path along with filename on the router. If
+            ignored FILE will be copied to "tmp"
+
+        :returns: True if the transfer succeeds, else False
         """
 
         try:

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -2,12 +2,17 @@
 import unittest
 from nose.plugins.attrib import attr
 from ftplib import FTP
+import sys
 
 from jnpr.junos import Device
 from jnpr.junos.utils.ftp import Ftp
 
 from mock import patch
 
+if sys.version<'3':
+    builtin_string = '__builtin__'
+else:
+    builtin_string = 'builtins'
 
 @attr('unit')
 class TestFtp(unittest.TestCase):
@@ -53,7 +58,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
-    @patch('__builtin__.open')
+    @patch(builtin_string + '.open')
     def test_ftp_upload_file_errors(self, mock_ftpconnect, mock_ftplogin,
                                     mock_ftpclose, mock_open):
         dev_ftp = Ftp(self.dev)
@@ -66,7 +71,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
     @patch('ftplib.FTP.storbinary')
-    @patch('__builtin__.open')
+    @patch(builtin_string + '.open')
     def test_ftp_upload_file(self, mock_ftpconnect, mock_ftplogin,
                              mock_ftpclose, mock_ftpstore, mock_open):
         dev_ftp = Ftp(self.dev)
@@ -76,7 +81,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
-    @patch('__builtin__.open')
+    @patch(builtin_string + '.open')
     def test_ftp_dnload_file_errors(self, mock_ftpconnect, mock_ftplogin,
                                     mock_ftpclose, mock_open):
         dev_ftp = Ftp(self.dev)
@@ -88,7 +93,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
     @patch('ftplib.FTP.retrbinary')
-    @patch('__builtin__.open')
+    @patch(builtin_string + '.open')
     def test_ftp_dnload_file(self, mock_ftpconnect, mock_ftplogin,
                              mock_ftpclose, mock_ftpretr, mock_open):
         dev_ftp = Ftp(self.dev)

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -1,0 +1,97 @@
+
+import unittest
+from nose.plugins.attrib import attr
+from ftplib import FTP
+
+from jnpr.junos import Device
+from jnpr.junos.utils.ftp import Ftp
+
+from mock import patch
+
+
+@attr('unit')
+class TestFtp(unittest.TestCase):
+    @patch('ncclient.manager.connect')
+    def setUp(self, mock_connect):
+        self.dev = Device(host='1.1.1.1', user="testuser",
+                          passwd="testpasswd",
+                          gather_facts=False)
+        self.dev.open()
+        self.dev._facts = {'hostname': '1.1.1.1'}
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    def test_ftp_open(self, mock_Ftpconnect, mock_ftplogin):
+        dev_ftp = Ftp(self.dev)
+        self.assertIsInstance(dev_ftp.open(), FTP)
+
+    @patch('ncclient.manager.connect')
+    @patch('ftplib.FTP.connect')
+    def test_ftp_open_erors(self, mock_connect, mock_ftpconnect):
+        dev2 = Device(host='1.1.1.1', user="testuser",
+                      passwd="testpasswd",
+                      gather_facts=False)
+        dev2.open()
+        dev_ftp = Ftp(dev2)
+        self.assertRaises(Exception, dev_ftp.open)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    def test_ftp_close(self, mock_Ftpconnect, mock_ftplogin, mock_ftpclose):
+        dev_ftp = Ftp(self.dev)
+        dev_ftp.open()
+        self.assertEqual(dev_ftp.close(), None)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    def test_ftp_context(self, mock_ftpconnect, mock_ftplogin, mock_ftpclose):
+        with Ftp(self.dev) as dev_ftp:
+            self.assertIsInstance(dev_ftp, FTP)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    @patch('__builtin__.open')
+    def test_ftp_upload_file_errors(self, mock_ftpconnect, mock_ftplogin,
+                                    mock_ftpclose, mock_open):
+        dev_ftp = Ftp(self.dev)
+        dev_ftp.open()
+        self.assertEqual(dev_ftp.upload_file(local_file="testfile"), False)
+        self.assertEqual(dev_ftp.upload_file(local_file="/var/testfile"),
+                         False)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    @patch('ftplib.FTP.storbinary')
+    @patch('__builtin__.open')
+    def test_ftp_upload_file(self, mock_ftpconnect, mock_ftplogin,
+                             mock_ftpclose, mock_ftpstore, mock_open):
+        dev_ftp = Ftp(self.dev)
+        dev_ftp.open()
+        self.assertEqual(dev_ftp.upload_file(local_file="testfile"), True)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    @patch('__builtin__.open')
+    def test_ftp_dnload_file_errors(self, mock_ftpconnect, mock_ftplogin,
+                                    mock_ftpclose, mock_open):
+        dev_ftp = Ftp(self.dev)
+        dev_ftp.open()
+        self.assertEqual(dev_ftp.dnload_file(local_file="testfile",
+                                             remote_file="testfile"), False)
+
+    @patch('ftplib.FTP.connect')
+    @patch('ftplib.FTP.login')
+    @patch('ftplib.FTP.close')
+    @patch('ftplib.FTP.retrbinary')
+    @patch('__builtin__.open')
+    def test_ftp_dnload_file(self, mock_ftpconnect, mock_ftplogin,
+                             mock_ftpclose, mock_ftpretr, mock_open):
+        dev_ftp = Ftp(self.dev)
+        dev_ftp.open()
+        self.assertEqual(dev_ftp.dnload_file(local_file="testfile",
+                                             remote_file="testfile"), True)

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -23,7 +23,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.login')
     def test_ftp_open(self, mock_Ftpconnect, mock_ftplogin):
         dev_ftp = Ftp(self.dev)
-        self.assertIsInstance(dev_ftp.open(), FTP)
+        assert isinstance(dev_ftp.open(), FTP)
 
     @patch('ncclient.manager.connect')
     @patch('ftplib.FTP.connect')
@@ -48,7 +48,7 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.close')
     def test_ftp_context(self, mock_ftpconnect, mock_ftplogin, mock_ftpclose):
         with Ftp(self.dev) as dev_ftp:
-            self.assertIsInstance(dev_ftp, FTP)
+            assert isinstance(dev_ftp, FTP)
 
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -1,11 +1,11 @@
 
 import unittest
 from nose.plugins.attrib import attr
-from ftplib import FTP
+import ftplib
 import sys
 
 from jnpr.junos import Device
-from jnpr.junos.utils.ftp import Ftp
+import jnpr.junos.utils.ftp
 
 from mock import patch
 
@@ -27,8 +27,8 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')
     def test_ftp_open(self, mock_Ftpconnect, mock_ftplogin):
-        dev_ftp = Ftp(self.dev)
-        assert isinstance(dev_ftp.open(), FTP)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
+        assert isinstance(dev_ftp.open(), ftplib.FTP)
 
     @patch('ncclient.manager.connect')
     @patch('ftplib.FTP.connect')
@@ -37,14 +37,14 @@ class TestFtp(unittest.TestCase):
                       passwd="testpasswd",
                       gather_facts=False)
         dev2.open()
-        dev_ftp = Ftp(dev2)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(dev2)
         self.assertRaises(Exception, dev_ftp.open)
 
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
     def test_ftp_close(self, mock_Ftpconnect, mock_ftplogin, mock_ftpclose):
-        dev_ftp = Ftp(self.dev)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
         dev_ftp.open()
         self.assertEqual(dev_ftp.close(), None)
 
@@ -52,8 +52,8 @@ class TestFtp(unittest.TestCase):
     @patch('ftplib.FTP.login')
     @patch('ftplib.FTP.close')
     def test_ftp_context(self, mock_ftpconnect, mock_ftplogin, mock_ftpclose):
-        with Ftp(self.dev) as dev_ftp:
-            assert isinstance(dev_ftp, FTP)
+        with jnpr.junos.utils.ftp.FTP(self.dev) as dev_ftp:
+            assert isinstance(dev_ftp, ftplib.FTP)
 
     @patch('ftplib.FTP.connect')
     @patch('ftplib.FTP.login')
@@ -61,7 +61,7 @@ class TestFtp(unittest.TestCase):
     @patch(builtin_string + '.open')
     def test_ftp_upload_file_errors(self, mock_ftpconnect, mock_ftplogin,
                                     mock_ftpclose, mock_open):
-        dev_ftp = Ftp(self.dev)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
         dev_ftp.open()
         self.assertEqual(dev_ftp.upload_file(local_file="testfile"), False)
         self.assertEqual(dev_ftp.upload_file(local_file="/var/testfile"),
@@ -74,7 +74,7 @@ class TestFtp(unittest.TestCase):
     @patch(builtin_string + '.open')
     def test_ftp_upload_file(self, mock_ftpconnect, mock_ftplogin,
                              mock_ftpclose, mock_ftpstore, mock_open):
-        dev_ftp = Ftp(self.dev)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
         dev_ftp.open()
         self.assertEqual(dev_ftp.upload_file(local_file="testfile"), True)
 
@@ -84,7 +84,7 @@ class TestFtp(unittest.TestCase):
     @patch(builtin_string + '.open')
     def test_ftp_dnload_file_errors(self, mock_ftpconnect, mock_ftplogin,
                                     mock_ftpclose, mock_open):
-        dev_ftp = Ftp(self.dev)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
         dev_ftp.open()
         self.assertEqual(dev_ftp.dnload_file(local_file="testfile",
                                              remote_file="testfile"), False)
@@ -96,7 +96,7 @@ class TestFtp(unittest.TestCase):
     @patch(builtin_string + '.open')
     def test_ftp_dnload_file(self, mock_ftpconnect, mock_ftplogin,
                              mock_ftpclose, mock_ftpretr, mock_open):
-        dev_ftp = Ftp(self.dev)
+        dev_ftp = jnpr.junos.utils.ftp.FTP(self.dev)
         dev_ftp.open()
         self.assertEqual(dev_ftp.dnload_file(local_file="testfile",
                                              remote_file="testfile"), True)


### PR DESCRIPTION
FTP utility can be used to transfer files to and from device
This is required when Telnet and console connections are implemented and user wants to use FTP to transfer files.