### PR TITLE
table/view was broken on python 3.x

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -496,7 +496,7 @@ class Device(object):
         self.connected = True
 
         self._nc_transform = self.transform
-        self._norm_transform = lambda: JXML.normalize_xslt
+        self._norm_transform = lambda: JXML.normalize_xslt.encode('UTF-8')
 
         normalize = kvargs.get('normalize', self._normalize)
         if normalize is True:


### PR DESCRIPTION
With python 3.x, table/view was giving below trace. Fixed
```
tbl.get()
  File "/root/PyEZ/venv/lib/python3.4/site-packages/jnpr/junos/factory/optable.py", line 63, in get
    self.xml = getattr(self.RPC, self.GET_RPC)(**rpc_args)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/jnpr/junos/rpcmeta.py", line 143, in _exec_rpc
    return self._junos.execute(rpc, **dec_args)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/jnpr/junos/decorators.py", line 58, in wrapper
    result = function(*args, **kwargs)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/jnpr/junos/decorators.py", line 26, in wrapper
    return function(*args, **kwargs)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/jnpr/junos/device.py", line 569, in execute
    rpc_rsp_e = self._conn.rpc(rpc_cmd_e)._NCElement__doc
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/manager.py", line 171, in wrapper
    return self.execute(op_cls, *args, **kwds)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/manager.py", line 231, in execute
    raise_mode=self._raise_mode).request(*args, **kwds)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/operations/third_party/juniper/rpc.py", line 42, in request
    return self._request(rpc)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/operations/rpc.py", line 339, in _request
    return NCElement(self._reply, self._device_handler.transform_reply())
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/xml_.py", line 151, in __init__
    self.__doc = self.remove_namespaces(self.__result)
  File "/root/PyEZ/venv/lib/python3.4/site-packages/ncclient/xml_.py", line 197, in remove_namespaces
    self.__xslt_doc = etree.parse(io.BytesIO(self.__xslt), self.__parser)
TypeError: 'str' does not support the buffer interface
```