### PR TITLE
to make dev.cli command more robut

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -615,9 +615,7 @@ class Device(object):
         # uplevel they can always call the getparent() method on it.
 
         try:
-            # print etree.tostring(rpc_rsp_e)
             ret_rpc_rsp = rpc_rsp_e[0]
-            # print etree.tostring(ret_rpc_rsp)
         except IndexError:
             # For cases where reply are like
             # <rpc-reply>

--- a/tests/unit/rpc-reply/show-interfaces-terse-asdf.xml
+++ b/tests/unit/rpc-reply/show-interfaces-terse-asdf.xml
@@ -1,0 +1,4 @@
+<rpc-reply message-id="urn:uuid:cc8caa21-0236-11e6-ac05-b8e85604f858">
+protocol: operation-failed
+error: device asdf not found
+</rpc-reply>

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -319,6 +319,14 @@ class TestDevice(unittest.TestCase):
         self.assertEqual('', self.dev.cli('show configuration interfaces',
                                           warning=False))
 
+    #@patch('jnpr.junos.Device.execute')
+    def test_device_cli_rpc_reply_with_message(self):#, mock_execute):
+        self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
+        self.assertEqual(
+            '\nprotocol: operation-failed\nerror: device asdf not found\n',
+                         self.dev.cli('show interfaces terse asdf',
+                                          warning=False))
+
     @patch('jnpr.junos.Device.execute')
     def test_device_cli_rpc(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
@@ -526,7 +534,8 @@ class TestDevice(unittest.TestCase):
             elif (fname == 'get-index-error.xml' or
                     fname == 'get-system-core-dumps.xml' or
                     fname == 'load-configuration-error.xml' or
-                          fname=='show-configuration-interfaces.xml'):
+                    fname == 'show-configuration-interfaces.xml' or
+                  fname == 'show-interfaces-terse-asdf.xml'):
                 rpc_reply = NCElement(foo, self.dev._conn._device_handler
                                   .transform_reply())
             elif (fname == 'show-configuration.xml' or
@@ -564,6 +573,8 @@ class TestDevice(unittest.TestCase):
                     return self._read_file('show-system-uptime-rpc.xml')
                 elif args[0].text == 'show configuration interfaces':
                     return self._read_file('show-configuration-interfaces.xml')
+                elif args[0].text == 'show interfaces terse asdf':
+                    return self._read_file('show-interfaces-terse-asdf.xml')
                 else:
                     raise RpcError
 


### PR DESCRIPTION
dev.cli("show configuration xyz", warning=False)

it will show:
syntax error: show configuration xyz

in place of 
invalid command: show configuration xyz

Also for commands where rpc-reply (which looked like below)

> show interfaces terse asdf | display xml
```xml          
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/xx.1D0/junos">
    <interface-information xmlns="http://xml.juniper.net/junos/xx.1D0/junos-interface" junos:style="terse">
        <xnm:error xmlns="http://xml.juniper.net/xnm/1.1/xnm" xmlns:xnm="http://xml.juniper.net/xnm/1.1/xnm">
            <source-daemon>ifinfo</source-daemon>
            <message>device asdf not found</message>
        </xnm:error>
    </interface-information>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```xml
now if we call this command from dev.cli it will work as below

print (dev.cli("show interfaces terse asdf", warning=False))
protocol: operation-failed
error: device asdf not found