### PR TITLE
fix Device.timeout is ignored when dev.open()

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -997,8 +997,8 @@ class Device(_Connection):
                                (self._ssh_private_key_file is None))
 
             # set connection timeout by Device.timeout                         
-            timeout = (self.__class__.timeout) \                                
-                    if isinstance(self.__class__.timeout, int) else (None)      
+            timeout = (self.__class__.timeout) \
+                    if isinstance(self.__class__.timeout, int) else (None)
 
             # open connection using ncclient transport
             self._conn = netconf_ssh.connect(

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -996,6 +996,10 @@ class Device(_Connection):
             allow_agent = bool((self._auth_password is None) and
                                (self._ssh_private_key_file is None))
 
+            # set connection timeout by Device.timeout                         
+            timeout = (self.__class__.timeout) \                                
+                    if isinstance(self.__class__.timeout, int) else (None)      
+
             # open connection using ncclient transport
             self._conn = netconf_ssh.connect(
                 host=self._hostname,
@@ -1006,6 +1010,7 @@ class Device(_Connection):
                 key_filename=self._ssh_private_key_file,
                 allow_agent=allow_agent,
                 ssh_config=self._sshconf_lkup(),
+                timeout=timeout,
                 device_params={'name': 'junos', 'local': False})
 
         except NcErrors.AuthenticationError as err:


### PR DESCRIPTION
In method comment, connection timeout value should be set by Device.timeout.
But, It's ignored.

>         :raises ConnectTimeoutError:
>             When the the :meth:`Device.timeout` value is exceeded
>             during the attempt to connect to the remote device