### PR TITLE
Handle differences in |display xml rpc

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -367,7 +367,8 @@ class _Connection(object):
         """
         try:
             command = command + '| display xml rpc'
-            rsp = self.rpc.cli(command)
+            rsp = self.rpc.cli(command, format="xml")
+            rsp = rsp.getparent().find('.//rpc')
             if format == 'text':
                 encode = None if sys.version < '3' else 'unicode'
                 return etree.tostring(rsp[0], encoding=encode)

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.1.3.dev2"
-DATE = "2017-May-16"
+VERSION = "2.1.3.dev3"
+DATE = "2017-May-23"
 
 # Augment with the internal version if present
 try:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:2] == (2, 6):
 setup(
     name="junos-eznc",
     namespace_packages=['jnpr'],
-    version="2.1.3.dev2",
+    version="2.1.3.dev3",
     author="Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith",
     author_email="jnpr-community-netdev@juniper.net",
     description=("Junos 'EZ' automation for non-programmers"),


### PR DESCRIPTION
On some devices, dev.rpc.cli() the use of `| display xml rpc` requires the explicit setting of `format="xml"`. In addition, on some devices, the response may not be wrapped in `<rpc-reply>` tags. This change handles both of those issues while remaining backwards compatible.