### PR TITLE
Improve the auto-detection of "text" config format.

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -336,7 +336,7 @@ class Config(Util):
                 kvargs['format'] = 'xml'
             elif re.search(r'^\s*(set|delete|replace|rename)\s', rpc):
                 kvargs['format'] = 'set'
-            elif re.search(r'^[a-z:]*\s*\w+\s+{', rpc, re.I) and re.search(r'.*}\s*$', rpc):
+            elif re.search(r'^[a-z:]*\s*[\w-]+\s+\{', rpc, re.I) and re.search(r'.*}\s*$', rpc):
                 kvargs['format'] = 'text'
 
         def try_load(rpc_contents, rpc_xattrs):

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -198,6 +198,28 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.conf.load(xmldata, format='xml'),
                          'rpc_contents')
 
+    def test_config_load_len_with_format_text(self):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value='rpc_contents')
+        textdata = """policy-options {
+    prefix-list TEST1-NETS {
+        100.0.0.0/24;
+    }
+    policy-statement TEST1-NETS {
+        term TEST1 {
+            from {
+                prefix-list TEST1-NETS;
+            }
+            then accept;
+        }
+        term REJECT {
+            then reject;
+        }
+    }
+}"""
+
+        self.assertEqual(self.conf.load(textdata), 'rpc_contents')
+
     @patch(builtin_string + '.open')
     def test_config_load_lformat_byext_ValueError(self, mock_open):
         self.conf.rpc.load_config = \


### PR DESCRIPTION
Regex contained an error in which the `{` was not escaped which
caused an exception. Regex also failed to catch tokens split with `-`.