### PR TITLE
Fix regressions caused by `ignore_warning`

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -20,6 +20,7 @@ from jnpr.junos.rpcmeta import _RpcMetaExec
 from jnpr.junos.factcache import _FactCache
 from jnpr.junos import jxml as JXML
 from jnpr.junos.ofacts import *
+from jnpr.junos.decorators import ignoreWarnDecorator
 
 QFX_MODEL_LIST = ['QFX3500', 'QFX3600', 'VIRTUAL CHASSIS']
 QFX_MODE_NODE = 'NODE'
@@ -214,6 +215,7 @@ class Console(_Connection):
                 raise err
             self.connected = False
 
+    @ignoreWarnDecorator
     def _rpc_reply(self, rpc_cmd_e):
         encode = None if sys.version < '3' else 'unicode'
         rpc_cmd = etree.tostring(rpc_cmd_e, encoding=encode) \

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -3,7 +3,9 @@ from functools import wraps
 import re
 import sys
 
-from jnpr.junos.exception import RpcError
+from lxml import etree
+from ncclient.operations.rpc import RPCError
+from ncclient.xml_ import NCElement
 from jnpr.junos import jxml as JXML
 
 
@@ -107,44 +109,65 @@ def ignoreWarnDecorator(function):
             complicated match conditions.
     """
     @wraps(function)
-    def wrapper(*args, **kwargs):
-        ignore_warn = kwargs.pop('ignore_warning', False)
-        if ignore_warn:
-            try:
-                result = function(*args, **kwargs)
-                return result
-            except RpcError as ex:
-                if hasattr(ex, 'errs'):
-                    for err in ex.errs:
-                        if err['severity'] == 'warning':
-                            if ((sys.version < '3' and
-                                 isinstance(ignore_warn, (str, unicode))) or
-                                (sys.version >= '3' and
-                                 isinstance(ignore_warn, str))):
-                                if not re.search(ignore_warn, err['message'],
-                                                 re.I):
-                                    # Message did not match.
-                                    raise ex
-                            elif isinstance(ignore_warn, list):
-                                for warn_msg in ignore_warn:
-                                    if re.search(warn_msg, err['message'],
-                                                 re.I):
-                                        # Warning matches. Break skips else.
-                                        break
-                                else:
-                                    # Message didn't match any of the
-                                    # ignore_warn pattern values.
-                                    raise ex
-                        else:
-                            # Not a warning (probably an error).
-                            raise ex
-                    # Every err was a warning that matched ignore_warn
-                    return ex.xml
-                else:
-                    # Safety net.
-                    # I can't think of a situation where this would occur.
-                    raise ex
-        else:
-            return function(*args, **kwargs)
+    def wrapper(self, *args, **kwargs):
+        ignore_warning = kwargs.pop('ignore_warning', False)
+        rsp = None
+        try:
+            rsp = function(self, *args, **kwargs)
+        except RPCError as ex:
+            if hasattr(ex, 'xml'):
+                if ignore_warning:
+                    if hasattr(ex, 'errors'):
+                        for err in ex.errors:
+                            if err.severity == 'warning':
+                                if ((sys.version < '3' and
+                                         isinstance(ignore_warning,
+                                                    (str, unicode))) or
+                                        (sys.version >= '3' and
+                                             isinstance(ignore_warning,
+                                                        str))):
+                                    if not re.search(ignore_warning,
+                                                     err.message,
+                                                     re.I):
+                                        # Message did not match.
+                                        raise ex
+                                elif isinstance(ignore_warning, list):
+                                    for warn_msg in ignore_warning:
+                                        if re.search(warn_msg,
+                                                     err.message,
+                                                     re.I):
+                                            # Warning matches.
+                                            # Break skips else.
+                                            break
+                                    else:
+                                        # Message didn't match any of the
+                                        # ignore_warn pattern values.
+                                        raise ex
+                            else:
+                                # Not a warning (probably an error).
+                                raise ex
+                        # Every err was a warning that matched ignore_warning.
+                        # Prepare the response which will get returned.
+                        # ex.xml contains the raw xml response which was
+                        # received.
+                        rsp = ex.xml
+                        # 1) A normal response has been run through the XSLT
+                        #    transformation, but ex.xml has not. Do that now.
+                        rsp = NCElement(etree.tostring(rsp),
+                                        self.transform())._NCElement__doc
+                        # 2) Now remove all of the <rpc-error> elements from
+                        #    the response. We've already confirmed they are
+                        #    all warnings
+                        rsp = etree.fromstring(
+                                  str(JXML.strip_rpc_error_transform(rsp)))
+                    else:
+                        # Safety net. I can't think of a situation
+                        # where this would occur.
+                        raise ex
+            else:
+                # An RPCError which doesn't have an XML attribute. Raise it
+                # up for the caller to deal with.
+                raise ex
+        return rsp
 
     return wrapper

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -120,11 +120,10 @@ def ignoreWarnDecorator(function):
                     for err in ex.errors:
                         if err.severity == 'warning':
                             if ((sys.version < '3' and
-                                     isinstance(ignore_warning,
-                                                (str, unicode))) or
-                                    (sys.version >= '3' and
-                                         isinstance(ignore_warning,
-                                                    str))):
+                               isinstance(ignore_warning,
+                                          (str, unicode))) or
+                               (sys.version >= '3' and
+                               isinstance(ignore_warning, str))):
                                 if not re.search(ignore_warning,
                                                  err.message,
                                                  re.I):

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -151,7 +151,8 @@ def ignoreWarnDecorator(function):
                     rsp = ex.xml
                     # 1) A normal response has been run through the XSLT
                     #    transformation, but ex.xml has not. Do that now.
-                    rsp = NCElement(etree.tostring(rsp),
+                    encode = None if sys.version < '3' else 'unicode'
+                    rsp = NCElement(etree.tostring(rsp, encoding=encode),
                                     self.transform())._NCElement__doc
                     # 2) Now remove all of the <rpc-error> elements from
                     #    the response. We've already confirmed they are

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -115,58 +115,58 @@ def ignoreWarnDecorator(function):
         try:
             rsp = function(self, *args, **kwargs)
         except RPCError as ex:
-            if hasattr(ex, 'xml'):
-                if ignore_warning:
-                    if hasattr(ex, 'errors'):
-                        for err in ex.errors:
-                            if err.severity == 'warning':
-                                if ((sys.version < '3' and
+            if hasattr(ex, 'xml') and ignore_warning:
+                if hasattr(ex, 'errors'):
+                    for err in ex.errors:
+                        if err.severity == 'warning':
+                            if ((sys.version < '3' and
+                                     isinstance(ignore_warning,
+                                                (str, unicode))) or
+                                    (sys.version >= '3' and
                                          isinstance(ignore_warning,
-                                                    (str, unicode))) or
-                                        (sys.version >= '3' and
-                                             isinstance(ignore_warning,
-                                                        str))):
-                                    if not re.search(ignore_warning,
-                                                     err.message,
-                                                     re.I):
-                                        # Message did not match.
-                                        raise ex
-                                elif isinstance(ignore_warning, list):
-                                    for warn_msg in ignore_warning:
-                                        if re.search(warn_msg,
-                                                     err.message,
-                                                     re.I):
-                                            # Warning matches.
-                                            # Break skips else.
-                                            break
-                                    else:
-                                        # Message didn't match any of the
-                                        # ignore_warn pattern values.
-                                        raise ex
-                            else:
-                                # Not a warning (probably an error).
-                                raise ex
-                        # Every err was a warning that matched ignore_warning.
-                        # Prepare the response which will get returned.
-                        # ex.xml contains the raw xml response which was
-                        # received.
-                        rsp = ex.xml
-                        # 1) A normal response has been run through the XSLT
-                        #    transformation, but ex.xml has not. Do that now.
-                        rsp = NCElement(etree.tostring(rsp),
-                                        self.transform())._NCElement__doc
-                        # 2) Now remove all of the <rpc-error> elements from
-                        #    the response. We've already confirmed they are
-                        #    all warnings
-                        rsp = etree.fromstring(
-                                  str(JXML.strip_rpc_error_transform(rsp)))
-                    else:
-                        # Safety net. I can't think of a situation
-                        # where this would occur.
-                        raise ex
+                                                    str))):
+                                if not re.search(ignore_warning,
+                                                 err.message,
+                                                 re.I):
+                                    # Message did not match.
+                                    raise ex
+                            elif isinstance(ignore_warning, list):
+                                for warn_msg in ignore_warning:
+                                    if re.search(warn_msg,
+                                                 err.message,
+                                                 re.I):
+                                        # Warning matches.
+                                        # Break skips else.
+                                        break
+                                else:
+                                    # Message didn't match any of the
+                                    # ignore_warn pattern values.
+                                    raise ex
+                        else:
+                            # Not a warning (probably an error).
+                            raise ex
+                    # Every err was a warning that matched ignore_warning.
+                    # Prepare the response which will get returned.
+                    # ex.xml contains the raw xml response which was
+                    # received.
+                    rsp = ex.xml
+                    # 1) A normal response has been run through the XSLT
+                    #    transformation, but ex.xml has not. Do that now.
+                    rsp = NCElement(etree.tostring(rsp),
+                                    self.transform())._NCElement__doc
+                    # 2) Now remove all of the <rpc-error> elements from
+                    #    the response. We've already confirmed they are
+                    #    all warnings
+                    rsp = etree.fromstring(
+                              str(JXML.strip_rpc_error_transform(rsp)))
+                else:
+                    # Safety net. ex doesn't have an errors attribute.
+                    # I can't think of a situation where this would
+                    # actually occur.
+                    raise ex
             else:
-                # An RPCError which doesn't have an XML attribute. Raise it
-                # up for the caller to deal with.
+                # ignore_warning was false, or an RPCError which doesn't have
+                #  an XML attribute. Raise it up for the caller to deal with.
                 raise ex
         return rsp
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -715,7 +715,7 @@ class _Connection(object):
             raise EzErrors.ConnectClosedError(self)
         except RPCError as ex:
             if hasattr(ex, 'xml'):
-                rsp = ex.xml
+                rsp = JXML.remove_namespaces(ex.xml)
                 message = rsp.findtext('error-message')
                 # see if this is a permission error
                 if message and message == 'permission denied':

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -641,18 +641,11 @@ class _Connection(object):
           <rpc> element itself
 
         :param ignore_warning: A boolean, string or list of string.
-          If the value is True, it will ignore all warnings regarldess of the
+          If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore
           warning(s) if the message of each warning matches the string. If
           the value is a list of strings, ignore warning(s) if the message of
           each warning matches at least one of the strings in the list.
-
-          For example::
-            dev.rpc.get(ignore_warning=True)
-            dev.rpc.get(ignore_warning='vrrp subsystem not running')
-            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
-                                        'statement not found'])
-            cu.load(cnf, ignore_warning='statement not found')
 
           .. note::
             When the value of ignore_warning is a string, or list of strings,

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -63,7 +63,6 @@ class RpcError(Exception):
             if self.errs is None or not isinstance(self.errs, list):
                 self.errs = [self.rpc_error]
 
-
     def __repr__(self):
         """
           pprints the response XML attribute

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -33,9 +33,7 @@ class RpcError(Exception):
         self.timeout = timeout
         self.re = re
         self.rpc_error = None
-        xml = None
-        if isinstance(rsp, _Element):
-            xml = JXML.remove_namespaces(rsp)
+        self.xml = rsp
         # To handle errors coming from ncclient, Here errs is list of RPCError
         if isinstance(errs, RPCError) and hasattr(errs, 'errors'):
             self.errs = [JXML.rpc_error(error.xml) for error in errs.errors]
@@ -50,10 +48,6 @@ class RpcError(Exception):
                             self.rsp = JXML.remove_namespaces(error.xml)
                             break
             self.message = errs.message
-            if (xml is None and
-               hasattr(errs, 'xml') and
-               isinstance(errs.xml, _Element)):
-                xml = JXML.remove_namespaces(errs.xml)
         else:
             self.errs = errs
             self.message = "\n".join(["%s: %s" % (err['severity'].strip(),
@@ -68,18 +62,7 @@ class RpcError(Exception):
             self.message = self.message or self.rpc_error['message']
             if self.errs is None or not isinstance(self.errs, list):
                 self.errs = [self.rpc_error]
-        if isinstance(xml, _Element) and xml.tag == 'rpc-reply':
-            for child in xml.findall('*'):
-                if child.tag != 'rpc-error':
-                    self.xml = child
-                    break
-            else:
-                if xml.text is not None and xml.text.strip() is not '':
-                    self.xml = xml
-                # no non rpc-error children
-                self.xml = True
-        else:
-            self.xml = xml
+
 
     def __repr__(self):
         """

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -151,6 +151,7 @@ strip_rpc_error_xslt = '''
 strip_rpc_error_root = etree.XML(strip_rpc_error_xslt)
 strip_rpc_error_transform = etree.XSLT(strip_rpc_error_root)
 
+
 def remove_namespaces(xml):
     for elem in xml.getiterator():
         if elem.tag is etree.Comment:

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -131,6 +131,25 @@ strip_comments_xslt = '''\
 strip_xslt_root = etree.XML(strip_comments_xslt)
 strip_comments_transform = etree.XSLT(strip_xslt_root)
 
+# XSLT to strip <rpc-error> elements
+strip_rpc_error_xslt = '''
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+    <xsl:template match="node()|@*">
+      <xsl:copy>
+         <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="rpc-error"/>
+</xsl:stylesheet>
+'''
+
+strip_rpc_error_root = etree.XML(strip_rpc_error_xslt)
+strip_rpc_error_transform = etree.XSLT(strip_rpc_error_root)
 
 def remove_namespaces(xml):
     for elem in xml.getiterator():

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -147,7 +147,7 @@ class _RpcMetaExec(object):
     # get
     # -----------------------------------------------------------------------
 
-    def get(self, filter_select=None, **kwargs):
+    def get(self, filter_select=None, ignore_warning=False, **kwargs):
         """
         Retrieve running configuration and device state information using
         <get> rpc
@@ -166,6 +166,29 @@ class _RpcMetaExec(object):
           The select attribute will be treated as an XPath expression and
           used to filter the returned data.
 
+        :param ignore_warning: A boolean, string or list of string.
+          If the value is True, it will ignore all warnings regarldess of the
+          warning message. If the value is a string, it will ignore
+          warning(s) if the message of each warning matches the string. If
+          the value is a list of strings, ignore warning(s) if the message of
+          each warning matches at least one of the strings in the list.
+
+          For example::
+            dev.rpc.get(ignore_warning=True)
+            dev.rpc.get(ignore_warning='vrrp subsystem not running')
+            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
+                                        'statement not found'])
+            cu.load(cnf, ignore_warning='statement not found')
+
+          .. note::
+            When the value of ignore_warning is a string, or list of strings,
+            the string is actually used as a case-insensitive regular
+            expression pattern. If the string contains only alpha-numeric
+            characters, as shown in the above examples, this results in a
+            case-insensitive substring match. However, any regular expression
+            pattern supported by the re library may be used for more
+            complicated match conditions.
+
         :returns: xml object
         """
         # junos only support filter type to be xpath
@@ -173,7 +196,9 @@ class _RpcMetaExec(object):
         if filter_select is not None:
             filter_params['source'] = filter_select
         rpc = E('get', E('filter', filter_params))
-        return self._junos.execute(rpc, **kwargs)
+        return self._junos.execute(rpc,
+                                   ignore_warning=ignore_warning,
+                                   **kwargs)
 
     # -----------------------------------------------------------------------
     # load_config
@@ -182,6 +207,29 @@ class _RpcMetaExec(object):
     def load_config(self, contents, ignore_warning=False, **options):
         """
         loads :contents: onto the Junos device, does not commit the change.
+
+        :param ignore_warning: A boolean, string or list of string.
+          If the value is True, it will ignore all warnings regarldess of the
+          warning message. If the value is a string, it will ignore
+          warning(s) if the message of each warning matches the string. If
+          the value is a list of strings, ignore warning(s) if the message of
+          each warning matches at least one of the strings in the list.
+
+          For example::
+            dev.rpc.get(ignore_warning=True)
+            dev.rpc.get(ignore_warning='vrrp subsystem not running')
+            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
+                                        'statement not found'])
+            cu.load(cnf, ignore_warning='statement not found')
+
+          .. note::
+            When the value of ignore_warning is a string, or list of strings,
+            the string is actually used as a case-insensitive regular
+            expression pattern. If the string contains only alpha-numeric
+            characters, as shown in the above examples, this results in a
+            case-insensitive substring match. However, any regular expression
+            pattern supported by the re library may be used for more
+            complicated match conditions.
 
         :options: is a dictionary of XML attributes to set within the
                   <load-configuration> RPC.

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -167,7 +167,7 @@ class _RpcMetaExec(object):
           used to filter the returned data.
 
         :param ignore_warning: A boolean, string or list of string.
-          If the value is True, it will ignore all warnings regarldess of the
+          If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore
           warning(s) if the message of each warning matches the string. If
           the value is a list of strings, ignore warning(s) if the message of
@@ -178,7 +178,6 @@ class _RpcMetaExec(object):
             dev.rpc.get(ignore_warning='vrrp subsystem not running')
             dev.rpc.get(ignore_warning=['vrrp subsystem not running',
                                         'statement not found'])
-            cu.load(cnf, ignore_warning='statement not found')
 
           .. note::
             When the value of ignore_warning is a string, or list of strings,
@@ -209,18 +208,20 @@ class _RpcMetaExec(object):
         loads :contents: onto the Junos device, does not commit the change.
 
         :param ignore_warning: A boolean, string or list of string.
-          If the value is True, it will ignore all warnings regarldess of the
+          If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore
           warning(s) if the message of each warning matches the string. If
           the value is a list of strings, ignore warning(s) if the message of
           each warning matches at least one of the strings in the list.
 
           For example::
-            dev.rpc.get(ignore_warning=True)
-            dev.rpc.get(ignore_warning='vrrp subsystem not running')
-            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
-                                        'statement not found'])
-            cu.load(cnf, ignore_warning='statement not found')
+            dev.rpc.load_config(cnf, ignore_warning=True)
+            dev.rpc.load_config(cnf,
+                                ignore_warning='vrrp subsystem not running')
+            dev.rpc.load_config(cnf,
+                                ignore_warning=['vrrp subsystem not running',
+                                                'statement not found'])
+            dev.rpc.load_config(cnf, ignore_warning='statement not found')
 
           .. note::
             When the value of ignore_warning is a string, or list of strings,

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -179,7 +179,7 @@ class _RpcMetaExec(object):
     # load_config
     # -----------------------------------------------------------------------
 
-    def load_config(self, contents, **options):
+    def load_config(self, contents, ignore_warning=False, **options):
         """
         loads :contents: onto the Junos device, does not commit the change.
 
@@ -214,7 +214,7 @@ class _RpcMetaExec(object):
             else:
                 rpc.append(contents)
 
-        return self._junos.execute(rpc)
+        return self._junos.execute(rpc, ignore_warning=ignore_warning)
 
     # -----------------------------------------------------------------------
     # cli

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -61,6 +61,28 @@ class Config(Util):
                             evaluate the new configuration.
         :param bool detail: When true return commit detail as XML
 
+        :param ignore_warning: A boolean, string or list of string.
+          If the value is True, it will ignore all warnings regarldess of the
+          warning message. If the value is a string, it will ignore
+          warning(s) if the message of each warning matches the string. If
+          the value is a list of strings, ignore warning(s) if the message of
+          each warning matches at least one of the strings in the list.
+
+          For example::
+            dev.rpc.get(ignore_warning=True)
+            dev.rpc.get(ignore_warning='vrrp subsystem not running')
+            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
+                                        'statement not found'])
+            cu.load(cnf, ignore_warning='statement not found')
+
+          .. note::
+            When the value of ignore_warning is a string, or list of strings,
+            the string is actually used as a case-insensitive regular
+            expression pattern. If the string contains only alpha-numeric
+            characters, as shown in the above examples, this results in a
+            case-insensitive substring match. However, any regular expression
+            pattern supported by the re library may be used for more
+            complicated match conditions.
 
         :returns:
             * ``True`` when successful
@@ -304,6 +326,29 @@ class Config(Util):
         :param dict template_vars:
           Used in conjunction with the other template options.  This parameter
           contains a dictionary of variables to render into the template.
+          
+        :param ignore_warning: A boolean, string or list of string.
+          If the value is True, it will ignore all warnings regarldess of the
+          warning message. If the value is a string, it will ignore
+          warning(s) if the message of each warning matches the string. If
+          the value is a list of strings, ignore warning(s) if the message of
+          each warning matches at least one of the strings in the list.
+
+          For example::
+            dev.rpc.get(ignore_warning=True)
+            dev.rpc.get(ignore_warning='vrrp subsystem not running')
+            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
+                                        'statement not found'])
+            cu.load(cnf, ignore_warning='statement not found')
+
+          .. note::
+            When the value of ignore_warning is a string, or list of strings,
+            the string is actually used as a case-insensitive regular
+            expression pattern. If the string contains only alpha-numeric
+            characters, as shown in the above examples, this results in a
+            case-insensitive substring match. However, any regular expression
+            pattern supported by the re library may be used for more
+            complicated match conditions.
 
         :returns:
             RPC-reply as XML object.

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -62,18 +62,20 @@ class Config(Util):
         :param bool detail: When true return commit detail as XML
 
         :param ignore_warning: A boolean, string or list of string.
-          If the value is True, it will ignore all warnings regarldess of the
+          If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore
           warning(s) if the message of each warning matches the string. If
           the value is a list of strings, ignore warning(s) if the message of
           each warning matches at least one of the strings in the list.
 
           For example::
-            dev.rpc.get(ignore_warning=True)
-            dev.rpc.get(ignore_warning='vrrp subsystem not running')
-            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
-                                        'statement not found'])
-            cu.load(cnf, ignore_warning='statement not found')
+            cu.commit(ignore_warning=True)
+            cu.commit(ignore_warning='Advertisement-interval is '
+                                     'less than four times')
+            cu.commit(ignore_warning=['Advertisement-interval is '
+                                      'less than four times',
+                                      'Chassis configuration for network '
+                                      'services has been changed.'])
 
           .. note::
             When the value of ignore_warning is a string, or list of strings,
@@ -328,18 +330,17 @@ class Config(Util):
           contains a dictionary of variables to render into the template.
           
         :param ignore_warning: A boolean, string or list of string.
-          If the value is True, it will ignore all warnings regarldess of the
+          If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore
           warning(s) if the message of each warning matches the string. If
           the value is a list of strings, ignore warning(s) if the message of
           each warning matches at least one of the strings in the list.
 
           For example::
-            dev.rpc.get(ignore_warning=True)
-            dev.rpc.get(ignore_warning='vrrp subsystem not running')
-            dev.rpc.get(ignore_warning=['vrrp subsystem not running',
-                                        'statement not found'])
+            cu.load(cnf, ignore_warning=True)
             cu.load(cnf, ignore_warning='statement not found')
+            cu.load(cnf, ignore_warning=['statement not found',
+                                         'statement has no contents; ignored')
 
           .. note::
             When the value of ignore_warning is a string, or list of strings,

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.1.0"
-DATE = "2017-Mar-22"
+VERSION = "2.1.1dev0"
+DATE = "2017-Mar-27"
 
 # Augment with the internal version if present
 try:

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -774,7 +774,6 @@ class TestDevice(unittest.TestCase):
             device_handler = make_device_handler(device_params)
             session = SSHSession(device_handler)
             return Manager(session, device_handler)
-
         elif args:
             if args[0].tag == 'command':
                 if args[0].text == 'show cli directory':


### PR DESCRIPTION
In some circumstances, the implementation of the `ignore_warning` decorator didn't return the same value that would have been returned prior to the `ignore_warning` implementation. Once of those circumstances was when a `CommitError` was raised. The content of the `CommitError` was incorrectly empty.
