### PR TITLE
Lookup user from ~/.ssh/config

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -833,6 +833,7 @@ class Device(_Connection):
             self._conf_ssh_private_key_file = None
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
+            self._sshconf_lkup()
             # but if user or private key is explicit from call, then use it.
             self._auth_user = kvargs.get('user') or self._conf_auth_user or \
                 self._auth_user


### PR DESCRIPTION
Due to a change in commit b03e611ef4eb, the user wasn't extracted from
user (or specified) SSH configuration. Add back the call to parse SSH
configuration.

Also, don't use the parsed private keyfile as it will be done
automatically by the underlying Paramiko. Using the parsed key doesn't
work, either because this is a list and not a string or because it is
encrypted and I am using an agent.