### PR TITLE
Improve error handling in directory_usage():

### DIFF
--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -283,7 +283,7 @@ class FS(Util):
         result = {}
 
         directories = rsp.findall(".//directory")
-        if directories is None:
+        if not directories:
             raise RpcError(rsp=rsp)
 
         for directory in directories:

--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -286,7 +286,7 @@ class FS(Util):
         if directories is None:
             raise RpcError(rsp=rsp)
 
-        for directory in directories
+        for directory in directories:
             dir_name = directory.findtext("directory-name")
             if dir_name is not None:
                 dir_name = dir_name.strip()

--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -282,9 +282,15 @@ class FS(Util):
 
         result = {}
 
-        for directory in rsp.findall(".//directory"):
-            dir_name = directory.findtext("directory-name").strip()
-            if dir_name is None:
+        directories = rsp.findall(".//directory")
+        if directories is None:
+            raise RpcError(rsp=rsp)
+
+        for directory in directories
+            dir_name = directory.findtext("directory-name")
+            if dir_name is not None:
+                dir_name = dir_name.strip()
+            else:
                 raise RpcError(rsp=rsp)
 
             used_space = directory.find('used-space')

--- a/tests/unit/utils/rpc-reply/get-directory-usage-information_error1.xml
+++ b/tests/unit/utils/rpc-reply/get-directory-usage-information_error1.xml
@@ -1,0 +1,7 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X47/junos">
+    <directory-usage-information>
+    </directory-usage-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/utils/rpc-reply/get-directory-usage-information_error2.xml
+++ b/tests/unit/utils/rpc-reply/get-directory-usage-information_error2.xml
@@ -1,0 +1,48 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X47/junos">
+    <directory-usage-information>
+        <directory>
+            <directory-name>/var/tmp</directory-name>
+            <directory>
+                <directory-name>/var/tmp/install</directory-name>
+                <used-space used-blocks="4">
+                    2.0K
+                </used-space>
+            </directory>
+            <directory>
+                <directory-name>/var/tmp/vi.recover</directory-name>
+                <used-space used-blocks="4">
+                    2.0K
+                </used-space>
+            </directory>
+            <directory>
+                <directory-name>/var/tmp/pics</directory-name>
+                <used-space used-blocks="4">
+                    2.0K
+                </used-space>
+            </directory>
+            <directory>
+                <directory-name>/var/tmp/gres-tp</directory-name>
+                <used-space used-blocks="68">
+                    34K
+                </used-space>
+            </directory>
+            <directory>
+                <directory-name>/var/tmp/rtsdb</directory-name>
+                <used-space used-blocks="4">
+                    2.0K
+                </used-space>
+            </directory>
+            <directory>
+                <used-space used-blocks="8">
+                    4.0K
+                </used-space>
+            </directory>
+            <used-space used-blocks="456076">
+                223M
+            </used-space>
+        </directory>
+    </directory-usage-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -10,6 +10,7 @@ from ncclient.transport import SSHSession
 
 from jnpr.junos import Device
 from jnpr.junos.utils.fs import FS
+from jnpr.junos.exception import RpcError
 
 from mock import patch, MagicMock, call
 
@@ -280,6 +281,16 @@ class TestFS(unittest.TestCase):
                          )
 
     @patch('jnpr.junos.Device.execute')
+    def test_directory_usage_no_directory(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_error1
+        self.assertRaises(RpcError, self.fs.directory_usage, path="/var/tmp", depth="1")
+
+    @patch('jnpr.junos.Device.execute')
+    def test_directory_usage_no_dir_name(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_error2
+        self.assertRaises(RpcError, self.fs.directory_usage, path="/var/tmp", depth="1")
+
+    @patch('jnpr.junos.Device.execute')
     def test_storage_cleanup(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.assertEqual(self.fs.storage_cleanup(),
@@ -351,3 +362,13 @@ class TestFS(unittest.TestCase):
                 return self._read_file('request-system-storage-cleanup.xml')
             elif args[0].tag == 'file-archive':
                 return self._read_file('file-archive.xml')
+
+    def _mock_manager_error1(self, *args, **kwargs):
+        if args:
+            if args[0].tag == 'get-directory-usage-information':
+                return self._read_file('get-directory-usage-information_error1.xml')
+
+    def _mock_manager_error2(self, *args, **kwargs):
+        if args:
+            if args[0].tag == 'get-directory-usage-information':
+                return self._read_file('get-directory-usage-information_error2.xml')


### PR DESCRIPTION
Improve error handling in directory_usage():
 - Raise an RpcError if no <directory> element present in the response.
 - Raise an RpcError (rather than trying to perform None.strip()) if a
   <directory-name> element is missing.