### PR TITLE
Add views found on github

### DIFF
--- a/lib/jnpr/junos/op/allroutes.py
+++ b/lib/jnpr/junos/op/allroutes.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for All Routes Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/allroutes.yml
+++ b/lib/jnpr/junos/op/allroutes.yml
@@ -1,0 +1,19 @@
+---
+
+# Taken from https://github.com/Olichous/routeShow/blob/master/allRoutes.yml
+
+allRoutes:
+ rpc: get-route-information
+ args_key: destination
+ args:
+  extensive: True
+  active-path : True
+ item: route-table/rt
+ key: rt-destination
+ view: allView
+
+allView:
+ fields:
+  rt_destination: rt-destination
+  rt_prefix_length: rt-prefix-length
+  nh_via: rt-entry/nh/via

--- a/lib/jnpr/junos/op/bgppeer.py
+++ b/lib/jnpr/junos/op/bgppeer.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for BGP Peer Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/bgppeer.yml
+++ b/lib/jnpr/junos/op/bgppeer.yml
@@ -1,0 +1,20 @@
+---
+
+# Taken from https://github.com/ut0mt8/junos-netconf/blob/master/scripts/bgp-peer.yml
+
+BgpPeerTable:
+  rpc: get-bgp-neighbor-information
+  item: bgp-peer
+  key: bgp-peer
+  view: BgpPeerTableView
+
+BgpPeerTableView:
+  fields:
+    peer_address: peer-address
+    peer_as: peer-as
+    description: description
+    peer_state: peer-state
+    peer_type: peer-type
+    prefix_received: bgp-rib/received-prefix-count
+    table: bgp-rib/name
+    policy: bgp-option-information/export-policy 

--- a/lib/jnpr/junos/op/flowsession.py
+++ b/lib/jnpr/junos/op/flowsession.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for OSPF Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/flowsession.yml
+++ b/lib/jnpr/junos/op/flowsession.yml
@@ -1,0 +1,17 @@
+---
+
+# Taken from https://github.com/barnesry/srx-session-table-clear/blob/master/flowsession.yml
+
+  SessionTable:
+    rpc:  get-flow-session-information
+    item: .//flow-session/flow-information
+    key:  ../session-identifier
+    view: SessionView
+
+  SessionView:
+    fields:
+      source_address: source-address
+      destination_address:  destination-address
+      destination_port: destination-port
+      session_protocol: protocol
+      session_direction:  direction

--- a/lib/jnpr/junos/op/interfaces.py
+++ b/lib/jnpr/junos/op/interfaces.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Interface Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/interfaces.yml
+++ b/lib/jnpr/junos/op/interfaces.yml
@@ -1,0 +1,30 @@
+---
+
+# Taken from https://github.com/macrujugl/pyez/blob/master/interfaces_table.yml
+
+IfacesEthernetTable:
+   rpc: get-interface-information
+   args:
+     interface-name: 'lt-*'
+   args_key: 'interface-name'
+   item: physical-interface
+   key: name
+   view: IfacesEthernetView
+
+IfacesEthernetView:
+   fields:
+     Name: name
+     AdminStatus: admin-status
+     OperStatus: oper-status
+     MTU: mtu
+     SubInterfaces: _SubIntTable
+     
+_SubIntTable:
+   item: logical-interface
+   key: name
+   view: _SubIntView
+
+_SubIntView:
+   fields:
+      LogicalInterfaceName: name
+      LogicalInterfaceAddress: address-family/interface-address/ifa-local

--- a/lib/jnpr/junos/op/license.py
+++ b/lib/jnpr/junos/op/license.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for license Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/license.yml
+++ b/lib/jnpr/junos/op/license.yml
@@ -1,0 +1,17 @@
+---
+### ------------------------------------------------------
+### show system license
+### ------------------------------------------------------
+
+# Taken from https://github.com/dhoutz/netops-tools/blob/master/juniper/juniper_license_audit/license.yml
+
+LicenseTable:
+  rpc: get-license-usage-summary
+  item: feature-summary
+  view: LicenseTableView
+
+LicenseTableView:
+  fields:
+    description: description
+    licensed: licensed
+    needed: needed

--- a/lib/jnpr/junos/op/loopback.py
+++ b/lib/jnpr/junos/op/loopback.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Loopback Interface Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/loopback.yml
+++ b/lib/jnpr/junos/op/loopback.yml
@@ -1,0 +1,32 @@
+---
+
+# Taken from https://github.com/networktocode/pyntc/blob/master/pyntc/devices/tables/jnpr/loopback.yml
+
+LoopbackTable:
+  rpc: get-interface-information
+  args:
+    media: True
+    interface_name: 'lo*'
+  args_key: interface_name
+  item: physical-interface
+  view: LoopbackView
+
+LoopbackView:
+  groups:
+    mac_stats: ethernet-mac-statistics
+    flags: if-device-flags
+  fields:
+    oper: oper-status
+    admin: admin-status
+    description: description
+    mtu: { mtu : int }
+    link_mode: link-mode
+    macaddr: current-physical-address
+  fields_mac_stats:
+    rx_bytes: input-bytes
+    rx_packets: input-packets
+    tx_bytes: output-bytes
+    tx_packets: output-packets
+  fields_flags:
+    running: { ifdf-running: flag }
+    present: { ifdf-present: flag }

--- a/lib/jnpr/junos/op/partition.py
+++ b/lib/jnpr/junos/op/partition.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Partition Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/partition.yml
+++ b/lib/jnpr/junos/op/partition.yml
@@ -1,0 +1,17 @@
+---
+
+# Taken from https://github.com/eatmoreonions/python-junos/blob/master/srx/partitioninfo.yml
+
+PartitionTable:
+  rpc:  get-snapshot-information
+  args:
+    media: internal
+  item:  .//multi-routing-engine-item/snapshot-information
+  key: snapshot-medium
+  view:  PartitionView
+
+PartitionView:
+  fields:
+    medium: snapshot-medium
+    package: software-version/package/package-name
+    version: software-version/package/package-version

--- a/lib/jnpr/junos/op/pimjoin.py
+++ b/lib/jnpr/junos/op/pimjoin.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for PIM Join Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/pimjoin.yml
+++ b/lib/jnpr/junos/op/pimjoin.yml
@@ -1,0 +1,39 @@
+---
+
+# Taken from https://github.com/gavmckee80/PyEz-Examples/blob/master/pimjoin.yml
+
+PimJoinTable:
+ rpc: get-pim-join-information
+ args:
+  extensive: True
+ args_key: group
+ item: join-family/join-group
+ key: multicast-source-address
+ view: PimJoinView
+
+PimJoinView:
+ fields:
+  group: multicast-group-address
+  style: '@style'
+  sparse: {pim-group-flags/sparse: flag}
+  spt: {pim-group-flags/spt: flag}
+  rpt: {pim-group-flags/rptree: flag}
+  wildcard: {pim-group-flags/rptree: flag}
+  src_address: multicast-source-address  
+  uptime: {uptime/@seconds: int}
+  rpf_interface: upstream-interface-name
+  rpf_neighbor: upstream-neighbor
+  rp_join: {upstream-state-flags/join-to-rp: flag}
+  oil_count: {downstream-interface-count: int}
+  oil: _DownStreamInterfaceTable
+
+_DownStreamInterfaceTable:
+  item: downstream-interfaces/downstream-interface
+  key: pim-interface-name
+  view: _DownStreamInterfaceView
+
+_DownStreamInterfaceView:
+  fields: 
+    interface: pim-interface-name
+
+

--- a/lib/jnpr/junos/op/pimneighbor.py
+++ b/lib/jnpr/junos/op/pimneighbor.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for OSPF Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/pimneighbor.yml
+++ b/lib/jnpr/junos/op/pimneighbor.yml
@@ -1,0 +1,40 @@
+---
+
+# Taken from https://github.com/gavmckee80/PyEz-Examples/blob/master/pimneighbor.yml
+
+PimNeighborsTable:
+  rpc: get-pim-neighbors-information
+  args:
+    detail: True
+  item: //pim-interface
+  key: pim-interface-name
+  view: PimInterfaceView
+
+PimInterfaceView:
+  fields:
+    interface: pim-interface-name
+    neighbor: _PimNeighborTable
+
+_PimNeighborTable:
+  item: pim-neighbor
+  key: pim-neighbor-address
+  view: _PimNeighborView
+_PimNeighborView:
+  fields:
+    neighbor_address: pim-neighbor-address
+    ip_version: ip-protocol-version
+    pim_version: protocol-version
+    sg_count: pim-neighbor-join-sg-count
+    tsg_count: pim-neighbor-join-tsg-count
+    pim_joins: _PimJoinTable
+
+_PimJoinTable:
+  item: pim-neighbor-join 
+  key: multicast-group-address
+  view: _PimJoinView
+_PimJoinView:
+  fields:
+    group_address: multicast-group-address
+    source_address: multicast-source-address
+
+

--- a/lib/jnpr/junos/op/preflist.py
+++ b/lib/jnpr/junos/op/preflist.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Preference List Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/preflist.yml
+++ b/lib/jnpr/junos/op/preflist.yml
@@ -1,0 +1,22 @@
+---
+
+# Taken from https://github.com/tamihiro/cm_demo/blob/master/cm_sess/netconf_yaml/preflist.yml
+
+PrefListTable:
+  rpc: get-configuration
+  item: policy-options/prefix-list
+  key: name
+  view: PrefListView
+
+PrefListView:
+  fields:
+    name: name
+    entries: _PrefListEntryTable
+
+_PrefListEntryTable:
+  item: prefix-list-item
+  view: _PrefListItemView
+
+_PrefListItemView:
+  fields:
+    prefix: name

--- a/lib/jnpr/junos/op/routedetail.py
+++ b/lib/jnpr/junos/op/routedetail.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Route Detail Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/routedetail.yml
+++ b/lib/jnpr/junos/op/routedetail.yml
@@ -1,0 +1,22 @@
+---
+
+# Taken from https://github.com/ut0mt8/junos-netconf/blob/master/scripts/route-detail.yml
+
+RtrTable:
+  rpc: get-route-information
+  args_key: destination
+  item: route-table/rt/rt-entry
+  key: rt-entry
+  view: RteTableView
+
+RteTableView:
+  fields:
+    protocol: protocol-name
+    via: nh/via | nh/nh-local-interface
+    age: { age/@seconds : int }
+    nexthop: nh/to
+    preference : preference
+    med: med
+    local-preference: local-preference
+    learned-from: learned-from
+    as-path: as-path

--- a/lib/jnpr/junos/op/version.py
+++ b/lib/jnpr/junos/op/version.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for JunOS Version Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/version.yml
+++ b/lib/jnpr/junos/op/version.yml
@@ -1,0 +1,12 @@
+---
+
+# Taken from https://github.com/spkrishnan/macsec/blob/master/junver.yml
+
+VersionTable:
+  rpc: get-software-information
+  item: multi-routing-engine-item/software-information/package-information
+  view: VersionView
+
+VersionView:
+  fields:
+   name: name

--- a/lib/jnpr/junos/op/vlanels.py
+++ b/lib/jnpr/junos/op/vlanels.py
@@ -1,0 +1,7 @@
+"""
+Pythonifier for Vlan Els Table/View
+"""
+from jnpr.junos.factory import loadyaml
+from os.path import splitext
+_YAML_ = splitext(__file__)[0] + '.yml'
+globals().update(loadyaml(_YAML_))

--- a/lib/jnpr/junos/op/vlanels.yml
+++ b/lib/jnpr/junos/op/vlanels.yml
@@ -1,0 +1,16 @@
+---
+
+# Taken from https://github.com/rickmur/PyEZtests/blob/master/vlanEls.yml
+
+ElsVlanTable:
+  rpc: get-vlan-information
+  item: l2ng-l2ald-vlan-instance-group
+  view: ElsVlanView
+  key: l2ng-l2rtb-vlan-tag
+
+ElsVlanView:
+  fields:
+    instance: l2ng-l2rtb-name
+    vlan_name: l2ng-l2rtb-vlan-name
+    tag: l2ng-l2rtb-vlan-tag
+    members: .//l2ng-l2rtb-vlan-member-interface


### PR DESCRIPTION
Would be nice to consolidate views that people have created. I searched github and found the following in the wild. I have accredited them in the file, and tagged them here. 

https://github.com/Olichous/routeShow/blob/master/allRoutes.yml
https://github.com/ut0mt8/junos-netconf/blob/master/scripts/bgp-peer.yml
https://github.com/barnesry/srx-session-table-clear/blob/master/flowsession.yml
https://github.com/macrujugl/pyez/blob/master/interfaces_table.yml
https://github.com/dhoutz/netops-tools/blob/master/juniper/juniper_license_audit/license.yml
https://github.com/networktocode/pyntc/blob/master/pyntc/devices/tables/jnpr/loopback.yml
https://github.com/eatmoreonions/python-junos/blob/master/srx/partitioninfo.yml
https://github.com/gavmckee80/PyEz-Examples/blob/master/pimjoin.yml
https://github.com/gavmckee80/PyEz-Examples/blob/master/pimneighbor.yml
https://github.com/tamihiro/cm_demo/blob/master/cm_sess/netconf_yaml/preflist.yml
https://github.com/ut0mt8/junos-netconf/blob/master/scripts/route-detail.yml
https://github.com/spkrishnan/macsec/blob/master/junver.yml
https://github.com/rickmur/PyEZtests/blob/master/vlanEls.yml


@Olichous
@ut0mt8
@barnesry
@macrujugl
@dhoutz
@eatmoreonions
@gavmckee80
@tamihiro
@spkrishnan
@rickmur


I also know there is a bunch in:
https://github.com/napalm-automation/napalm-junos/blob/master/napalm_junos/utils/junos_views.yml 
but could not easily tell which are part of original repo or not. I thought I would tag @mirceaulinic to see if he had any input. 