### PR TITLE
mode='telnet' did not logout non-cli user

### DIFF
--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -50,7 +50,7 @@ class Terminal(object):
         _re_pat_login,
         '(?P<passwd>assword:\s*$)',
         '(?P<badpasswd>ogin incorrect)',
-        '(?P<already_closed>session end at .*\n%)',
+        '(?P<netconf_closed>\<\!\-\- session end at .*\-\-\>\s*)',
         '(?P<shell>%|#\s*$)',
         '(?P<cli>[^\\-"]>\s*$)',
         '(?P<option>Enter your option:\s*$)',
@@ -145,14 +145,14 @@ class Terminal(object):
             self.write('exit')
 
         # Connection closed by foreign host
-        def _ev_already_closed():
+        def _ev_netconf_closed():
             return True
 
         _ev_tbl = {
             'login': _ev_login,
             'shell': _ev_shell,
             'cli': _ev_cli,
-            'already_closed': _ev_already_closed
+            'netconf_closed': _ev_netconf_closed
         }
 
         # hack for now
@@ -164,12 +164,12 @@ class Terminal(object):
         else:
             return True
 
-        if found == 'login' or found == 'already_closed':
+        if found == 'login':
             return True
 
         else:
             sleep(1)
-            self._logout_state_machine(attempt=attempt + 1)
+            return self._logout_state_machine(attempt=attempt + 1)
 
     # -----------------------------------------------------------------------
     # TTY login state-machine

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -50,7 +50,7 @@ class Terminal(object):
         _re_pat_login,
         '(?P<passwd>assword:\s*$)',
         '(?P<badpasswd>ogin incorrect)',
-        '(?P<netconf_closed>\<\!\-\- session end at .*\-\-\>\s*)',
+        '(?P<netconf_closed><!-- session end at .*-->\s*)',
         '(?P<shell>%|#\s*$)',
         '(?P<cli>[^\\-"]>\s*$)',
         '(?P<option>Enter your option:\s*$)',

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -215,12 +215,14 @@ class TestConsole(unittest.TestCase):
                                           'switch_style': 'NONE',
                                           'personality': 'UNKNOWN'})
 
+    @patch('jnpr.junos.transport.tty.sleep')
     @patch('ncclient.operations.rpc.RPCReply.parse')
     @patch('jnpr.junos.transport.tty_telnet.telnetlib.Telnet.write')
     @patch('jnpr.junos.transport.tty_netconf.select.select')
     @patch('jnpr.junos.transport.tty_telnet.telnetlib.Telnet.read_until')
     def test_load_console(
-            self, mock_read_until, mock_select, mock_write, mock_parse):
+            self, mock_read_until, mock_select, mock_write, mock_parse,
+            mock_sleep):
         mock_select.return_value = ([self.dev._tty._rx], [], [])
         xml = """<policy-options>
                   <policy-statement>

--- a/tests/unit/transport/test_tty.py
+++ b/tests/unit/transport/test_tty.py
@@ -31,7 +31,8 @@ class TestTTY(unittest.TestCase):
         self.assertRaises(EzErrors.ConnectAuthError,
                           self.terminal._login_state_machine)
 
-    def test_tty_no_login(self):
+    @patch('jnpr.junos.transport.tty.sleep')
+    def test_tty_no_login(self, mock_sleep):
         self.terminal._badpasswd = 4
         self.terminal.read_prompt = MagicMock()
         self.terminal.read_prompt.return_value = (None, 'testing')
@@ -66,7 +67,8 @@ class TestTTY(unittest.TestCase):
         self.terminal._login_state_machine()
         self.assertEqual(self.terminal.state, 4)
 
-    def test_ev_option(self):
+    @patch('jnpr.junos.transport.tty.sleep')
+    def test_ev_option(self, mock_sleep):
         self.terminal.write = MagicMock()
         self.terminal.read_prompt = MagicMock()
         self.terminal.read_prompt.return_value = (None, 'option')
@@ -74,13 +76,18 @@ class TestTTY(unittest.TestCase):
         self.terminal.write.assert_called_with("1")
         self.assertEqual(self.terminal.state, 7)
 
-    def test_tty_ev_already_closed(self):
+    @patch('jnpr.junos.transport.tty.sleep')
+    def test_tty_ev_netconf_closed(self, mock_sleep):
         self.terminal.write = MagicMock()
+        self.terminal._tty_close = MagicMock()
         self.terminal.read_prompt = MagicMock()
-        self.terminal.read_prompt.return_value = (None, 'already_closed')
+        self.terminal.read_prompt.side_effect = iter([(None, 'netconf_closed'),
+                                                      (None, 'shell'),
+                                                      (None, 'login')])
         self.assertTrue(self.terminal._logout_state_machine())
 
-    def test_tty_already_logout(self):
+    @patch('jnpr.junos.transport.tty.sleep')
+    def test_tty_already_logout(self, mock_sleep):
         self.terminal.write = MagicMock()
         self.terminal.read_prompt = MagicMock()
         self.terminal.read_prompt.return_value = (None, None)


### PR DESCRIPTION
When connecting to the device via console server with mode='telnet',
if the login user was configured to log into the shell, like the root
user, then the session was not logged out completely upon close.