### PR TITLE
Provide a master property and a re_name property for Device

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -218,12 +218,13 @@ class _Connection(object):
         The current Routing Engine is the RE to which the NETCONF session is
         connected.
 
-        Note: This property is based on new-style fact gathering and the
-              value of currently cached facts. If there is a chance the
-              mastership state may have changed since the facts were cached,
-              then dev.facts_refresh() should be invoked prior to checking
-              this property. If old-style fact gathering is in use,
-              this property will return None.
+        .. note::
+            This property is based on new-style fact gathering and the
+            value of currently cached facts. If there is a chance the
+            mastership state may have changed since the facts were cached,
+            then dev.facts_refresh() should be invoked prior to checking
+            this property. If old-style fact gathering is in use,
+            this property will return None.
 
         :returns: True if the current RE is the master Routing Engine. False if
                   the current RE is not the master Routing Engine. None if
@@ -231,31 +232,32 @@ class _Connection(object):
         """
         master = None
 
-        try:
-            # Make sure the 'current_re' fact has a value
-            if self.facts['current_re'] is not None:
-                # Typical master case
-                if 'master' in self.facts['current_re']:
-                    master = True
-                # Typical backup case
-                elif 'backup' in self.facts['current_re']:
-                    master = False
-                # Some single RE platforms don't have 'master' in the
-                # 'current_re' fact. It's best to check if it's a single RE
-                # platform based on the '2RE' fact, not the 'current_re' fact.
-                elif (self.facts['2RE'] is False and
-                      're0' in self.facts['current_re']):
-                    master = True
-                else:
-                    for re_state in self.facts['current_re']:
-                        # Multi-chassis case. A chassis master/backup, but
-                        # not the system master/backup.
-                        if '-backup' in re_state or '-master' in re_state:
-                            master = False
-                            break
-        except KeyError:
-            # Old style fact gathering is likely in use. Nothing we can do.
-            pass
+        # Make sure the 'current_re' fact has a value
+        if self.facts.get('current_re') is not None:
+            # Typical master case
+            if 'master' in self.facts['current_re']:
+                master = True
+            # Typical backup case
+            elif 'backup' in self.facts['current_re']:
+                master = False
+            # Some single chanssis and single RE platforms don't have
+            # 'master' in the 'current_re' fact. It's best to check if it's a
+            #  single chassis and single RE platform based on the
+            # 'RE_hw_mi' and '2RE' facts, not the 'current_re' fact.
+            elif (self.facts.get('2RE') is False and
+                  self.facts.get('RE_hw_mi') is False and
+                  're0' in self.facts['current_re']):
+                master = True
+            else:
+                # Might be a multi-chassis case where this RE is neither the
+                # master or the backup for the entire system. In that case,
+                # it's either a chassis master or a chassis backup.
+                for re_state in self.facts['current_re']:
+                    # Multi-chassis case. A chassis master/backup, but
+                    # not the system master/backup.
+                    if '-backup' in re_state or '-master' in re_state:
+                        master = False
+                        break
         return master
 
     @master.setter
@@ -275,8 +277,9 @@ class _Connection(object):
         The current Routing Engine is the RE to which the NETCONF session is
         connected.
 
-        Note: This property is based on new-style fact gathering. If old-style
-              fact gathering is in use, this property will return None.
+        .. note::
+            This property is based on new-style fact gathering. If
+            old-style fact gathering is in use, this property will return None.
 
         :returns: A string containing the name of the current Routing Engine or
                   None if unable to determine the state of the current
@@ -284,34 +287,31 @@ class _Connection(object):
         """
         re_name = None
 
-        try:
-            # Make sure the 'current_re' and 'hostname_info' facts have values
-            if (self.facts['current_re'] is not None and
-               self.facts['hostname_info'] is not None):
-                # re_name should be the intersection of the values in the
-                # 'current_re' fact and the keys in the 'hostname_info' fact.
-                intersect = (set(self.facts['current_re']) &
-                             set(self.facts['hostname_info'].keys()))
-                # intersect should usually contain a single element (the RE's
-                # name) if things worked correctly.
-                if len(intersect) == 1:
-                    re_name = list(intersect)[0]
-                # If intersect contains no elements
-                elif len(intersect) == 0:
-                    # Look for the first value
-                    # in 'current_re' which contains '-re'.
-                    for re_state in self.facts['current_re']:
-                        if '-re' in re_state:
-                            re_name = re_state
-                            break
+        # Make sure the 'current_re' and 'hostname_info' facts have values
+        if (self.facts.get('current_re') is not None and
+           self.facts.get('hostname_info') is not None):
+            # re_name should be the intersection of the values in the
+            # 'current_re' fact and the keys in the 'hostname_info' fact.
+            intersect = (set(self.facts['current_re']) &
+                         set(self.facts['hostname_info'].keys()))
+            # intersect should usually contain a single element (the RE's
+            # name) if things worked correctly.
+            if len(intersect) == 1:
+                re_name = list(intersect)[0]
+            # If intersect contains no elements
+            elif len(intersect) == 0:
+                # Look for the first value
+                # in 'current_re' which contains '-re'.
+                for re_state in self.facts['current_re']:
+                    if '-re' in re_state:
+                        re_name = re_state
+                        break
+                if re_name is None:
                     # Still haven't figured it out, if there's only one key
                     # in 'hostname_info', assume that.
-                    if (re_name is None and
-                       len(self.facts['hostname_info']) == 1):
-                        re_name = self.facts['hostname_info'].keys()[0]
-        except KeyError:
-            # Old style fact gathering is likely in use. Nothing we can do.
-            pass
+                    all_re_names = list(self.facts['hostname_info'].keys())
+                    if len(all_re_names) == 1:
+                        re_name = all_re_names[0]
         return re_name
 
     @re_name.setter

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -206,6 +206,119 @@ class _Connection(object):
         """
         return self._port
 
+    # ------------------------------------------------------------------------
+    # property: master
+    # ------------------------------------------------------------------------
+
+    @property
+    def master(self):
+        """
+        The mastership state of the current Routing Engine.
+
+        The current Routing Engine is the RE to which the NETCONF session is
+        connected.
+
+        Note: This property is based on new-style fact gathering and the
+              value of currently cached facts. If there is a chance the
+              mastership state may have changed since the facts were cached,
+              then dev.facts_refresh() should be invoked prior to checking
+              this property. If old-style fact gathering is in use,
+              this property will return None.
+
+        :returns: True if the current RE is the master Routing Engine. False if
+                  the current RE is not the master Routing Engine. None if
+                  unable to determine the state of the current Routing Engine.
+        """
+        master = None
+
+        try:
+            # Make sure the 'current_re' fact has a value
+            if self.facts['current_re'] is not None:
+                # Typical master case
+                if 'master' in self.facts['current_re']:
+                    master = True
+                # Typical backup case
+                elif 'backup' in self.facts['current_re']:
+                    master = False
+                # Some single RE platforms don't have 'master' in the
+                # 'current_re' fact. It's best to check if it's a single RE
+                # platform based on the '2RE' fact, not the 'current_re' fact.
+                elif (self.facts['2RE'] is False and
+                      're0' in self.facts['current_re']):
+                    master = True
+                else:
+                    for re_state in self.facts['current_re']:
+                        # Multi-chassis case. A chassis master/backup, but
+                        # not the system master/backup.
+                        if '-backup' in re_state or '-master' in re_state:
+                            master = False
+                            break
+        except KeyError:
+            # Old style fact gathering is likely in use. Nothing we can do.
+            pass
+        return master
+
+    @master.setter
+    def master(self, value):
+        """ read-only property """
+        raise RuntimeError("master is read-only!")
+
+    # ------------------------------------------------------------------------
+    # property: re_name
+    # ------------------------------------------------------------------------
+
+    @property
+    def re_name(self):
+        """
+        The name of the current Routing Engine.
+
+        The current Routing Engine is the RE to which the NETCONF session is
+        connected.
+
+        Note: This property is based on new-style fact gathering. If old-style
+              fact gathering is in use, this property will return None.
+
+        :returns: A string containing the name of the current Routing Engine or
+                  None if unable to determine the state of the current
+                  Routing Engine.
+        """
+        re_name = None
+
+        try:
+            # Make sure the 'current_re' and 'hostname_info' facts have values
+            if (self.facts['current_re'] is not None and
+               self.facts['hostname_info'] is not None):
+                # re_name should be the intersection of the values in the
+                # 'current_re' fact and the keys in the 'hostname_info' fact.
+                intersect = (set(self.facts['current_re']) &
+                             set(self.facts['hostname_info'].keys()))
+                # intersect should usually contain a single element (the RE's
+                # name) if things worked correctly.
+                if len(intersect) == 1:
+                    re_name = list(intersect)[0]
+                # If intersect contains no elements
+                elif len(intersect) == 0:
+                    # Look for the first value
+                    # in 'current_re' which contains '-re'.
+                    for re_state in self.facts['current_re']:
+                        if '-re' in re_state:
+                            re_name = re_state
+                            break
+                    # Still haven't figured it out, if there's only one key
+                    # in 'hostname_info', assume that.
+                    if (re_name is None and
+                       len(self.facts['hostname_info']) == 1):
+                        re_name = self.facts['hostname_info'].keys()[0]
+        except KeyError:
+            # Old style fact gathering is likely in use. Nothing we can do.
+            pass
+        return re_name
+
+    @re_name.setter
+    def re_name(self, value):
+        """ read-only property """
+        raise RuntimeError("re_name is read-only!")
+
     def _sshconf_lkup(self):
         if self._ssh_config:
             sshconf_path = os.path.expanduser(self._ssh_config)

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -1,9 +1,9 @@
-__author__ = "Rick Sherman, Nitin Kumar"
+__author__ = "Rick Sherman, Nitin Kumar, Stacy Smith"
 __credits__ = "Jeremy Schulman"
 
 import unittest2 as unittest
 from nose.plugins.attrib import attr
-from mock import MagicMock, patch, mock_open
+from mock import MagicMock, patch, mock_open, call
 import os
 from lxml import etree
 import sys
@@ -79,8 +79,8 @@ class TestDevice(unittest.TestCase):
         self.dev.close()
 
     def test_new_console_return(self):
-        dev = Device(host='1.1.1.1', user='test', password='password123', port=23,
-                     gather_facts=False)
+        dev = Device(host='1.1.1.1', user='test', password='password123',
+                     port=23, gather_facts=False)
         self.assertTrue(isinstance(dev, Console))
 
     @patch('jnpr.junos.device.netconf_ssh')
@@ -101,7 +101,8 @@ class TestDevice(unittest.TestCase):
         from datetime import timedelta, datetime
         currenttime = datetime.now()
         mock_datetime.datetime.now.side_effect = [currenttime,
-                                                  currenttime + timedelta(minutes=4)]
+                                                  currenttime +
+                                                  timedelta(minutes=4)]
         self.assertRaises(EzErrors.ConnectTimeoutError, self.dev.open)
 
     @patch('jnpr.junos.device.netconf_ssh')
@@ -112,7 +113,8 @@ class TestDevice(unittest.TestCase):
         from datetime import timedelta, datetime
         currenttime = datetime.now()
         mock_datetime.datetime.now.side_effect = [currenttime,
-                                                  currenttime + timedelta(minutes=4)]
+                                                  currenttime +
+                                                  timedelta(minutes=4)]
         self.assertRaises(EzErrors.ConnectError, self.dev.open)
 
     @patch('jnpr.junos.device.netconf_ssh')
@@ -163,6 +165,123 @@ class TestDevice(unittest.TestCase):
             self.dev.logfile = True
         except Exception as ex:
             self.assertEqual(type(ex), ValueError)
+
+    def test_device_master_is_master(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['re1', 'master', 'node',
+                                               'fwdd', 'member', 'pfem']
+        self.assertEqual(localdev.master, True)
+
+    def test_device_master_is_backup(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['re0', 'backup']
+        self.assertEqual(localdev.master, False)
+
+    def test_device_master_is_re0_only(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['2RE'] = False
+        localdev.facts._cache['current_re'] = ['re0']
+        self.assertEqual(localdev.master, True)
+
+    def test_device_master_is_multi_chassis_non_master1(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['2RE'] = True
+        localdev.facts._cache['current_re'] = ['lcc1-re1', 'member1-re1',
+                                               'lcc1-backup', 'member1-backup']
+        self.assertEqual(localdev.master, False)
+
+    def test_device_master_is_multi_chassis_non_master2(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['2RE'] = True
+        localdev.facts._cache['current_re'] = ['lcc1-re0', 'member1-re0',
+                                               'lcc1-master', 'member1-master',
+                                               'member1']
+        self.assertEqual(localdev.master, False)
+
+    def test_device_master_is_none1(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = None
+        self.assertEqual(localdev.master, None)
+
+    def test_device_master_is_none2(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['2RE'] = True
+        localdev.facts._cache['current_re'] = ['foo', 'bar']
+        self.assertEqual(localdev.master, None)
+
+    @patch('jnpr.junos.device.warnings')
+    def test_device_master_is_old_facts(self, mock_warn):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          fact_style='old', gather_facts=False)
+        mock_warn.assert_has_calls([call.warn('fact-style old will be removed '
+                                              'in a future release.',
+                                              RuntimeWarning)])
+        self.assertEqual(localdev.master, None)
+
+    def test_device_master_setter(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        with self.assertRaises(RuntimeError):
+            localdev.master = 'foo'
+
+    def test_device_re_name_is_re0(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['re0', 'backup']
+        localdev.facts._cache['hostname_info'] = {'re0': 'tapir',
+                                                  're1': 'tapir1'}
+        self.assertEqual(localdev.re_name, 're0')
+
+    def test_device_re_name_is_lcc_re1(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['lcc1-re1', 'member1-re1',
+                                               'lcc1-backup', 'member1-backup']
+        localdev.facts._cache['hostname_info'] = {'re0': 'mj1'}
+        self.assertEqual(localdev.re_name, 'lcc1-re1')
+
+    def test_device_re_name_is_re0_only(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['foo']
+        localdev.facts._cache['hostname_info'] = {'re0': 'mj1'}
+        self.assertEqual(localdev.re_name, 're0')
+
+    def test_device_re_name_is_none1(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = None
+        self.assertEqual(localdev.re_name, None)
+
+    def test_device_re_name_is_none2(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        localdev.facts._cache['current_re'] = ['re1', 'master', 'node',
+                                               'fwdd', 'member', 'pfem']
+        localdev.facts._cache['hostname_info'] = None
+        self.assertEqual(localdev.re_name, None)
+
+    @patch('jnpr.junos.device.warnings')
+    def test_device_re_name_is_old_facts(self, mock_warn):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          fact_style='old', gather_facts=False)
+        mock_warn.assert_has_calls([call.warn('fact-style old will be removed '
+                                              'in a future release.',
+                                              RuntimeWarning)])
+        self.assertEqual(localdev.re_name, None)
+
+    def test_device_re_name_setter(self):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        with self.assertRaises(RuntimeError):
+            localdev.re_name = 'foo'
 
     def test_device_repr(self):
         localdev = Device(host='1.1.1.1', user='test', password='password123',
@@ -244,23 +363,25 @@ class TestDevice(unittest.TestCase):
 
     @patch('jnpr.junos.Device.execute')
     @patch('jnpr.junos.device.warnings')
-    def test_device_facts_error_exception_on_error(self, mock_warnings, mock_execute):
+    def test_device_facts_error_exception_on_error(self, mock_warnings,
+                                                   mock_execute):
         with patch('jnpr.junos.utils.fs.FS.cat') as mock_cat:
             mock_execute.side_effect = self._mock_manager
             mock_cat.side_effect = IOError('File cant be handled')
-            self.assertRaises(IOError, self.dev.facts_refresh, exception_on_failure=True)
+            self.assertRaises(IOError, self.dev.facts_refresh,
+                              exception_on_failure=True)
 
     @patch('jnpr.junos.Device.execute')
     @patch('jnpr.junos.device.warnings')
     def test_device_old_style_facts_error_exception_on_error(self,
-                                                            mock_warnings,
-                                                            mock_execute):
+                                                             mock_warnings,
+                                                             mock_execute):
         self.dev._fact_style = 'old'
         with patch('jnpr.junos.utils.fs.FS.cat') as mock_cat:
             mock_execute.side_effect = self._mock_manager
             mock_cat.side_effect = IOError('File cant be handled')
-            self.assertRaises(IOError, self.dev.facts_refresh, exception_on_failure=True)
-
+            self.assertRaises(IOError, self.dev.facts_refresh,
+                              exception_on_failure=True)
 
     def test_device_facts_refresh_unknown_fact_style(self):
         self.dev._fact_style = 'bad'
@@ -330,11 +451,10 @@ class TestDevice(unittest.TestCase):
         self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
         ex = ValueError('Extra data ')
         ex.message = 'Extra data '  # for py3 as we dont have message thr
-        mock_json_loads.side_effect = [ex,
-                                       self._mock_manager(
-                                           etree.fromstring(
-                                               '<get-route-information format="json"/>')
-                                       )]
+        mock_json_loads.side_effect = [
+            ex,
+            self._mock_manager(etree.fromstring(
+                                   '<get-route-information format="json"/>'))]
         self.dev.rpc.get_route_information({'format': 'json'})
         self.assertEqual(mock_json_loads.call_count, 2)
 
@@ -342,25 +462,29 @@ class TestDevice(unittest.TestCase):
     def test_device_cli_to_rpc_string(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         data = self.dev.cli_to_rpc_string('show system uptime')
-        self.assertEqual("rpc.get_system_uptime_information()",data)
+        self.assertEqual("rpc.get_system_uptime_information()", data)
 
     @patch('jnpr.junos.Device.execute')
     def test_device_cli_to_rpc_string_strip_pipes(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        data = self.dev.cli_to_rpc_string('show system uptime | match foo | count')
-        self.assertEqual("rpc.get_system_uptime_information()",data)
+        data = self.dev.cli_to_rpc_string(
+                   'show system uptime | match foo | count')
+        self.assertEqual("rpc.get_system_uptime_information()", data)
 
     @patch('jnpr.junos.Device.execute')
     def test_device_cli_to_rpc_string_complex(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        data = self.dev.cli_to_rpc_string('show interfaces ge-0/0/0.0 routing-instance all media')
-        self.assertEqual("rpc.get_interface_information(routing_instance='all', media=True, interface_name='ge-0/0/0.0')",data)
+        data = self.dev.cli_to_rpc_string(
+                   'show interfaces ge-0/0/0.0 routing-instance all media')
+        self.assertEqual("rpc.get_interface_information("
+                         "routing_instance='all', media=True, "
+                         "interface_name='ge-0/0/0.0')", data)
 
     @patch('jnpr.junos.Device.execute')
     def test_device_cli_to_rpc_string_invalid(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         data = self.dev.cli_to_rpc_string('foo')
-        self.assertEqual(None,data)
+        self.assertEqual(None, data)
 
     @patch('jnpr.junos.Device.execute')
     def test_device_cli_format_json(self, mock_execute):
@@ -388,14 +512,15 @@ class TestDevice(unittest.TestCase):
     @patch('jnpr.junos.device.warnings')
     def test_device_cli_output_warning(self, mock_warnings, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        data = self.dev.cli('show interfaces ge-0/0/0.0 routing-instance all media',
-                            format = 'xml')
+        data = self.dev.cli('show interfaces ge-0/0/0.0 routing-instance '
+                            'all media', format='xml')
         ip = data.findtext('logical-interface[name="ge-0/0/0.0"]/'
                            'address-family[address-family-name="inet"]/'
                            'interface-address/ifa-local')
         self.assertTrue('192.168.100.1' in ip)
         self.assertTrue(mock_warnings.warn.called)
-        rpc_string = "rpc.get_interface_information(routing_instance='all', media=True, interface_name='ge-0/0/0.0')"
+        rpc_string = "rpc.get_interface_information(routing_instance='all', "\
+                     "media=True, interface_name='ge-0/0/0.0')"
         self.assertIn(rpc_string, mock_warnings.warn.call_args[0][0])
 
     def test_device_cli_blank_output(self):
@@ -403,8 +528,7 @@ class TestDevice(unittest.TestCase):
         self.assertEqual('', self.dev.cli('show configuration interfaces',
                                           warning=False))
 
-    #@patch('jnpr.junos.Device.execute')
-    def test_device_cli_rpc_reply_with_message(self):  # , mock_execute):
+    def test_device_cli_rpc_reply_with_message(self):
         self.dev._conn.rpc = MagicMock(side_effect=self._mock_manager)
         self.assertEqual(
             '\nprotocol: operation-failed\nerror: device asdf not found\n',

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -183,6 +183,7 @@ class TestDevice(unittest.TestCase):
         localdev = Device(host='1.1.1.1', user='test', password='password123',
                           gather_facts=False)
         localdev.facts._cache['2RE'] = False
+        localdev.facts._cache['RE_hw_mi'] = False
         localdev.facts._cache['current_re'] = ['re0']
         self.assertEqual(localdev.master, True)
 


### PR DESCRIPTION
Provide a master property to indicate if the current Routing Engine is the master. Provide a re_name property to return the name of the current Routing Engine.