### PR TITLE
exception rpc_error element were None in case of multiple warnings 

### DIFF
--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -34,6 +34,12 @@ class RpcError(Exception):
                 if error.severity == 'error':
                     self.rsp = JXML.remove_namespaces(error.xml)
                     break
+            else:
+                # if there is no error, looking for first warning.
+                for error in errs.errors:
+                    if error.severity == 'warning':
+                        self.rsp = JXML.remove_namespaces(error.xml)
+                        break
             self.message = errs.message
         else:
             self.errs = errs

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -26,7 +26,6 @@ class RpcError(Exception):
         self.timeout = timeout
         self.re = re
         self.rpc_error = None
-
         # To handle errors coming from ncclient, Here errs is list of RPCError
         if isinstance(errs, RPCError) and hasattr(errs, 'errors'):
             self.errs = [JXML.rpc_error(error.xml) for error in errs.errors]
@@ -35,11 +34,11 @@ class RpcError(Exception):
                     self.rsp = JXML.remove_namespaces(error.xml)
                     break
             else:
-                # if there is no error, looking for first warning.
-                for error in errs.errors:
-                    if error.severity == 'warning':
-                        self.rsp = JXML.remove_namespaces(error.xml)
-                        break
+                if errs.severity == 'warning':
+                    for error in errs.errors:
+                        if error.severity == 'warning':
+                            self.rsp = JXML.remove_namespaces(error.xml)
+                            break
             self.message = errs.message
         else:
             self.errs = errs

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -43,6 +43,25 @@ conf_xml = '''
     </rpc-error>
 '''
 
+multi_warning_xml = '''
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/16.1I0/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+<load-configuration-results>
+<rpc-error>
+<error-severity>warning</error-severity>
+<error-message>
+statement not found
+</error-message>
+</rpc-error>
+<rpc-error>
+<error-severity>warning</error-severity>
+<error-message>
+statement not found
+</error-message>
+</rpc-error>
+<ok/>
+</load-configuration-results>
+</rpc-reply>
+'''
 
 @attr('unit')
 class Test_RpcError(unittest.TestCase):
@@ -102,3 +121,18 @@ class Test_RpcError(unittest.TestCase):
         obj = SwRollbackError(re='test1', rsp="Multi RE exception")
         err = 'SwRollbackError(re: test1, output: Multi RE exception)'
         self.assertEqual(obj.__repr__(), err)
+
+    def test_repr_multi_warning(self):
+        rsp = etree.XML(multi_warning_xml)
+        from ncclient.operations import RPCError
+        warn_msg = '''
+        <rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/16.1I0/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+        <error-severity>warning</error-severity>
+        <error-message>
+        statement not found
+        </error-message>
+        </rpc-error>'''
+        errs = RPCError(etree.XML(warn_msg))
+        errs.errors = [errs, errs]
+        obj = RpcError(rsp=rsp, errs=errs)
+        self.assertEqual(obj.rpc_error['severity'], 'warning')


### PR DESCRIPTION
In case where rpc error reply contained only warnings. rpc_reply data was None.