### PR TITLE
Make SCP and StartShell behaves the same way as Device for SSH

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -218,7 +218,6 @@ class _Connection(object):
                 self._hostname = found.get('hostname', self._hostname)
                 self._port = found.get('port', self._port)
                 self._conf_auth_user = found.get('user')
-                self._conf_ssh_private_key_file = found.get('identityfile')
             return sshconf_path
 
     def display_xml_rpc(self, command, format='xml'):
@@ -830,15 +829,13 @@ class Device(_Connection):
             # user will default to $USER
             self._auth_user = os.getenv('USER')
             self._conf_auth_user = None
-            self._conf_ssh_private_key_file = None
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
             self._sshconf_lkup()
             # but if user or private key is explicit from call, then use it.
             self._auth_user = kvargs.get('user') or self._conf_auth_user or \
                 self._auth_user
-            self._ssh_private_key_file = kvargs.get('ssh_private_key_file') \
-                or self._conf_ssh_private_key_file
+            self._ssh_private_key_file = kvargs.get('ssh_private_key_file')
             self._auth_password = kvargs.get(
                 'password') or kvargs.get('passwd')
 

--- a/lib/jnpr/junos/utils/misc.py
+++ b/lib/jnpr/junos/utils/misc.py
@@ -1,0 +1,34 @@
+# utils/misc.py
+
+import paramiko
+
+def get_ssh_client(junos):
+    """Get a Paramiko SSHClient using settings from the provided device."""
+    ssh = paramiko.SSHClient()
+    ssh.load_system_host_keys()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # use junos._hostname since this will be correct if we are going
+    # through a jumphost.
+
+    # Retrieve ProxyCommand and IdentityFile
+    sock = None
+    key_file = junos._ssh_private_key_file
+    ssh_config = junos._sshconf_path
+    if ssh_config:
+        config = paramiko.SSHConfig()
+        config.parse(open(ssh_config))
+        config = config.lookup(junos._hostname)
+        if config.get("proxycommand"):
+            sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
+        key_file = key_file or config.get("identityfile")
+
+    ssh.connect(hostname=junos._hostname,
+                port=(22, int(junos._port))[
+                    junos._hostname == 'localhost'],
+                username=junos._auth_user,
+                password=junos._auth_password,
+                key_filename=key_file,
+                allow_agent=junos._allow_agent,
+                sock=sock)
+    return ssh

--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 import inspect
 
-import paramiko
 from scp import SCPClient
+
+from jnpr.junos.utils.misc import get_ssh_client
 
 """
 Secure Copy Utility
@@ -81,33 +82,7 @@ class SCP(object):
         #@@@ should check for multi-calls to connect to ensure we don't keep
         #@@@ opening new connections
         junos = self._junos
-        self._ssh = paramiko.SSHClient()
-        self._ssh.load_system_host_keys()
-        self._ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-        # use junos._hostname since this will be correct if we are going
-        # through a jumphost.
-
-        # Retrieve ProxyCommand and IdentityFile
-        sock = None
-        key_file = junos._ssh_private_key_file
-        ssh_config = junos._sshconf_path
-        if ssh_config:
-            config = paramiko.SSHConfig()
-            config.parse(open(ssh_config))
-            config = config.lookup(junos._hostname)
-            if config.get("proxycommand"):
-                sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
-            key_file = key_file or config.get("identityfile")
-
-        self._ssh.connect(hostname=junos._hostname,
-                          port=(22, int(junos._port))[
-                              junos._hostname == 'localhost'],
-                          username=junos._auth_user,
-                          password=junos._auth_password,
-                          key_filename=key_file,
-                          allow_agent=junos._allow_agent,
-                          sock=sock)
+        self._ssh = get_ssh_client(junos)
         return SCPClient(self._ssh.get_transport(), **scpargs)
 
     def close(self):

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -1,7 +1,8 @@
-import paramiko
 from select import select
 import re
 import datetime
+
+from jnpr.junos.utils.misc import get_ssh_client
 
 _JUNOS_PROMPT = '> '
 _SHELL_PROMPT = '(%|#)\s'
@@ -82,16 +83,7 @@ class StartShell(object):
         :class:`paramiko.SSHClient` instance.
         """
         junos = self._nc
-
-        client = paramiko.SSHClient()
-        client.load_system_host_keys()
-        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname=junos.hostname,
-                       port=(22, junos._port)[junos.hostname == 'localhost'],
-                       username=junos._auth_user,
-                       password=junos._auth_password,
-                       )
-
+        client = get_ssh_client(junos)
         chan = client.invoke_shell()
         self._client = client
         self._chan = chan


### PR DESCRIPTION
This is a followup to #648 (and this PR includes the commit from #648, so it shouldn't be merged before #648).

First commit makes small changes to SCP. This is mostly cosmetic with the exception of the agent and the private key. This is quite similar to what ncclient is doing with the same parameters that were provided in `Device`.

The second commit moves the creation of the paramiko SSH client into a dedicated function.

The third commit reuses this dedicated function for `StartShell()`.