### PR TITLE
removing the hard check of serial number if present then only assigned

### DIFF
--- a/lib/jnpr/junos/facts/chassis.py
+++ b/lib/jnpr/junos/facts/chassis.py
@@ -43,10 +43,11 @@ def facts_chassis(junos, facts):
 
     facts['model'] = x_ch.findtext('description')
 
-    try:
+    #try:
+    if x_ch.find('serial-number') != None:
         facts['serialnumber'] = x_ch.find('serial-number').text
-    except:
-        # if the toplevel chassis does not have a serial-number, then
-        # check the Backplane chassis-module
-        facts['serialnumber'] = x_ch.xpath(
-            'chassis-module[name="Backplane" or name="Midplane"]/serial-number')[0].text
+    #except:
+    #    # if the toplevel chassis does not have a serial-number, then
+    #    # check the Backplane chassis-module
+    #    facts['serialnumber'] = x_ch.xpath(
+    #        'chassis-module[name="Backplane" or name="Midplane"]/serial-number')[0].text


### PR DESCRIPTION
`Device(host=ip, user='user', password="xxxxxx", os="JUNOS", connect_mode="ssh")`

In above Simple ssh is failing because device doesn't have a serial number. In the juniper too many device doesn't have a serial number. In this pull request hard checking of serial number is removed. assign only if it presents. 