### PR TITLE
Return None when the RPC equiv is either str or unicode

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -542,7 +542,7 @@ class _Connection(object):
         command = command.strip()
         # Get the equivalent RPC
         rpc = self.display_xml_rpc(command)
-        if isinstance(rpc, str):
+        if isinstance(rpc, basestring):
             # No RPC is available.
             return None
         rpc_string = "rpc.%s(" % (rpc.tag.replace('-', '_'))

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1,5 +1,6 @@
 # stdlib
 import os
+import six
 import types
 import platform
 import warnings
@@ -542,7 +543,7 @@ class _Connection(object):
         command = command.strip()
         # Get the equivalent RPC
         rpc = self.display_xml_rpc(command)
-        if isinstance(rpc, basestring):
+        if isinstance(rpc, six.string_types):
             # No RPC is available.
             return None
         rpc_string = "rpc.%s(" % (rpc.tag.replace('-', '_'))


### PR DESCRIPTION
Currently it checks against str, and it borks when the command
is sent as unicode. An example of issue is under
https://github.com/napalm-automation/napalm-junos/issues/152.
To make sure it works with both, we need to check against
the base string class.