### PR TITLE
added remote port ID to lldp.yml (OP)

### DIFF
--- a/lib/jnpr/junos/op/lldp.yml
+++ b/lib/jnpr/junos/op/lldp.yml
@@ -12,4 +12,5 @@ LLDPNeighborView:
     remote_type: lldp-remote-chassis-id-subtype
     remote_chassis_id: lldp-remote-chassis-id
     remote_port_desc: lldp-remote-port-description
+    remote_port_id: lldp-remote-port-id
     remote_sysname: lldp-remote-system-name


### PR DESCRIPTION
Added Remote Port ID to lldp.yml OP.  Not sure why it wasn't there to begin with.  Tested against live MX480.