### PR TITLE
raise JSONLoadError if json config is malformed

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -30,6 +30,7 @@ from jnpr.junos.ofacts import *
 from jnpr.junos import jxml as JXML
 from jnpr.junos.decorators import timeoutDecorator, normalizeDecorator, \
     ignoreWarnDecorator
+from jnpr.junos.exception import JSONLoadError
 
 
 _MODULEPATH = os.path.dirname(__file__)
@@ -740,6 +741,8 @@ class _Connection(object):
                     if str(ex).startswith('Extra data'):
                         return json.loads(
                             re.sub('\s?{\s?}\s?', '', rpc_rsp_e.text))
+                    else:
+                        raise JSONLoadError(ex, rpc_rsp_e.text)
             else:
                 warnings.warn("Native JSON support is only from 14.2 onwards",
                               RuntimeWarning)

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -1,3 +1,4 @@
+import re
 from jnpr.junos import jxml
 from jnpr.junos import jxml as JXML
 from lxml.etree import _Element
@@ -297,3 +298,26 @@ class ConnectClosedError(ConnectError):
     def __init__(self, dev):
         ConnectError.__init__(self, dev=dev)
         dev.connected = False
+
+
+class JSONLoadError(Exception):
+
+    """
+    Generated if json content of rpc reply fails to load
+    """
+    def __init__(self, exception, rpc_content):
+        self.ex_msg = str(exception)
+        self.rpc_content = rpc_content
+        self.offending_line = ''
+        obj = re.search('line (\d+)', self.ex_msg)
+        if obj:
+            line_no = int(obj.group(1))
+            self.offending_line = rpc_content.splitlines()[line_no-1]
+
+    def __repr__(self):
+        return "{0}(reason: {1}, \nThe offending config appears to be: \n{2}" \
+                .format(self.__class__.__name__, self.ex_msg,
+                        self.offending_line)
+
+    __str__ = __repr__
+

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -312,7 +312,9 @@ class JSONLoadError(Exception):
         obj = re.search('line (\d+)', self.ex_msg)
         if obj:
             line_no = int(obj.group(1))
-            self.offending_line = rpc_content.splitlines()[line_no-1]
+            rpc_lines = rpc_content.splitlines()
+            for line in range(line_no-3, line_no+2):
+                self.offending_line += '%s: %s\n' % (line+1, rpc_lines[line])
 
     def __repr__(self):
         return "{0}(reason: {1}, \nThe offending config appears to be: \n{2}" \

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -317,9 +317,13 @@ class JSONLoadError(Exception):
                 self.offending_line += '%s: %s\n' % (line+1, rpc_lines[line])
 
     def __repr__(self):
-        return "{0}(reason: {1}, \nThe offending config appears to be: \n{2}" \
+        if self.offending_line:
+            return "{0}(reason: {1}, \nThe offending config appears to be: \n{2})" \
                 .format(self.__class__.__name__, self.ex_msg,
                         self.offending_line)
+        else:
+            return "{0}(reason: {1})" \
+                .format(self.__class__.__name__, self.ex_msg)
 
     __str__ = __repr__
 

--- a/tests/unit/rpc-reply/get-configuration.json
+++ b/tests/unit/rpc-reply/get-configuration.json
@@ -1,0 +1,32 @@
+<rpc-reply>
+{
+    "configuration" : {
+        "@" : {
+            "junos:changed-seconds" : "1492754952", 
+            "junos:changed-localtime" : "2017-04-21 11:39:12 IST"
+        }, 
+        "system" : {
+            "services" : {
+                "netconf" : {
+                    "ssh" : {
+                        "port" : 830
+                    }, 
+                    "traceoptions" : {
+                        "file" : {
+                            "filename" : "netconf-ops.log", 
+                            "size" : 3m, 
+                            "files" : 20, 
+                            "world-readable" : [null]
+                        }, 
+                        "flag" : [
+                        {
+                            "name" : "all"
+                        }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+</rpc-reply>


### PR DESCRIPTION
Handle error case for https://github.com/Juniper/py-junos-eznc/issues/701

exception would look like

```python
jnpr.junos.exception.JSONLoadError: JSONLoadError(reason: Expecting , delimiter: line 461 column 39 (char 16862), 
The offending config appears to be: 
459:                         "file" : {
460:                             "filename" : "netconf-ops.log", 
461:                             "size" : 3m, 
462:                             "files" : 20, 
463:                             "world-readable" : [null]
```