### PR TITLE
ignore_warning fails when single <rpc-error> that is first child of <rpc-reply>.

### DIFF
--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -117,53 +117,52 @@ def ignoreWarnDecorator(function):
         except RPCError as ex:
             if hasattr(ex, 'xml') and ignore_warning:
                 if hasattr(ex, 'errors'):
-                    for err in ex.errors:
-                        if err.severity == 'warning':
-                            if ((sys.version < '3' and
-                               isinstance(ignore_warning,
-                                          (str, unicode))) or
-                               (sys.version >= '3' and
-                               isinstance(ignore_warning, str))):
-                                if not re.search(ignore_warning,
-                                                 err.message,
-                                                 re.I):
-                                    # Message did not match.
-                                    raise ex
-                            elif isinstance(ignore_warning, list):
-                                for warn_msg in ignore_warning:
-                                    if re.search(warn_msg,
-                                                 err.message,
-                                                 re.I):
-                                        # Warning matches.
-                                        # Break skips else.
-                                        break
-                                else:
-                                    # Message didn't match any of the
-                                    # ignore_warn pattern values.
-                                    raise ex
-                        else:
-                            # Not a warning (probably an error).
-                            raise ex
-                    # Every err was a warning that matched ignore_warning.
-                    # Prepare the response which will get returned.
-                    # ex.xml contains the raw xml response which was
-                    # received.
-                    rsp = ex.xml
-                    # 1) A normal response has been run through the XSLT
-                    #    transformation, but ex.xml has not. Do that now.
-                    encode = None if sys.version < '3' else 'unicode'
-                    rsp = NCElement(etree.tostring(rsp, encoding=encode),
-                                    self.transform())._NCElement__doc
-                    # 2) Now remove all of the <rpc-error> elements from
-                    #    the response. We've already confirmed they are
-                    #    all warnings
-                    rsp = etree.fromstring(
-                              str(JXML.strip_rpc_error_transform(rsp)))
+                    errors = ex.errors
                 else:
-                    # Safety net. ex doesn't have an errors attribute.
-                    # I can't think of a situation where this would
-                    # actually occur.
-                    raise ex
+                    errors = [ex]
+                for err in errors:
+                    if err.severity == 'warning':
+                        if ((sys.version < '3' and
+                           isinstance(ignore_warning,
+                                      (str, unicode))) or
+                           (sys.version >= '3' and
+                           isinstance(ignore_warning, str))):
+                            if not re.search(ignore_warning,
+                                             err.message,
+                                             re.I):
+                                # Message did not match.
+                                raise ex
+                        elif isinstance(ignore_warning, list):
+                            for warn_msg in ignore_warning:
+                                if re.search(warn_msg,
+                                             err.message,
+                                             re.I):
+                                    # Warning matches.
+                                    # Break skips else.
+                                    break
+                            else:
+                                # Message didn't match any of the
+                                # ignore_warn pattern values.
+                                raise ex
+                    else:
+                        # Not a warning (probably an error).
+                        raise ex
+                # Every err was a warning that matched ignore_warning.
+                # Prepare the response which will get returned.
+                # ex.xml contains the raw xml response which was
+                # received, but might be rooted at an <rpc-error> element.
+                # Set rsp to the root <rpc-reply> element.
+                rsp = ex.xml.getroottree().getroot()
+                # 1) A normal response has been run through the XSLT
+                #    transformation, but ex.xml has not. Do that now.
+                encode = None if sys.version < '3' else 'unicode'
+                rsp = NCElement(etree.tostring(rsp, encoding=encode),
+                                self.transform())._NCElement__doc
+                # 2) Now remove all of the <rpc-error> elements from
+                #    the response. We've already confirmed they are
+                #    all warnings
+                rsp = etree.fromstring(
+                          str(JXML.strip_rpc_error_transform(rsp)))
             else:
                 # ignore_warning was false, or an RPCError which doesn't have
                 #  an XML attribute. Raise it up for the caller to deal with.


### PR DESCRIPTION
The implementation of the ignore_warning decorator failed when there was
a single warning `<rpc-error>` element that was the first child of the
`<rpc-reply>` element, such as this example:
```
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/16.1R4/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:65b27597-c62d-4e8b-ba85-1ca000646a9e">
    <load-configuration-results>
        <rpc-error>
            <error-severity>warning</error-severity>
            <error-path>[edit]</error-path>
            <error-message>statement not found: system</error-message>
        </rpc-error>
        <ok/>
    </load-configuration-results>
</rpc-reply>
```
