### PR TITLE
To return Console object from Device

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -2,17 +2,12 @@
 This file defines the 'netconifyCmdo' class.
 Used by the 'netconify' shell utility.
 """
-import os
-import json
-import warnings
 import traceback
 from lxml import etree
 
 from jnpr.junos.transport.tty_telnet import Telnet
 from jnpr.junos.transport.tty_serial import Serial
 from jnpr.junos.rpcmeta import _RpcMetaExec
-from jnpr.junos import exception as EzErrors
-from jnpr.junos import Device
 from jnpr.junos.facts import *
 import logging
 
@@ -21,7 +16,6 @@ QFX_MODE_NODE = 'NODE'
 QFX_MODE_SWITCH = 'SWITCH'
 
 logger = logging.getLogger("jnpr.junos.console")
-#logging.basicConfig(level=logging.INFO)
 
 class Console(object):
 
@@ -61,7 +55,7 @@ class Console(object):
             So its assumed ssh is enabled by the time we use SCP functionality.
 
         :param bool gather_facts:
-            *OPTIONAL* default is ``False``.  If ``False`` then the
+            *OPTIONAL* default is ``True``.  If ``False`` then the
             facts are not gathered on call to :meth:`open`
 
         """
@@ -84,8 +78,9 @@ class Console(object):
         self._mode = kvargs.get('mode', 'telnet')
         self._timeout = kvargs.get('timeout', '0.5')
         self._attempts = kvargs.get('attempts', 10)
-        self.gather_facts = kvargs.get('gather_facts', False)
+        self.gather_facts = kvargs.get('gather_facts', True)
         self.rpc = _RpcMetaExec(self)
+        from jnpr.junos import Device
         self.cli = lambda cmd, format='text', warning=True: \
             Device.cli.im_func(self, cmd, format, warning)
         self._ssh_config = kvargs.get('ssh_config')

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -55,7 +55,7 @@ class Console(object):
             So its assumed ssh is enabled by the time we use SCP functionality.
 
         :param bool gather_facts:
-            *OPTIONAL* default is ``True``.  If ``False`` then the
+            *OPTIONAL* default is ``False``.  If ``False`` then the
             facts are not gathered on call to :meth:`open`
 
         """
@@ -78,7 +78,7 @@ class Console(object):
         self._mode = kvargs.get('mode', 'telnet')
         self._timeout = kvargs.get('timeout', '0.5')
         self._attempts = kvargs.get('attempts', 10)
-        self.gather_facts = kvargs.get('gather_facts', True)
+        self.gather_facts = kvargs.get('gather_facts', False)
         self.rpc = _RpcMetaExec(self)
         from jnpr.junos import Device
         self.cli = lambda cmd, format='text', warning=True: \

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -25,10 +25,10 @@ import jinja2
 # local modules
 from jnpr.junos.rpcmeta import _RpcMetaExec
 from jnpr.junos import exception as EzErrors
-from jnpr.junos.cfg import Resource
 from jnpr.junos.facts import *
 from jnpr.junos import jxml as JXML
 from jnpr.junos.decorators import timeoutDecorator, normalizeDecorator
+from jnpr.junos.console import Console
 
 _MODULEPATH = os.path.dirname(__file__)
 
@@ -282,6 +282,18 @@ class Device(object):
                 self._conf_auth_user = found.get('user')
                 self._conf_ssh_private_key_file = found.get('identityfile')
             return sshconf_path
+
+    def __new__(cls, *args, **kwargs):
+        if int(kwargs.get('port')) == 23 or kwargs.get('mode'):
+            instance = object.__new__(Console, *args, **kwargs)
+            # Python only calls __init__() if the object returned from
+            # __new__() is an instance of the class in which the __new__()
+            # method is contained (here Device class). Hence calling __init__
+            # explicitly.
+            instance.__init__(*args, **kwargs)
+            return instance
+        else:
+            return super(Device, cls).__new__(cls, *args, **kwargs)
 
     def __init__(self, *vargs, **kvargs):
         """

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -284,7 +284,7 @@ class Device(object):
             return sshconf_path
 
     def __new__(cls, *args, **kwargs):
-        if int(kwargs.get('port')) == 23 or kwargs.get('mode'):
+        if kwargs.get('port') in [23, '23'] or kwargs.get('mode'):
             instance = object.__new__(Console, *args, **kwargs)
             # Python only calls __init__() if the object returned from
             # __new__() is an instance of the class in which the __new__()

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -293,7 +293,10 @@ class Device(object):
             instance.__init__(*args, **kwargs)
             return instance
         else:
-            return super(Device, cls).__new__(cls, *args, **kwargs)
+            if sys.version_info.major==2:
+                return super(Device, cls).__new__(cls, *args, **kwargs)
+            else:
+                return super().__new__(cls)
 
     def __init__(self, *vargs, **kvargs):
         """

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -293,7 +293,7 @@ class Device(object):
             instance.__init__(*args, **kwargs)
             return instance
         else:
-            if sys.version_info.major==2:
+            if sys.version < '3':
                 return super(Device, cls).__new__(cls, *args, **kwargs)
             else:
                 return super().__new__(cls)


### PR DESCRIPTION
To use telnet & console.
If we provide mode as telnet/console Device will return Console object or port as 23 (for telnet)

```python
from jnpr.junos import Device
from pprint import pprint
from lxml import etree

with Device(host='xxxxx', user='xxx', password='xxx', mode='telnet', port='23') as dev:
    print dev.facts
    print dev.cli("show version", warning=False)
    op = dev.rpc.get_interface_information()
    print etree.tostring(op)
```