### PR TITLE
Update rpcmeta.py comments

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -25,9 +25,10 @@ class _RpcMetaExec(object):
         """
         retrieve configuration from the Junos device
 
-        :filter_xml: is options, defines what to retrieve.  if omitted then the entire configuration is returned
+        :filter_xml: XPath expression consisting of XML tag names separated by slashes,
+                     defines what to retrieve; when omitted then the entire configuration is returned
 
-        :options: is a dict, creates attributes for the RPC
+        :options: is a dictionary of XML attributes to set within the <get-configuration> RPC.
 
         """
         rpc = E('get-configuration', options)

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -25,10 +25,18 @@ class _RpcMetaExec(object):
         """
         retrieve configuration from the Junos device
 
-        :filter_xml: XPath expression consisting of XML tag names separated by slashes,
-                     defines what to retrieve; when omitted then the entire configuration is returned
+        :filter_xml: fully XML formatted tag which defines what to retrieve,
+                     when omitted the entire configuration is returned;
+                     the following returns the device host-name configured with "set system host-name":
 
-        :options: is a dictionary of XML attributes to set within the <get-configuration> RPC.
+        config = dev.rpc.get_config(filter_xml=etree.XML('<configuration><system><host-name/></system></configuration>'))
+
+        :options: is a dictionary of XML attributes to set within the <get-configuration> RPC;
+                  the following returns the device host-name either configured with "set system host-name"
+                  and if unconfigured, the value inherited from apply-group re0|re1, typical for multi-RE systems:
+
+        config = dev.rpc.get_config(filter_xml=etree.XML('<configuration><system><host-name/></system></configuration>'), 
+                 options={'database':'committed','inherit':'inherit'})
 
         """
         rpc = E('get-configuration', options)


### PR DESCRIPTION
ansible [documentation](http://junos-ansible-modules.readthedocs.io/en/1.3.1/junos_get_config.html#synopsis) points to jnpr/junos/rpcmeta/get_config; but this did not document how and which options to pass