### PR TITLE
Support platforms which have single-RE ISSU.

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -243,7 +243,9 @@ class SW(Util):
 
     def _parse_pkgadd_response(self, rsp):
         got = rsp.getparent()
-        rc = int(got.findtext('package-result').strip())
+        # If <package-result> is not present, then assume success.
+        # That is, assume <package-result>0</package-result>
+        rc = int(got.findtext('package-result','0').strip())
         output_msg = '\n'.join([i.text for i in got.findall('output')
                                 if i.text is not None])
         self.log("software pkgadd package-result: %s\nOutput: %s" % (

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -245,7 +245,7 @@ class SW(Util):
         got = rsp.getparent()
         # If <package-result> is not present, then assume success.
         # That is, assume <package-result>0</package-result>
-        rc = int(got.findtext('package-result','0').strip())
+        rc = int(got.findtext('package-result', '0').strip())
         output_msg = '\n'.join([i.text for i in got.findall('output')
                                 if i.text is not None])
         self.log("software pkgadd package-result: %s\nOutput: %s" % (

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -70,6 +70,8 @@ class SW(Util):
             self._multi_RE is True and dev.facts.get('vc_capable') is True and
             dev.facts.get('vc_mode') != 'Disabled')
         self._mixed_VC = bool(dev.facts.get('vc_mode') == 'Mixed')
+        self._single_re_issu = bool('current_re' in dev.facts and
+                                    'localre' in dev.facts['current_re'])
         self.log = lambda report: None
 
     # -----------------------------------------------------------------------
@@ -715,7 +717,9 @@ class SW(Util):
         if issu is True and nssu is True:
             raise TypeError(
                 'install function can either take issu or nssu not both')
-        elif (issu is True or nssu is True) and self._multi_RE is not True:
+        elif ((issu is True or nssu is True) and
+              (self._multi_RE is not True and
+               self._single_re_issu is not True)):
             raise TypeError(
                 'ISSU/NSSU requires Multi RE setup')
 

--- a/tests/unit/utils/rpc-reply/request-package-add.no_result.xml
+++ b/tests/unit/utils/rpc-reply/request-package-add.no_result.xml
@@ -1,0 +1,29 @@
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/10.4R3/junos">
+    <pipe>
+    <more-no-more/>
+    </pipe>
+    <cli>
+        <ignore-signals>
+            hup
+        </ignore-signals>
+    </cli>
+    <output>
+        /var/tmp/incoming-package.31020                       1742 kB 1742 kBps
+        Package contains junos-11.1R3.5.tgz ; renaming ...
+        Formatting alternate root (/dev/ad0s1a)...
+        /dev/ad0s1a: 299.7MB (613792 sectors) block size 16384, fragment size 2048
+                using 4 cylinder groups of 74.94MB, 4796 blks, 9600 inodes.
+        super-block backups (for fsck -b #) at:
+         32, 153504, 306976, 460448
+        Removing /var/tmp/junos-11.1R3.5.tgz
+        Installing package '/altroot/cf/packages/install-tmp/junos-11.1R3.5-domestic' ...
+        Verified junos-boot-srxsme-11.1R3.5.tgz signed by PackageProduction_11_1_0
+        Verified junos-srxsme-11.1R3.5-domestic signed by PackageProduction_11_1_0
+        Saving boot file package in /var/sw/pkg/junos-boot-srxsme-11.1R3.5.tgz
+        JUNOS 11.1R3.5 will become active at next reboot
+        WARNING: A reboot is required to load this software correctly
+        WARNING:     Use the 'request system reboot' command
+        WARNING:         when software installation is complete
+        Saving state for rollback ...
+    </output>
+</rpc-reply>

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -37,6 +37,7 @@ facts = {'domain': None, 'hostname': 'firefly', 'ifd_style': 'CLASSIC',
                  'normal shutdown.',
                  'model': 'FIREFLY-PERIMETER RE',
                  'up_time': '6 hours, 29 minutes, 30 seconds'},
+         'current_re': ['re0', 'master'],
          'vc_capable': False, 'personality': 'SRX_BRANCH'}
 
 
@@ -131,6 +132,7 @@ class TestSW(unittest.TestCase):
     def test_sw_put_ftp(self, mock_ftp_put):
         dev = Device(host='1.1.1.1', user='rick', password='password123',
                      mode='telnet', port=23, gather_facts=False)
+        dev.facts = facts
         sw = SW(dev)
         sw.put(package='test.tgz')
         self.assertTrue(

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -166,6 +166,12 @@ class TestSW(unittest.TestCase):
         self.assertTrue(self.sw.install('test.tgz', no_copy=True))
 
     @patch('jnpr.junos.Device.execute')
+    def test_sw_install_no_package_result(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        self.sw._multi_RE = False
+        self.assertTrue(self.sw.install('test_no_result.tgz', no_copy=True))
+
+    @patch('jnpr.junos.Device.execute')
     def test_sw_install_issu(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         package = 'test.tgz'
@@ -779,7 +785,11 @@ class TestSW(unittest.TestCase):
         if kwargs:
             # Little hack for mocked execute
             if 'dev_timeout' in kwargs:
-                return self._read_file(args[0].tag + '.xml')
+                if (args and args[0].findtext('package-name') ==
+                             '/var/tmp/test_no_result.tgz'):
+                    return self._read_file(args[0].tag + '.no_result.xml')
+                else:
+                    return self._read_file(args[0].tag + '.xml')
             if 'path' in kwargs:
                 if kwargs['path'] == '/packages':
                     return self._read_file('file-list_dir.xml')
@@ -787,7 +797,6 @@ class TestSW(unittest.TestCase):
             device_handler = make_device_handler(device_params)
             session = SSHSession(device_handler)
             return Manager(session, device_handler)
-
         elif args:
             if args[0].find('at') is not None:
                 return self._read_file('request-reboot-at.xml')


### PR DESCRIPTION
Support platforms which have single-RE ISSU.
Handle the fact that some platforms don't return <package-result> from sw install.
Unit test fixup and PEP8 cleanup.