### PR TITLE
SW() updates for new fact gathering. Fix Juniper/ansible-junos-stdlib#222

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -62,7 +62,10 @@ class SW(Util):
         self._RE_list = []
         if 'junos_info' in dev.facts and dev.facts['junos_info'] is not None:
             self._RE_list = list(dev.facts['junos_info'].keys())
-        self._multi_RE = bool(dev.facts['2RE'])
+        else:
+            self._RE_list = [x for x in dev.facts.keys()
+                             if x.startswith('version_RE')]
+        self._multi_RE = bool(dev.facts.get('2RE'))
         self._multi_VC = bool(
             self._multi_RE is True and dev.facts.get('vc_capable') is True and
             dev.facts.get('vc_mode') != 'Disabled')

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -60,7 +60,7 @@ class SW(Util):
         Util.__init__(self, dev)
         self._dev = dev
         self._RE_list = []
-        if dev.facts['junos_info'] is not None:
+        if 'junos_info' in dev.facts and dev.facts['junos_info'] is not None:
             self._RE_list = list(dev.facts['junos_info'].keys())
         self._multi_RE = bool(dev.facts['2RE'])
         self._multi_VC = bool(

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -59,9 +59,10 @@ class SW(Util):
     def __init__(self, dev):
         Util.__init__(self, dev)
         self._dev = dev
-        self._RE_list = [
-            x for x in dev.facts.keys() if x.startswith('version_RE')]
-        self._multi_RE = bool(len(self._RE_list) > 1)
+        self._RE_list = []
+        if dev.facts['junos_info'] is not None:
+            self._RE_list = list(dev.facts['junos_info'].keys())
+        self._multi_RE = bool(dev.facts['2RE'])
         self._multi_VC = bool(
             self._multi_RE is True and dev.facts.get('vc_capable') is True and
             dev.facts.get('vc_mode') != 'Disabled')

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -30,6 +30,8 @@ facts = {'domain': None, 'hostname': 'firefly', 'ifd_style': 'CLASSIC',
          'version_RE0': '16.1-20160925.0',
          'version_RE1': '16.1-20160925.0',
          'model': 'FIREFLY-PERIMETER',
+         'junos_info': {'re0': {'text': '16.1-20160925.0'},
+                        're1': {'text': '16.1-20160925.0'}},
          'RE0': {'status': 'Testing',
                  'last_reboot_reason': 'Router rebooted after a '
                  'normal shutdown.',


### PR DESCRIPTION

The SW class previously depended upon the existence of version_REx fact keys.
With enhanced fact gathering, these keys always exist, and are not a sign that
the device actually has multiple REs.