### PR TITLE
Add CentOS Support to install instructions

### DIFF
--- a/INSTALL-FEDORA-CENTOS.md
+++ b/INSTALL-FEDORA-CENTOS.md
@@ -8,10 +8,11 @@ Operating Systems
 ---------------
 - Fedora 19
 - Fedora 20
+- CentOS 7
 
 #### Step 1: Install packages for Junos PyEZ
 
-    sudo yum install -y python-pip python-devel libxml2-devel libxslt-devel gcc openssl libffi-devel
+    sudo yum install -y python-pip python-devel libxml2-devel libxslt-devel gcc openssl openssl-devel libffi-devel
 	
 #### Step 2: Install Junos PyEZ
 


### PR DESCRIPTION
Add `openssl-devel` dependency for CentOS 7 and update that this works with CentOS via filename and listing