### PR TITLE
Implement SSH keepalives, default 30-second interval, for NETCONF over SSH sessions.

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -866,6 +866,16 @@ class Device(_Connection):
             This can be used to load SSH information from a configuration file.
             By default ~/.ssh/config is queried.
 
+        :param int ssh_keepalives:
+            *OPTIONAL* The interval, in seconds, at which to send SSH
+            keepalives for the NETCONF over SSH session. Without SSH
+            keepalives, a NAT or stateful firewall along the network
+            path between the PyEZ host and the target Junos device,
+            may timeout an inactive TCP flow and cause the NETCONF over SSH
+            session to hang. Sending SSH keepalives avoids this situation. The
+            default value is 30 seconds. Setting this parameter to a value of 0
+            disables SSH keepalives.
+
         :param bool normalize:
             *OPTIONAL* default is ``False``.  If ``True`` then the
             XML returned by :meth:`execute` will have whitespace normalized
@@ -897,6 +907,7 @@ class Device(_Connection):
             self._hostname = 'localhost'
             self._ssh_private_key_file = None
             self._ssh_config = None
+            self._ssh_keepalives = None
         else:
             # --------------------------
             # making a remote connection
@@ -910,6 +921,7 @@ class Device(_Connection):
             self._conf_ssh_private_key_file = None
             # user can get updated by ssh_config
             self._ssh_config = kvargs.get('ssh_config')
+            self._ssh_keepalives = kvargs.get('ssh_keepalives', 30)
             self._sshconf_lkup()
             # but if user or private key is explicit from call, then use it.
             self._auth_user = kvargs.get('user') or self._conf_auth_user or \
@@ -1007,6 +1019,8 @@ class Device(_Connection):
                 allow_agent=allow_agent,
                 ssh_config=self._sshconf_lkup(),
                 device_params={'name': 'junos', 'local': False})
+
+            self._conn._session.transport.set_keepalive(self._ssh_keepalives)
 
         except NcErrors.AuthenticationError as err:
             # bad authentication credentials


### PR DESCRIPTION
Without SSH keepalives, a NAT or stateful firewall along the network
path between the PyEZ host and the target Junos device,
may timeout an inactive TCP flow and cause the NETCONF over SSH
session to hang. Sending SSH keepalives avoids this situation. The
default value is 30 seconds. Setting this parameter to a value of 0
disables SSH keepalives.

Note: This is a different situation than Issue #663 in which the
target Junos device is timing out the NETCONF over SSH session
due to a configured idle-timeout on the system login class.