### PR TITLE
Updating install instructions for Ubuntu and Debian

### DIFF
--- a/INSTALL-UBUNTU-DEBIAN.md
+++ b/INSTALL-UBUNTU-DEBIAN.md
@@ -1,30 +1,36 @@
 ### Installation on stock Ubuntu and Debian
 
-The following are instructions for setting up a system starting from a stock system images.
+The following are instructions for setting up a system starting from stock system images.
 
-These instructions were tested on a 64-bit systems from https://github.com/opscode/bento, and using the _Junos PyEZ_ library version 0.0.5.
+These instructions were tested on a 64-bit systems from https://github.com/opscode/bento, and using the _Junos PyEZ_ library version 1.3.1.
 
 Operating Systems
 ---------------
 - Ubuntu 12.04
 - Ubuntu 12.10
 - Ubuntu 13.10
+- Ubuntu 14.04
 - Debian 7.4
+- Debian 8.4
 
 
 #### Step 1: Update package list
 
 	sudo apt-get update
 
-#### Step 2: Install packages for Junos PyEZ
+#### Step 2: Install OS packages required by Junos PyEZ and it's pre-requisite Python packages
 
-    sudo apt-get install -y python-pip python-dev libxml2-dev libxslt-dev libssl-dev libffi-dev
+    sudo apt-get install -y python-dev libxslt1-dev libssl-dev libffi-dev
+
+#### Step 3: Install PyPI (the Python Package Index) from source
+
+	wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python
 	
-#### Step 3: Install Junos PyEZ
+#### Step 4: Install Junos PyEZ
 
     sudo pip install junos-eznc
     
-#### Step 4: Verify 
+#### Step 5: Verify 
 
 Once you've completed the above step, you should be able to create a `Device` instance, connect to a Junos system, and display the "facts", as illustrated in the README.md file.
 
@@ -35,11 +41,13 @@ Enjoy!
 
 Development code can be installed directly from GitHub based on any branch, commit, or tag.
 
-***Packages from Step 2 are required.***
+***Steps 1 -3 are still required.***
+#### Alternate Step 4: Install Junos PyEZ from GitHub
 
+#### Step 4a: Install Git from OS packages 
     sudo apt-get install -y git
+
+#### Step 4b: Install Junos PyEZ from GitHub
 	sudo pip install git+https://github.com/Juniper/py-junos-eznc.git
-	
 	or
-	
 	sudo pip install git+https://github.com/Juniper/py-junos-eznc.git@<branch,tag,commit>

--- a/INSTALL-UBUNTU-DEBIAN.md
+++ b/INSTALL-UBUNTU-DEBIAN.md
@@ -22,7 +22,7 @@ Operating Systems
 
     sudo apt-get install -y python-dev libxslt1-dev libssl-dev libffi-dev
 
-#### Step 3: Install PyPI (the Python Package Index) from source
+#### Step 3: Install the pip package manager from source
 
 	wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python
 	


### PR DESCRIPTION
Updating install instructions for Ubuntu and Debian to avoid the
problem with conflicting and outdated versions of setuptools,
cryptography, and pip.