### PR TITLE
convert to text for multiple output tags - Juniper/ansible-junos-stdlib#144

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -702,7 +702,7 @@ class Device(object):
             if rsp is True:
                 return ''
             if rsp.tag in ['output', 'rpc-reply']:
-                return etree.tostring(rsp, method="text")
+                return etree.tounicode(rsp, method="text", with_tail=False)
             if rsp.tag == 'configuration-information':
                 return rsp.findtext('configuration-output')
             if rsp.tag == 'rpc':

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -702,7 +702,7 @@ class Device(object):
             if rsp is True:
                 return ''
             if rsp.tag in ['output', 'rpc-reply']:
-                return rsp.text
+                return etree.tostring(rsp, method="text")
             if rsp.tag == 'configuration-information':
                 return rsp.findtext('configuration-output')
             if rsp.tag == 'rpc':


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes Juniper/ansible-junos-stdlib#144
Due to switches returning multiple output-tags when running "show system core-dumps", the xml.etree.elementtree.text won't do.

Tested with both 12.3R9 and 15.1R3 - due to the following rpc-reply containing multiple output tags - we need to use xml.etree.ElementTree.tostring.

Debug output:

```
Jul  4 18:33:13 [NETCONF] - [83745] Incoming: <?xml version="1.0" encoding="UTF-8"?><nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:00c66a54-4205-11e6-a4af-0050569f425a"><command>show system core-dumps all-members</command></nc:rpc>]]>]]>
Jul  4 18:33:13 [NETCONF] - [83745] Outgoing: <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/15.1R3/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:00c66a54-4205-11e6-a4af-0050569f425a">
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <directory-list root-path="/var/crash/*core*" junos:seconds="1467649994" junos:style="verbose">
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing:
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: /var/crash/*core*: No such file or directory
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: /var/tmp/*core*: No such file or directory
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: /var/tmp/pics/*core*: No such file or directory
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: /var/crash/kernel.*: No such file or directory
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: <output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: /var/jails/rest-api/tmp/*core*: No such file or directory
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </output>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </directory-list>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </multi-routing-engine-results>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: </rpc-reply>
Jul  4 18:33:14 [NETCONF] - [83745] Outgoing: ]]>]]>
```

Tested with both "show version" and "file list /tmp/ detail". Output looks good.

Now we're getting:
```
fpc0:
--------------------------------------------------------------------------

/var/crash/*core*: No such file or directory

-rw-r--r--  1 stianv field         0 Jul 4  19:41 /var/tmp/chassisd.core-tarball.0.090422.1902.tgz

/var/tmp/pics/*core*: No such file or directory


/var/crash/kernel.*: No such file or directory


/var/jails/rest-api/tmp/*core*: No such file or directory

total files: 1
```
