### PR TITLE
adjust ConnectTimeoutError comment on Device#open() to implement

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -971,7 +971,7 @@ class Device(_Connection):
             When the device does not have NETCONF enabled
 
         :raises ConnectTimeoutError:
-            When the the :meth:`Device.timeout` value is exceeded
+            When the OS determined maximum timeout value is exceeded
             during the attempt to connect to the remote device
 
         :raises ConnectError:


### PR DESCRIPTION
According to the comment on Device#open(), ConnectTimeoutError raises when Device.timeout() value is exceeded.
But, it actually depends on OS determined timeout value, such as net.ipv4.tcp_syn_retries. 