### PR TITLE
socket.error handling for console->close()

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -6,6 +6,7 @@ import traceback
 import sys
 import logging
 import warnings
+import socket
 
 # 3rd-party packages
 from ncclient.devices.junos import JunosDeviceHandler
@@ -219,6 +220,11 @@ class Console(_Connection):
         if skip_logout is False and self.connected is True:
             try:
                 self._tty_logout()
+            except socket.error as err:
+                # if err contains "Connection reset by peer" connection to the
+                # device got closed
+                if "Connection reset by peer" not in err:
+                    raise err
             except Exception as err:
                 logger.error("ERROR {0}:{1}\n".format('logout', str(err)))
                 raise err

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -223,7 +223,7 @@ class Console(_Connection):
             except socket.error as err:
                 # if err contains "Connection reset by peer" connection to the
                 # device got closed
-                if "Connection reset by peer" not in err:
+                if "Connection reset by peer" not in str(err):
                     raise err
             except Exception as err:
                 logger.error("ERROR {0}:{1}\n".format('logout', str(err)))

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -7,6 +7,7 @@ import sys
 import os
 from lxml import etree
 import six
+import socket
 
 from jnpr.junos.console import Console
 from jnpr.junos.transport.tty_netconf import tty_netconf
@@ -42,21 +43,6 @@ class TestConsole(unittest.TestCase):
             password='lab123',
             mode='Telnet')
         self.dev.open()
-
-    # @patch('jnpr.junos.transport.tty.tty_netconf.close')
-    # @patch('jnpr.junos.transport.tty_telnet.telnetlib.Telnet.expect')
-    # @patch('jnpr.junos.transport.tty_telnet.Telnet.write')
-    # def tearDown(self, mock_write, mock_expect, mock_nc_close):
-    #     mock_expect.side_effect = [(1, re.search('(?P<cli>[^\\-"]>\s*$)',
-    #                                              "cli>"),
-    #                                 six.b('\r\r\nroot@device>')),
-    #                                (2, re.search('(?P<shell>%|#\s*$)',
-    #                                              "junos %"),
-    #                                 six.b('\r\r\nroot@device:~ # ')),
-    #                                (3, re.search('(?P<login>ogin:\s*$)',
-    #                                              "login: "),
-    #                                 six.b('\r\r\nlogin'))]
-    #     self.dev.close()
 
     @patch('jnpr.junos.console.Console._tty_logout')
     def tearDown(self, mock_tty_logout):
@@ -141,6 +127,17 @@ class TestConsole(unittest.TestCase):
     def test_console_close_error(self, mock_logout):
         mock_logout.side_effect = RuntimeError
         self.assertRaises(RuntimeError, self.dev.close)
+
+    @patch('jnpr.junos.console.Console._tty_logout')
+    def test_console_close_socket_error(self, mock_logout):
+        mock_logout.side_effect = socket.error
+        self.assertRaises(socket.error, self.dev.close)
+
+    @patch('jnpr.junos.console.Console._tty_logout')
+    def test_console_close_socket_conn_reset(self, mock_logout):
+        mock_logout.side_effect = socket.error("Connection reset by peer")
+        self.dev.close()
+        self.assertFalse(self.dev.connected)
 
     @patch('jnpr.junos.transport.tty_telnet.Telnet')
     @patch('jnpr.junos.console.Console._tty_login')


### PR DESCRIPTION
issue fixed: below python code in telnet mode used to throw socker.error "Connection reset by peer" exception

python script:
```python
from jnpr.junos import Device

with Device(host="xx.xx.xx.xx", user="xxxx", passwd="xxx", *mode='telnet'*) as dev:
    print dev.facts
 ```
 output:
```
Traceback (most recent call last):
  File "/Users/nitinkr/Documents/PyEZ/py-junos-eznc/lib/jnpr/junos/nitin.py", line 113, in <module>
    print dev.facts
  File "/Users/nitinkr/Documents/PyEZ/py-junos-eznc/lib/jnpr/junos/console.py", line 299, in __exit__
    self.close()
  File "/Users/nitinkr/Documents/PyEZ/py-junos-eznc/lib/jnpr/junos/console.py", line 228, in close
    raise err
socket.error: [Errno 54] Connection reset by peer
 
Process finished with exit code 1
```