### PR TITLE
Explicitly initialize jnpr.junos.facts sub-modules. Addresses #723

### DIFF
--- a/lib/jnpr/junos/facts/__example.py
+++ b/lib/jnpr/junos/facts/__example.py
@@ -13,6 +13,9 @@ from jnpr.junos.exception import RpcError
 # file. This avoids accidentally invoking the same RPC multiple times when we
 # could invoke it just once and gather multiple facts from the output.
 
+# An import for each fact file must be present in
+# lib/jnpr/junos/facts/__init__.py
+
 # The file must include a provide_facts() function
 # The provide_facts() function must return a dictionary. The keys of the
 # dictionary are each fact that is handled/returned by this module. The value

--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -31,43 +31,21 @@ NOTE: The dictionary key for each available fact is guaranteed to exist. If
 The following dictionary keys represent the available facts and their meaning:
 
 """
-import importlib
-import os
+import sys
 
-
-def _get_list_of_fact_module_names():
-    """
-    Get a list of fact module names.
-
-    Gets a list of the module names that reside in the facts directory (the
-    directory where this jnpr.junos.facts.__init__.py file lives). Any module
-    names that begin with an underscore (_) are ommitted.
-
-    :returns:
-      A list of fact module names.
-    """
-    module_names = []
-    facts_dir = os.path.dirname(__file__)
-    for file in os.listdir(facts_dir):
-        if (os.path.isfile(os.path.join(facts_dir, file)) and
-           not os.path.islink(os.path.join(facts_dir, file))):
-            if file.endswith('.py') and not file.startswith('_'):
-                (module_name, _) = file.rsplit('.py', 1)
-                module_names.append('%s.%s' % (__name__, module_name))
-    return module_names
-
-
-def _import_fact_modules():
-    """
-    Import each of the modules returned by _get_list_of_fact_module_names().
-
-    :returns:
-      A list of the imported module objects.
-    """
-    modules = []
-    for name in _get_list_of_fact_module_names():
-        modules.append(importlib.import_module(name))
-    return modules
+import jnpr.junos.facts.current_re
+import jnpr.junos.facts.domain
+import jnpr.junos.facts.ethernet_mac_table
+import jnpr.junos.facts.file_list
+import jnpr.junos.facts.get_chassis_cluster_status
+import jnpr.junos.facts.get_chassis_inventory
+import jnpr.junos.facts.get_route_engine_information
+import jnpr.junos.facts.get_software_information
+import jnpr.junos.facts.get_virtual_chassis_information
+import jnpr.junos.facts.ifd_style
+import jnpr.junos.facts.iri_mapping
+import jnpr.junos.facts.personality
+import jnpr.junos.facts.swver
 
 
 def _build_fact_callbacks_and_doc_strings():
@@ -87,19 +65,20 @@ def _build_fact_callbacks_and_doc_strings():
     """
     callbacks = {}
     doc_strings = {}
-    for module in _import_fact_modules():
-        new_doc_strings = module.provides_facts()
-        for key in new_doc_strings:
-            if key not in callbacks:
-                callbacks[key] = module.get_facts
-                doc_strings[key] = new_doc_strings[key]
-            else:
-                raise RuntimeError('Both the %s module and the %s module '
-                                   'claim to provide the %s fact. Please '
-                                   'report this error.' %
-                                   (callbacks[key].__module__,
-                                    module.__name__,
-                                    key))
+    for (name,module) in sys.modules.items():
+        if name.startswith('jnpr.junos.facts.') and module is not None:
+            new_doc_strings = module.provides_facts()
+            for key in new_doc_strings:
+                if key not in callbacks:
+                    callbacks[key] = module.get_facts
+                    doc_strings[key] = new_doc_strings[key]
+                else:
+                    raise RuntimeError('Both the %s module and the %s module '
+                                       'claim to provide the %s fact. Please '
+                                       'report this error.' %
+                                       (callbacks[key].__module__,
+                                        module.__name__,
+                                        key))
     return (callbacks, doc_strings)
 
 

--- a/tests/unit/facts/test__init__.py
+++ b/tests/unit/facts/test__init__.py
@@ -3,23 +3,18 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest2 as unittest
 from nose.plugins.attrib import attr
-from mock import patch, MagicMock
 import importlib
+import sys
 
 import jnpr.junos.facts
-
 
 @attr('unit')
 class TestFactInitialization(unittest.TestCase):
 
-    @patch('jnpr.junos.facts._import_fact_modules')
-    def test_duplicate_facts(self, mock_import):
-        mock_import.side_effect = self._mock_import_side_effect
+    def test_duplicate_facts(self):
+        module = importlib.import_module('tests.unit.facts.dupe_foo1')
+        sys.modules['jnpr.junos.facts.dupe_foo1'] = module
+        module = importlib.import_module('tests.unit.facts.dupe_foo2')
+        sys.modules['jnpr.junos.facts.dupe_foo2'] = module
         with self.assertRaises(RuntimeError):
             jnpr.junos.facts._build_fact_callbacks_and_doc_strings()
-
-    def _mock_import_side_effect(self, *args, **kwargs):
-        modules = []
-        modules.append(importlib.import_module('tests.unit.facts.dupe_foo1'))
-        modules.append(importlib.import_module('tests.unit.facts.dupe_foo2'))
-        return modules


### PR DESCRIPTION
Previously, the sub-modules within jnpr/junos/facts/ were dynamically
loaded based on their filename. However, that conflicted with some
tools such as Pyinstaller.

Changed to explicitly load the sub-modules.