### PR TITLE
Ensure dev.timeout is an integer value. Addresses #735

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -177,10 +177,9 @@ class _Connection(object):
         """
         try:
             self._conn.timeout = int(value)
-        except (ValueError,TypeError):
+        except (ValueError, TypeError):
             raise RuntimeError("could not convert timeout value of %s to an "
                                "integer" % (value))
-
 
     # ------------------------------------------------------------------------
     # property: facts

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -175,7 +175,12 @@ class _Connection(object):
         :param int value:
             New timeout value in seconds
         """
-        self._conn.timeout = value
+        try:
+            self._conn.timeout = int(value)
+        except (ValueError,TypeError):
+            raise RuntimeError("could not convert timeout value of %s to an "
+                               "integer" % (value))
+
 
     # ------------------------------------------------------------------------
     # property: facts

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -414,6 +414,18 @@ class TestDevice(unittest.TestCase):
         self.dev.timeout = 10
         self.assertEqual(self.dev.timeout, 10)
 
+    def test_device_set_timeout_string(self):
+        self.dev.timeout = '10'
+        self.assertEqual(self.dev.timeout, 10)
+
+    def test_device_set_timeout_invalid_string_value(self):
+        with self.assertRaises(RuntimeError):
+            self.dev.timeout = 'foo'
+
+    def test_device_set_timeout_invalid_type(self):
+        with self.assertRaises(RuntimeError):
+            self.dev.timeout = [1,2,3,4]
+
     def test_device_manages(self):
         self.assertEqual(self.dev.manages, [],
                          'By default manages will be empty list')


### PR DESCRIPTION
Try to convert the dev.timeout value to an integer to ensure
that ncclient receives an integer value. If the value can not
be converted to an integer, raise a RuntimeError with a meaningful
error message.