### PR TITLE
doc badge was pointing to older version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![PyPi Version](https://img.shields.io/pypi/v/junos-eznc.svg)](https://pypi.python.org/pypi/junos-eznc/) [![Documentation Status](https://readthedocs.org/projects/junos-pyez/badge/?version=2.0.1)](http://junos-pyez.readthedocs.io/en/2.0.1/?badge=2.0.1) [![Coverage Status](https://img.shields.io/coveralls/Juniper/py-junos-eznc.svg)](https://coveralls.io/r/Juniper/py-junos-eznc) [![Coverage Status](https://travis-ci.org/Juniper/py-junos-eznc.svg?branch=master)](https://travis-ci.org/Juniper/py-junos-eznc) [![](https://images.microbadger.com/badges/image/juniper/pyez.svg)](https://microbadger.com/images/juniper/pyez)
+[![PyPi Version](https://img.shields.io/pypi/v/junos-eznc.svg)](https://pypi.python.org/pypi/junos-eznc/)
+[![Documentation Status](https://readthedocs.org/projects/junos-pyez/badge/?version=latest)](http://junos-pyez.readthedocs.io)
+[![Coverage Status](https://img.shields.io/coveralls/Juniper/py-junos-eznc.svg)](https://coveralls.io/r/Juniper/py-junos-eznc)
+[![UnitTest Status](https://travis-ci.org/Juniper/py-junos-eznc.svg?branch=master)](https://travis-ci.org/Juniper/py-junos-eznc)
+[![](https://images.microbadger.com/badges/image/juniper/pyez.svg)](https://microbadger.com/images/juniper/pyez)
 
 The repo is under active development.  If you take a clone, you are getting the latest, and perhaps not entirely stable code.  
 


### PR DESCRIPTION
Removed version numbers from 
```
(https://readthedocs.org/projects/junos-pyez/badge/?version=2.0.1)](http://junos-pyez.readthedocs.io/en/2.0.1/?badge=2.0.1)
```