### PR TITLE
Minor typos fixed in RuntimeError exception message and in comments

### DIFF
--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -17,13 +17,13 @@ class Terminal(object):
 
     """
     Terminal is used to bootstrap Junos New Out of the Box (NOOB) device
-    over the CONSOLE port.  The general use-case is to setup the minimal
+    over the CONSOLE port. The general use-case is to setup the minimal
     configuration so that the device is IP reachable using SSH
     and NETCONF for remote management.
 
     Serial is needed for Junos devices that do not support
     the DHCP 'auto-installation' or 'ZTP' feature; i.e. you *MUST*
-    to the NOOB configuration via the CONSOLE.
+    do the NOOB configuration via the CONSOLE.
 
     Serial is also useful for situations even when the Junos
     device supports auto-DHCP, but is not an option due to the
@@ -67,7 +67,7 @@ class Terminal(object):
           defaults to 'root'
 
         :kvargs['passwd']:
-          defaults to empty; NOOB Junos devics there is
+          defaults to empty; NOOB Junos device there is
           no root password initially
 
         :kvargs['attempts']:
@@ -156,7 +156,7 @@ class Terminal(object):
 
         # hack for now
         # in case of telnet to management port, after writing exit on console
-        # it exists completely and returns None
+        # it exits completely and returns None
         ###
         if found is not None:
             _ev_tbl[found]()
@@ -187,7 +187,7 @@ class Terminal(object):
             self._login_state_machine(attempt=0)
             self._loader += 1
             if self._loader == 2:
-                raise RuntimeError("propably corrupted image, stuck in loader")
+                raise RuntimeError("probably corrupted image, stuck in loader")
 
         def _ev_login():
             self.state = self._ST_LOGIN

--- a/lib/jnpr/junos/transport/tty_telnet.py
+++ b/lib/jnpr/junos/transport/tty_telnet.py
@@ -27,7 +27,7 @@ class Telnet(Terminal):
     def __init__(self, host, port, **kvargs):
         """
         :host:
-          The hostname or ip-addr of the ternminal server
+          The hostname or ip-addr of the terminal server
 
         :port:
           The TCP port that maps to the TTY device on the


### PR DESCRIPTION
I tried to make PyEZ work with my devices via console (terminal server) and had some problems. I haven't been able to localize the problem yet, but while browsing the sources found some typos and fixed them in this commit. Hopefully this improves overall code readability.

I wonder if you are interested in such type of contributions.