### PR TITLE
Version changes.

### DIFF
--- a/lib/jnpr/junos/__init__.py
+++ b/lib/jnpr/junos/__init__.py
@@ -1,19 +1,32 @@
-from jnpr.junos.device import Device
-from jnpr.junos.console import Console
-from jnpr.junos.factory.to_json import PyEzJSONEncoder
-from jnpr.junos.facts.swver import version_info
-from jnpr.junos.facts.swver import version_yaml_representer
-from . import jxml
-from . import jxml as JXML
 from . import version
-from . import exception
+
+try:
+    from jnpr.junos.device import Device
+    from jnpr.junos.console import Console
+    from jnpr.junos.facts.swver import version_info
+    from jnpr.junos.facts.swver import version_yaml_representer
+    from . import jxml
+    from . import jxml as JXML
+    from . import exception
+except ImportError:
+    pass
 
 import json
-import yaml
 import logging
-
 import sys
 import warnings
+
+try:
+    from jnpr.junos.factory.to_json import PyEzJSONEncoder
+    HAS_JSON_ENCODER = True
+except ImportError:
+    HAS_JSON_ENCODER = False
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 if sys.version_info[:2] == (2, 6):
     warnings.warn(
@@ -25,20 +38,20 @@ if sys.version_info[:2] == (2, 6):
 
 __version__ = version.VERSION
 __date__ = version.DATE
+__author__ = version.AUTHOR
 
-# import time
-# __date__ = time.strftime("%Y-%b-%d")
+if HAS_JSON_ENCODER:
+    # Set default JSON encoder
+    json._default_encoder = PyEzJSONEncoder()
 
-# Set default JSON encoder
-json._default_encoder = PyEzJSONEncoder()
-
-# Disable ignore_aliases for YAML dumper
-# To support version_info
-yaml.dumper.SafeDumper.ignore_aliases = lambda self, data: True
-yaml.dumper.Dumper.ignore_aliases = lambda self, data: True
-# Add YAML representer for version_info
-yaml.Dumper.add_multi_representer(version_info, version_yaml_representer)
-yaml.SafeDumper.add_multi_representer(version_info, version_yaml_representer)
+if HAS_YAML:
+    # Disable ignore_aliases for YAML dumper
+    # To support version_info
+    yaml.dumper.SafeDumper.ignore_aliases = lambda self, data: True
+    yaml.dumper.Dumper.ignore_aliases = lambda self, data: True
+    # Add YAML representer for version_info
+    yaml.Dumper.add_multi_representer(version_info, version_yaml_representer)
+    yaml.SafeDumper.add_multi_representer(version_info, version_yaml_representer)
 
 
 # Suppress Paramiko logger warnings

--- a/lib/jnpr/junos/__init__.py
+++ b/lib/jnpr/junos/__init__.py
@@ -1,32 +1,19 @@
+from jnpr.junos.device import Device
+from jnpr.junos.console import Console
+from jnpr.junos.factory.to_json import PyEzJSONEncoder
+from jnpr.junos.facts.swver import version_info
+from jnpr.junos.facts.swver import version_yaml_representer
+from . import jxml
+from . import jxml as JXML
 from . import version
-
-try:
-    from jnpr.junos.device import Device
-    from jnpr.junos.console import Console
-    from jnpr.junos.facts.swver import version_info
-    from jnpr.junos.facts.swver import version_yaml_representer
-    from . import jxml
-    from . import jxml as JXML
-    from . import exception
-except ImportError:
-    pass
+from . import exception
 
 import json
+import yaml
 import logging
+
 import sys
 import warnings
-
-try:
-    from jnpr.junos.factory.to_json import PyEzJSONEncoder
-    HAS_JSON_ENCODER = True
-except ImportError:
-    HAS_JSON_ENCODER = False
-
-try:
-    import yaml
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
 
 if sys.version_info[:2] == (2, 6):
     warnings.warn(
@@ -38,20 +25,20 @@ if sys.version_info[:2] == (2, 6):
 
 __version__ = version.VERSION
 __date__ = version.DATE
-__author__ = version.AUTHOR
 
-if HAS_JSON_ENCODER:
-    # Set default JSON encoder
-    json._default_encoder = PyEzJSONEncoder()
+# import time
+# __date__ = time.strftime("%Y-%b-%d")
 
-if HAS_YAML:
-    # Disable ignore_aliases for YAML dumper
-    # To support version_info
-    yaml.dumper.SafeDumper.ignore_aliases = lambda self, data: True
-    yaml.dumper.Dumper.ignore_aliases = lambda self, data: True
-    # Add YAML representer for version_info
-    yaml.Dumper.add_multi_representer(version_info, version_yaml_representer)
-    yaml.SafeDumper.add_multi_representer(version_info, version_yaml_representer)
+# Set default JSON encoder
+json._default_encoder = PyEzJSONEncoder()
+
+# Disable ignore_aliases for YAML dumper
+# To support version_info
+yaml.dumper.SafeDumper.ignore_aliases = lambda self, data: True
+yaml.dumper.Dumper.ignore_aliases = lambda self, data: True
+# Add YAML representer for version_info
+yaml.Dumper.add_multi_representer(version_info, version_yaml_representer)
+yaml.SafeDumper.add_multi_representer(version_info, version_yaml_representer)
 
 
 # Suppress Paramiko logger warnings

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,2 +1,11 @@
-VERSION = "2.0.2-dev"
-DATE = "2016-Oct-26"
+VERSION = "2.1.dev0"
+DATE = "2017-Mar-16"
+AUTHOR = "Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith"
+
+# Augment with the internal version if present
+try:
+    from jnpr.junos.internal_version import INTERNAL_VERSION
+    VERSION += '+internal.' + str(INTERNAL_VERSION)
+except ImportError:
+    # No internal version
+    pass

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,6 +1,5 @@
 VERSION = "2.1.dev0"
-DATE = "2017-Mar-16"
-AUTHOR = "Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith"
+DATE = "2017-Mar-17"
 
 # Augment with the internal version if present
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 from setuptools import setup, find_packages
 import sys
-import os
-
-sys.path.insert(0, os.path.abspath('lib'))
-from jnpr.junos import version
 
 # parse requirements
 req_lines = [line.strip() for line in open(
@@ -15,8 +11,8 @@ if sys.version_info[:2] == (2, 6):
 setup(
     name="junos-eznc",
     namespace_packages=['jnpr'],
-    version=version.VERSION,
-    author=version.AUTHOR,
+    version="2.1.dev0",
+    author="Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith",
     author_email="jnpr-community-netdev@juniper.net",
     description=("Junos 'EZ' automation for non-programmers"),
     license="Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 import sys
+import os
+
+sys.path.insert(0, os.path.abspath('lib'))
+from jnpr.junos import version
 
 # parse requirements
 req_lines = [line.strip() for line in open(
@@ -11,8 +15,8 @@ if sys.version_info[:2] == (2, 6):
 setup(
     name="junos-eznc",
     namespace_packages=['jnpr'],
-    version="2.0.2-dev",
-    author="Jeremy Schulman, Nitin Kumar",
+    version=version.VERSION,
+    author=version.AUTHOR,
     author_email="jnpr-community-netdev@juniper.net",
     description=("Junos 'EZ' automation for non-programmers"),
     license="Apache 2.0",


### PR DESCRIPTION
- Moving to version 2.1.dev0
- Adding support for internal version as a local version identifier
- Update jnpr.junos so it can be imported even if non-std libraries are not installed
- Update setup.py to pull version and author info from jnpr.junos.version.