### PR TITLE
Support to get the  configed ospf interfaces

### DIFF
--- a/lib/jnpr/junos/op/ospf.yml
+++ b/lib/jnpr/junos/op/ospf.yml
@@ -20,3 +20,15 @@ OspfNeighborView:
     bdr_address: bdr-address
     neighbor_up_time: neighbor-up-time
     neighbor_adjacency_time: neighbor-adjacency-time
+
+OspfInterfaceTable:
+  rpc: get_ospf_interface_information
+  item: ospf-interface
+  key: interface-name
+  view: OspfInterfaceView
+  
+OspfInterfaceView:
+  fields:
+    interface_name: interface-name
+    ospf_interface_state: ospf-interface-state
+    neighbor_count: neighbor-count


### PR DESCRIPTION
Support to get the  configed ospf interfaces,use to check ospf interfaces configed in OspfInterfaceTable but disappeared in the OspfNeighborTable.