### PR TITLE
PR 1192331

### DIFF
--- a/lib/jnpr/junos/op/vlan.yml
+++ b/lib/jnpr/junos/op/vlan.yml
@@ -2,6 +2,7 @@
 VlanTable:
   rpc: get-vlan-information
   item: vlan
+  key: vlan-name
   view: VlanView
 
 VlanView:


### PR DESCRIPTION
"key" definition was missing in the YAML table defined for the VlanTable class.