### PR TITLE
Added console_has_banner parameter

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -75,6 +75,11 @@ class Console(_Connection):
             *OPTIONAL* default is ``False``.  If ``False`` then the
             facts are not gathered on call to :meth:`open`
 
+        :param bool console_has_banner:
+            *OPTIONAL* default is ``False``.  If ``False`` then in case of a
+            hung state, <close-session/> rpc is sent to the console.
+            If ``True``, after sleep(5), a new-line is sent
+
         """
 
         # ----------------------------------------
@@ -106,6 +111,7 @@ class Console(_Connection):
         #self.timeout = self._timeout
         self._attempts = kvargs.get('attempts', 10)
         self.gather_facts = kvargs.get('gather_facts', False)
+        self.console_has_banner = kvargs.get('console_has_banner', False)
         self.rpc = _RpcMetaExec(self)
         self._ssh_config = kvargs.get('ssh_config')
         self._manages = []
@@ -209,6 +215,7 @@ class Console(_Connection):
         if self._mode.upper() == 'TELNET':
             tty_args['host'] = self._hostname
             tty_args['port'] = self._port
+            tty_args['console_has_banner'] = self.console_has_banner
             self.console = ('telnet', self._hostname, self.port)
             self._tty = Telnet(**tty_args)
         elif self._mode.upper() == 'SERIAL':

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -81,6 +81,7 @@ class Terminal(object):
         self.c_user = kvargs.get('s_user', self.user)
         self.c_passwd = kvargs.get('s_passwd', self.passwd)
         self.login_attempts = kvargs.get('attempts') or self.LOGIN_RETRY
+        self.console_has_banner = kvargs.get('console_has_banner') or False
 
         # misc setup
         self.nc = tty_netconf(self)
@@ -212,11 +213,14 @@ class Terminal(object):
                 # assume we're in a hung state, i.e. we don't see
                 # a login prompt for whatever reason
                 self.state = self._ST_TTY_NOLOGIN
-                self.write('<close-session/>')  # @@@ this is a hack
-                # if console connection have a banner or warning
-                # comment-out line above and uncoment lines bellow ... better hack
-                # sleep(5)
-                # self.write('\n')
+                if self.console_has_banner:
+                    # if console connection has a banner or warning,
+                    # use this hack
+                    sleep(5)
+                    self.write('\n')
+                else:
+                    # @@@ this is still a hack - used by default
+                    self.write('<close-session/>')
 
         def _ev_shell():
             if self.state == self._ST_INIT:


### PR DESCRIPTION
Hi

Basically, problem that I am solving with this proposed modification is described [here](http://stackoverflow.com/questions/40493376/how-to-make-junos-pyez-work-via-console-port)

In the existing PyEZ version, in comments, it is suggested to uncomment couple of lines in _ev_tty_nologin() function in case "we're in a hung state" and "console connection has a banner or warning". Really, uncommenting the lines solved my problem but this is not what users are supposed to do (modify library code).

So I propose to add the parameter console_has_banner to the Console (also Device) class constructor, allowing to make this switch more easily for users.

With this parameter enabled, this script now works much better:

```
with Device(host='X.X.X.X', user='XXX', password='XXXXXX', mode='telnet', 
        port='2014', gather_facts=True, console_has_banner=True) as dev:
    print(dev.facts)
    print(dev.cli("show version", format='text', warning=False))
```
