### PR TITLE
Key value is needed in  _IsisAdjacencyLogTable

### DIFF
--- a/lib/jnpr/junos/op/isis.yml
+++ b/lib/jnpr/junos/op/isis.yml
@@ -26,6 +26,7 @@ IsisAdjacencyView:
 
 _IsisAdjacencyLogTable:
   item: isis-adjacency-log
+  key: adjacency-when
   view: _IsisAdjacencyLogView
 
 _IsisAdjacencyLogView:

--- a/lib/jnpr/junos/op/isis.yml
+++ b/lib/jnpr/junos/op/isis.yml
@@ -26,7 +26,9 @@ IsisAdjacencyView:
 
 _IsisAdjacencyLogTable:
   item: isis-adjacency-log
-  key: adjacency-when
+  key: 
+    - adjacency-when
+    - adjacency-state
   view: _IsisAdjacencyLogView
 
 _IsisAdjacencyLogView:

--- a/lib/jnpr/junos/op/ldp.yml
+++ b/lib/jnpr/junos/op/ldp.yml
@@ -28,6 +28,7 @@ LdpNeighborView:
 
 _LdpNeighborHelloFlagsTable:
   item: ldp-neighbor-hello-flags
+  key: ldp-neighbor-hello-flag
   view: _LdpNeighborHelloFlagsView
 
 _LdpNeighborHelloFlagsView:
@@ -36,6 +37,7 @@ _LdpNeighborHelloFlagsView:
 
 _LdpNeighborTypesTable:
   item: ldp-neighbor-types
+  key: ldp-neighbor-type
   view: _LdpNeighborTypesView
 
 _LdpNeighborTypesView:


### PR DESCRIPTION
Omitting a key in the _IsisAdjacencyLogTable table renders no items in the _IsisAdjacencyLogView.  This may consequently crash an ansible module if used. 