### PR TITLE
fixed an issue where root shell wasn't working properly.

### DIFF
--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -1,9 +1,8 @@
 import paramiko
 from select import select
 import re
-
 _JUNOS_PROMPT = '> '
-_SHELL_PROMPT = '% '
+_SHELL_PROMPT = '%'
 _SELECT_WAIT = 0.1
 _RECVSZ = 1024
 
@@ -84,7 +83,7 @@ class StartShell(object):
         self._chan = chan
 
         got = self.wait_for('(%|>)')
-        if not got[-1].endswith(_SHELL_PROMPT):
+        if not got[-1].rstrip().endswith(_SHELL_PROMPT):
             self.send('start shell')
             self.wait_for(_SHELL_PROMPT)
 


### PR DESCRIPTION
https://github.com/Juniper/py-junos-eznc/issues/505

this was due to the fact that the junos command line
seems to use '%\t' as the prompt for root users,
but uses '% ' for non-root users.