### PR TITLE
Initial NFX Facts support

### DIFF
--- a/lib/jnpr/junos/facts/current_re.py
+++ b/lib/jnpr/junos/facts/current_re.py
@@ -40,8 +40,7 @@ def get_facts(device):
                             for host in device.facts['_iri_hostname'][ip]:
                                 if host not in current_re:
                                     current_re.append(host)
-    except RpcError as e:
-        # some devices (NFX *cough*) does not support private routing instance!
-        return {'current_re': 'master'}
+    except RpcError:
+        pass
 
     return {'current_re': current_re, }

--- a/lib/jnpr/junos/facts/current_re.py
+++ b/lib/jnpr/junos/facts/current_re.py
@@ -1,4 +1,4 @@
-
+from jnpr.junos.exception import RpcError
 
 def provides_facts():
     """
@@ -17,28 +17,31 @@ def get_facts(device):
     The RPC-equivalent of show interfaces terse on private routing instance.
     """
     current_re = None
-
-    rsp = device.rpc.get_interface_information(
-              normalize=True,
-              routing_instance='__juniper_private1__',
-              terse=True, )
-    # Get the local IPv4 addresses from the response.
-    for ifa in rsp.iterfind(".//address-family[address-family-name='inet']/"
-                            "interface-address/ifa-local"):
-        ifa_text = ifa.text
-        if ifa_text is not None:
-            # Separate the IP from the mask
-            (ip, _, _) = ifa.text.partition('/')
-            if ip is not None:
-                # Use the _iri_hostname fact to map the IP address to
-                # an internal routing instance hostname.
-                if ip in device.facts['_iri_hostname']:
-                    if current_re is None:
-                        # Make a copy, not a reference
-                        current_re = list(device.facts['_iri_hostname'][ip])
-                    else:
-                        for host in device.facts['_iri_hostname'][ip]:
-                            if host not in current_re:
-                                current_re.append(host)
+    try:
+        rsp = device.rpc.get_interface_information(
+                  normalize=True,
+                  routing_instance='__juniper_private1__',
+                  terse=True, )
+        # Get the local IPv4 addresses from the response.
+        for ifa in rsp.iterfind(".//address-family[address-family-name='inet']/"
+                                "interface-address/ifa-local"):
+            ifa_text = ifa.text
+            if ifa_text is not None:
+                # Separate the IP from the mask
+                (ip, _, _) = ifa.text.partition('/')
+                if ip is not None:
+                    # Use the _iri_hostname fact to map the IP address to
+                    # an internal routing instance hostname.
+                    if ip in device.facts['_iri_hostname']:
+                        if current_re is None:
+                            # Make a copy, not a reference
+                            current_re = list(device.facts['_iri_hostname'][ip])
+                        else:
+                            for host in device.facts['_iri_hostname'][ip]:
+                                if host not in current_re:
+                                    current_re.append(host)
+    except RpcError as e:
+        # some devices (NFX *cough*) does not support private routing instance!
+        return {'current_re': 'master'}
 
     return {'current_re': current_re, }

--- a/lib/jnpr/junos/facts/get_software_information.py
+++ b/lib/jnpr/junos/facts/get_software_information.py
@@ -125,18 +125,21 @@ def get_facts(device):
                                    'object': version_info(re_version), }
 
         # Check to see if re_name is the RE we are currently connected to.
-        # There are at least three cases to handle.
+        # There are at least four cases to handle.
         this_re = False
-        # 1) re_name is in the current_re fact. The easy case.
-        if re_name in device.facts['current_re']:
+        # 1) this device doesn't support the current_re fact
+        if device.facts['current_re'] is None:
             this_re = True
-        # 2) Some single-RE devices (discovered on EX2200 running 11.4R1)
+        # 2) re_name is in the current_re fact. The easy case.
+        elif re_name in device.facts['current_re']:
+            this_re = True
+        # 3) Some single-RE devices (discovered on EX2200 running 11.4R1)
         # don't include 'reX' in the current_re list. Check for this
         # condition and still set default hostname, model, and version
         elif (re_name == 're0' and 're1' not in device.facts['current_re'] and
               'master' in device.facts['current_re']):
             this_re = True
-        # 3) For an lcc in a TX(P) re_name is 're0' or 're1', but the
+        # 4) For an lcc in a TX(P) re_name is 're0' or 're1', but the
         # current_re fact is ['lcc1-re0', 'member1-re0', ...]. Check to see
         # if any iri_name endswith the name of the
         elif this_re is False:

--- a/lib/jnpr/junos/facts/get_software_information.py
+++ b/lib/jnpr/junos/facts/get_software_information.py
@@ -24,8 +24,8 @@ def _get_software_information(device):
                 software_information = device.rpc.get_software_information(local=True, normalize=True)
 
             return software_information
-        except Exception as e:
-            print str(e)
+        except:
+            pass
 
 
 def provides_facts():

--- a/lib/jnpr/junos/facts/personality.py
+++ b/lib/jnpr/junos/facts/personality.py
@@ -72,6 +72,9 @@ def get_facts(device):
     elif 'OLIVE' == model:
         personality = 'OLIVE'
         virtual = True
+    elif model.startswith("NFX"):
+        personality = 'NFX'
+        virtual = False
 
     return {'personality': personality,
             'virtual': virtual, }

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -91,6 +91,9 @@ class Serial(Terminal):
                 break         # done reading
         else:
             # exceeded the while loop timeout
+            self._ser.reset_input_buffer()
             return (None, None)
 
+        # clear the input buffer, the next read will refill as necessary
+        self._ser.reset_input_buffer()
         return (rxb, found.lastgroup)


### PR DESCRIPTION
Initial support for NFX250 Facts to address PR #652.

Changes were almost entirely done by catching exceptions through be non-existent XML in JDM, thus should have very little impact for other platforms.

Returned facts now look like:
{'2RE': None, 'HOME': '/root', 'RE0': None, 'RE1': None, 'RE_hw_mi': None, 'current_re': 'master', 'domain': None, 'fqdn': None, 'hostname': 'jdm', 'hostname_info': {'re0': 'jdm'}, 'ifd_style': 'CLASSIC', 'junos_info': {'re0': {'text': '15.1X53-D45.3', 'object': junos.version_info(major=(15, 1), type=X, minor=(53, 'D', 45), build=3)}}, 'master': None, 'model': 'NFX250_S2_10_T', 'model_info': {'re0': 'NFX250_S2_10_T'}, 'personality': 'NFX', 're_info': None, 're_master': None, 'serialnumber': None, 'srx_cluster': None, 'switch_style': 'NONE', 'vc_capable': False, 'vc_fabric': None, 'vc_master': None, 'vc_mode': None, 'version': '15.1X53-D45.3', 'version_RE0': '15.1X53-D45.3', 'version_RE1': None, 'version_info': junos.version_info(major=(15, 1), type=X, minor=(53, 'D', 45), build=3), 'virtual': False}