### PR TITLE
Refactor _exec_rpc() and handle boolean RPC arguments with a value of False.

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -741,8 +741,8 @@ class _Connection(object):
         # should not convert rpc response to json when loading json config
         # as response should be rpc-reply xml object.
 
-        if rpc_cmd_e.tag != 'load-configuration' and \
-                        rpc_cmd_e.attrib.get('format') in ['json', 'JSON']:
+        if (rpc_cmd_e.tag != 'load-configuration' and
+           rpc_cmd_e.attrib.get('format') in ['json', 'JSON']):
             ver_info = self.facts.get('version_info')
             if ver_info and ver_info.major[0] >= 15 or \
                     (ver_info.major[0] == 14 and ver_info.major[1] >= 2):

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -318,12 +318,11 @@ class JSONLoadError(Exception):
 
     def __repr__(self):
         if self.offending_line:
-            return "{0}(reason: {1}, \nThe offending config appears to be: \n{2})" \
-                .format(self.__class__.__name__, self.ex_msg,
-                        self.offending_line)
+            return "{0}(reason: {1}, \nThe offending config appears " \
+                   "to be: \n{2})".format(self.__class__.__name__, self.ex_msg,
+                                          self.offending_line)
         else:
             return "{0}(reason: {1})" \
                 .format(self.__class__.__name__, self.ex_msg)
 
     __str__ = __repr__
-

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from lxml import etree
 from lxml.builder import E
 from jnpr.junos import jxml as JXML
@@ -309,7 +310,9 @@ class _RpcMetaExec(object):
                     if not isinstance(arg_value, (tuple, list)):
                         arg_value = [arg_value]
                     for a in arg_value:
-                        if not isinstance(a, (bool, str, unicode)):
+                        if ((sys.version < '3' and
+                             not isinstance(a, (bool, str, unicode))) or
+                            not isinstance(a, (bool, str))):
                             raise TypeError("The value %s for argument %s"
                                             " is of %s. Argument "
                                             "values must be a string, "

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -295,14 +295,12 @@ class _RpcMetaExec(object):
             # create the rpc as XML command
             rpc = etree.Element(rpc_cmd)
 
-            # gather any decorator keywords
+            # Gather decorator keywords into dec_args and remove from kvargs
+            dec_arg_keywords = ['dev_timeout', 'normalize', 'ignore_warning']
             dec_args = {}
-            if 'dev_timeout' in kvargs:
-                dec_args['dev_timeout'] = kvargs.pop('dev_timeout')
-            if 'normalize' in kvargs:
-                dec_args['normalize'] = kvargs.pop('normalize')
-            if 'ignore_warning' in kvargs:
-                dec_args['ignore_warning'] = kvargs.pop('ignore_warning')
+            for keyword in dec_arg_keywords:
+                if keyword in kvargs:
+                    dec_args[keyword] = kvargs.pop(keyword)
 
             # kvargs are the command parameter/values
             if kvargs:

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -113,14 +113,15 @@ class Test_RpcMetaExec(unittest.TestCase):
 
     @patch('jnpr.junos.device.Device.execute')
     def test_rpcmeta_exec_rpc_kvargs_dict(self, mock_execute_fn):
-        with self.assertRaises(TypeError):
-            self.rpc.system_users_information(dict_data={'test': 'foo'})
+        self.assertRaises(TypeError,
+                          self.rpc.system_users_information,
+                          dict_data={'test': 'foo'})
 
     @patch('jnpr.junos.device.Device.execute')
     def test_rpcmeta_exec_rpc_kvargs_list_with_dict(self, mock_execute_fn):
-        with self.assertRaises(TypeError):
-            self.rpc.system_users_information(
-                list_with_dict_data=[True, {'test': 'foo'}])
+        self.assertRaises(TypeError,
+                          self.rpc.system_users_information,
+                          list_with_dict_data=[True, {'test': 'foo'}])
 
     @patch('jnpr.junos.device.Device.execute')
     def test_rpcmeta_exec_rpc_normalize(self, mock_execute_fn):


### PR DESCRIPTION
`_exec_rpc()` returned cryptic errors if an RPC argument was an unexpected
type, or if it had a boolean value of `False`. A boolean with a value of
`False` now results in the argument not being added to the RPC. An argument
with an unexpected type now raises a `TypeError` with an informative message.

Unecessary duplicate code existed to deal with list/tuple argument values vs
string or boolean argument values. Refactored to eliminate the duplication.

Unecessary code to deal with decorator arguments. Consolidated and simplified
the code to deal with decorator arguments.

Additional tests added to cover changes and increase coverage.

PEP8 cleanup.