### PR TITLE
replace tounicode with tostring as tounicode is getting depreciated

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -3,6 +3,7 @@ This file defines the 'netconifyCmdo' class.
 Used by the 'netconify' shell utility.
 """
 import traceback
+import sys
 from lxml import etree
 from jnpr.junos.transport.tty_telnet import Telnet
 from jnpr.junos.transport.tty_serial import Serial
@@ -171,7 +172,8 @@ class Console(_Connection):
     # execute rpc calls
     @timeoutDecorator
     def execute(self, rpc_cmd, *args, **kwargs):
-        rpc_cmd = etree.tounicode(rpc_cmd) if \
+        encode = None if sys.version < '3' else 'unicode'
+        rpc_cmd = etree.tostring(rpc_cmd, encoding=encode) if \
             isinstance(rpc_cmd, etree._Element) else rpc_cmd
         return self._tty.nc.rpc(rpc_cmd)
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -241,7 +241,8 @@ class _Connection(object):
             command = command + '| display xml rpc'
             rsp = self.rpc.cli(command)
             if format == 'text':
-                return etree.tounicode(rsp[0])
+                encode = None if sys.version < '3' else 'unicode'
+                return etree.tostring(rsp[0], encoding=encode)
             return rsp[0]
         except:
             return "invalid command: " + command
@@ -440,7 +441,9 @@ class _Connection(object):
             if rsp is True:
                 return ''
             if rsp.tag in ['output', 'rpc-reply']:
-                return etree.tounicode(rsp, method="text", with_tail=False)
+                encode = None if sys.version < '3' else 'unicode'
+                return etree.tostring(rsp, method="text", with_tail=False,
+                                      encoding=encode)
             if rsp.tag == 'configuration-information':
                 return rsp.findtext('configuration-output')
             if rsp.tag == 'rpc':

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -4,6 +4,7 @@ from lxml import etree
 import select
 import socket
 import logging
+import sys
 
 from lxml.builder import E
 from datetime import datetime, timedelta
@@ -84,7 +85,8 @@ class tty_netconf(object):
         """ issue a reboot to the device """
         cmd = E.command('request system zeroize')
         try:
-            rsp = self.rpc(etree.tounicode(cmd))
+            encode = None if sys.version < '3' else 'unicode'
+            rsp = self.rpc(etree.tostring(cmd, encoding=encode))
         except:
             return False
         return True


### PR DESCRIPTION
help(etree.tounicode)
Help on cython_function_or_method in module lxml.etree:

tounicode(...)
    tounicode(element_or_tree, method="xml", pretty_print=False,
                  with_tail=True, doctype=None)
    
    Serialize an element to the Python unicode representation of its XML
    tree.
    
    :deprecated: use ``tostring(el, encoding='unicode')`` instead.