### PR TITLE
To take care of special chars on screen during console

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -983,8 +983,9 @@ class Device(_Connection):
         """
         Closes the connection to the device.
         """
-        self._conn.close_session()
-        self.connected = False
+        if self.connected is True:
+            self._conn.close_session()
+            self.connected = False
 
     def _rpc_reply(self, rpc_cmd_e):
         return self._conn.rpc(rpc_cmd_e)._NCElement__doc

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -7,6 +7,7 @@ import logging
 import sys
 
 from lxml.builder import E
+from lxml.etree import XMLSyntaxError
 from datetime import datetime, timedelta
 from ncclient.operations.rpc import RPCReply, RPCError
 from ncclient.xml_ import to_ele
@@ -162,10 +163,14 @@ class tty_netconf(object):
             logger.debug('Received: \n%s' % rcvd_data)
             try:
                 etree.XML(rcvd_data)
-            except Exception as ex:
-                if isinstance(ex, etree.XMLSyntaxError):
+            except XMLSyntaxError:
+                if ']]>]]>' in rcvd_data:
                     rcvd_data = rcvd_data[:rcvd_data.index(']]>]]>')]
-                    etree.XML(rcvd_data)
+                    etree.XML(rcvd_data)     # just to recheck
+                else:
+                    parser = etree.XMLParser(recover=True)
+                    rcvd_data = etree.tostring(etree.XML(rcvd_data,
+                                                         parser=parser))
             return rcvd_data
         except:
             if '</xnm:error>' in rxbuf:

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -164,8 +164,8 @@ class tty_netconf(object):
             try:
                 etree.XML(rcvd_data)
             except XMLSyntaxError:
-                if ']]>]]>' in rcvd_data:
-                    rcvd_data = rcvd_data[:rcvd_data.index(']]>]]>')]
+                if _NETCONF_EOM in rcvd_data:
+                    rcvd_data = rcvd_data[:rcvd_data.index(_NETCONF_EOM)]
                     etree.XML(rcvd_data)     # just to recheck
                 else:
                     parser = etree.XMLParser(recover=True)


### PR DESCRIPTION
x = """<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/16.2D0/junos">
<request-reboot-results>
<request-reboot-status reboot-time="1475561673">
Shutdown at Mon Oct  3 23:14:33 2016.
[pid 6788]
</request-reboot-status>
</request-reboot-results>
*** System shutdown message from xxx@xxxx ***
System going down in 1 minute
</rpc-reply>"""
```python
>>> etree.fromstring(x)
Traceback (most recent call last):
  File "<pyshell#171>", line 1, in <module>
    etree.fromstring(x)
  File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:77697)
  File "src/lxml/parser.pxi", line 1819, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:116494)
  File "src/lxml/parser.pxi", line 1707, in lxml.etree._parseDoc (src/lxml/lxml.etree.c:115144)
  File "src/lxml/parser.pxi", line 1079, in lxml.etree._BaseParser._parseDoc (src/lxml/lxml.etree.c:109543)
  File "src/lxml/parser.pxi", line 573, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/lxml.etree.c:103404)
  File "src/lxml/parser.pxi", line 683, in lxml.etree._handleParseResult (src/lxml/lxml.etree.c:105058)
  File "src/lxml/parser.pxi", line 613, in lxml.etree._raiseParseError (src/lxml/lxml.etree.c:103967)
XMLSyntaxError: PCDATA invalid Char value 7, line 8, column 1
>>> parser = etree.XMLParser(recover=True)
>>> etree.fromstring(x, parser=parser)
<Element {urn:ietf:params:xml:ns:netconf:base:1.0}rpc-reply at 0x105865c20>
```