### PR TITLE
to support load json config too

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -58,6 +58,8 @@ class _RpcMetaExec(object):
 
         format='text', then :contents: is a string containing Junos configuration in curly-brace/text format
 
+        format='json', then :contents: is a string containing Junos configuration in json format
+
         <otherwise> :contents: is XML structure
         """
         rpc = E('load-configuration', options)
@@ -66,6 +68,8 @@ class _RpcMetaExec(object):
             rpc.append(E('configuration-set', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))
+        elif ('format' in options) and (options['format'] == 'json'):
+            rpc.append(E('configuration-json', contents))
         else:
             # otherwise, it's just XML Element
             if contents.tag != 'configuration':

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -239,6 +239,7 @@ class Config(Util):
             * "conf","text","txt" is curly-text-style
             * "set" - ascii-text, set-style
             * "xml" - ascii-text, XML
+            * "set" - ascii-text, json
 
             .. note:: The format can specifically set using **format**.
 
@@ -310,6 +311,8 @@ class Config(Util):
                 return 'text'
             if ext in ['.set']:
                 return 'set'
+            if ext in ['.json']:
+                return 'json'
             raise ValueError("Unknown file contents from extension: %s" % ext)
 
         def _lset_format(kvargs, rpc_xattrs):

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -65,6 +65,23 @@ class Test_RpcMetaExec(unittest.TestCase):
                          'text')
 
     @patch('jnpr.junos.device.Device.execute')
+    def test_rpcmeta_option_format_json(self, mock_execute_fn):
+        json_commands = """
+            {
+                "configuration" : {
+                    "system" : {
+                        "services" : {
+                            "telnet" : [null]
+                        }
+                    }
+                }
+            }
+        """
+        self.rpc.load_config(json_commands, format='json')
+        self.assertEqual(mock_execute_fn.call_args[0][0].get('format'),
+                         'json')
+
+    @patch('jnpr.junos.device.Device.execute')
     def test_rpcmeta_exec_rpc_vargs(self, mock_execute_fn):
         self.rpc.system_users_information(dict(format='text'))
         self.assertEqual(mock_execute_fn.call_args[0][0].get('format'),

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -220,6 +220,27 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(self.conf.load(textdata), 'rpc_contents')
 
+    def test_config_load_with_format_json(self):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value=etree.fromstring("""<load-configuration-results>
+                            <ok/>
+                        </load-configuration-results>"""))
+        op = self.conf.load('test.json', format='json')
+        self.assertEqual(op.tag, 'load-configuration-results')
+        self.assertEqual(self.conf.rpc.load_config.call_args[1]['format'],
+                         'json')
+
+    @patch(builtin_string + '.open')
+    def test_config_load_with_format_json_from_file_ext(self, mock_open):
+        self.conf.rpc.load_config = \
+            MagicMock(return_value=etree.fromstring("""<load-configuration-results>
+                            <ok/>
+                        </load-configuration-results>"""))
+        op = self.conf.load(path='test.json')
+        self.assertEqual(op.tag, 'load-configuration-results')
+        self.assertEqual(self.conf.rpc.load_config.call_args[1]['format'],
+                         'json')
+
     @patch(builtin_string + '.open')
     def test_config_load_lformat_byext_ValueError(self, mock_open):
         self.conf.rpc.load_config = \


### PR DESCRIPTION
example:

```python
cnf = """{
    "configuration" : {
        "system" : {
            "services" : {
                "telnet" : [null]
            }
        }
    }
}"""
dev.open()

cu = Config(dev)
op = cu.load(cnf, format='json')
print etree.tostring(op)
```