### PR TITLE
in rpc error: return None if ele.text is empty

### DIFF
--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -154,7 +154,7 @@ def rpc_error(rpc_xml):
 
     def find_strip(x):
         ele = rpc_xml.find(x)
-        return ele.text.strip() if None != ele else None
+        return ele.text.strip() if None != ele and None != ele.text else None
 
     this_err = {}
     this_err['severity'] = find_strip('error-severity')


### PR DESCRIPTION
Hey, I ran into an issue where `ele` was set, but `ele.text` was not. Maybe this can be double-checked here?

Traceback (most recent call last):
  File "/tmp/ansible_gjijSA/ansible_module_junos_install_config.py", line 273, in _load_via_netconf
    cu.load(**load_args)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/utils/config.py", line 397, in load
    return try_load(rpc_contents, rpc_xattrs)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/utils/config.py", line 344, in try_load
    got = self.rpc.load_config(rpc_contents, **rpc_xattrs)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/rpcmeta.py", line 76, in load_config
    return self._junos.execute(rpc)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/decorators.py", line 71, in wrapper
    return function(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/decorators.py", line 26, in wrapper
    return function(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/device.py", line 570, in execute
    raise e(cmd=rpc_cmd_e, rsp=rsp, errs=err)
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/exception.py", line 32, in __init__
    self.errs = [JXML.rpc_error(error.xml) for error in errs.errors]
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/jxml.py", line 166, in rpc_error
    this_err['bad_element'] = find_strip('error-info/bad-element')
  File "/usr/local/lib/python2.7/dist-packages/jnpr/junos/jxml.py", line 159, in find_strip
    return ele.text.strip() if None != ele else None
AttributeError: 'NoneType' object has no attribute 'strip'