### PR TITLE
Do not provide the key if it comes from the SSH configuration

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -218,7 +218,6 @@ class _Connection(object):
                 self._hostname = found.get('hostname', self._hostname)
                 self._port = found.get('port', self._port)
                 self._conf_auth_user = found.get('user')
-                self._conf_ssh_private_key_file = found.get('identityfile')
             return sshconf_path
 
     def display_xml_rpc(self, command, format='xml'):
@@ -830,15 +829,13 @@ class Device(_Connection):
             # user will default to $USER
             self._auth_user = os.getenv('USER')
             self._conf_auth_user = None
-            self._conf_ssh_private_key_file = None
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
             self._sshconf_lkup()
             # but if user or private key is explicit from call, then use it.
             self._auth_user = kvargs.get('user') or self._conf_auth_user or \
                 self._auth_user
-            self._ssh_private_key_file = kvargs.get('ssh_private_key_file') \
-                or self._conf_ssh_private_key_file
+            self._ssh_private_key_file = kvargs.get('ssh_private_key_file')
             self._auth_password = kvargs.get(
                 'password') or kvargs.get('passwd')
 


### PR DESCRIPTION
This is a followup of #628 where this change was initially pushed but
reverted because I didn't remember why I did it. Before #628, when an
identity is provided in the SSH configuration, it was not copied in
`_conf_ssh_private_key_file` due to a bug. After fixing the bug in #628,
the key is now copied.

However, the SSH configuration is provided to the `connect()` method
which will use it if needed. Therefore, this is not needed. Moreover, if
the key is provided by an agent and/or encrypted, this won't work as,
later in the code, `allow_agent` will be set to `False` due to the
presence of a private key.