### PR TITLE
load config using <load-configuration> RPCs url attribute

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -175,6 +175,7 @@ class _RpcMetaExec(object):
           each warning matches at least one of the strings in the list.
 
           For example::
+
             dev.rpc.get(ignore_warning=True)
             dev.rpc.get(ignore_warning='vrrp subsystem not running')
             dev.rpc.get(ignore_warning=['vrrp subsystem not running',
@@ -216,6 +217,7 @@ class _RpcMetaExec(object):
           each warning matches at least one of the strings in the list.
 
           For example::
+
             dev.rpc.load_config(cnf, ignore_warning=True)
             dev.rpc.load_config(cnf,
                                 ignore_warning='vrrp subsystem not running')
@@ -247,11 +249,15 @@ class _RpcMetaExec(object):
         format='json', then :contents: is a string containing Junos
             configuration in json format
 
+        url='path', then :contents: is a None
+
         <otherwise> :contents: is XML structure
         """
         rpc = E('load-configuration', options)
 
-        if ('action' in options) and (options['action'] == 'set'):
+        if contents is None and 'url' in options:
+            pass
+        elif ('action' in options) and (options['action'] == 'set'):
             rpc.append(E('configuration-set', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -18,7 +18,7 @@ Configuration Utilities
 
 class Config(Util):
     """
-    Overivew of Configuration Utilities.
+    Overview of Configuration Utilities.
 
     * :meth:`commit`: commit changes
     * :meth:`commit_check`: perform the commit check operation
@@ -358,6 +358,8 @@ class Config(Util):
           For example::
 
             cu.load(url="/var/home/user/golden.conf")
+            cu.load(url="ftp://username@ftp.hostname.net/filename")
+            cu.load(url="http://username:password@hostname/path/filename")
             cu.load(url="/var/home/user/golden.conf", overwrite=True)
 
         :returns:

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -17,9 +17,8 @@ Configuration Utilities
 
 
 class Config(Util):
-
     """
-    Overivew of Configuration Utilities:
+    Overivew of Configuration Utilities.
 
     * :meth:`commit`: commit changes
     * :meth:`commit_check`: perform the commit check operation
@@ -65,6 +64,7 @@ class Config(Util):
           each warning matches at least one of the strings in the list.
 
           For example::
+
             cu.commit(ignore_warning=True)
             cu.commit(ignore_warning='Advertisement-interval is '
                                      'less than four times')
@@ -333,6 +333,7 @@ class Config(Util):
           each warning matches at least one of the strings in the list.
 
           For example::
+
             cu.load(cnf, ignore_warning=True)
             cu.load(cnf, ignore_warning='statement not found')
             cu.load(cnf, ignore_warning=['statement not found',
@@ -346,6 +347,18 @@ class Config(Util):
             case-insensitive substring match. However, any regular expression
             pattern supported by the re library may be used for more
             complicated match conditions.
+
+        :param str url:
+          Specify the full pathname of the file that contains the configuration
+          data to load. The value can be a local file path, an FTP location, or
+          a Hypertext Transfer Protocol (HTTP).
+          Refer `Doc page <https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-load-configuration.html>`_
+          for more details.
+
+          For example::
+
+            cu.load(url="/var/home/user/golden.conf")
+            cu.load(url="/var/home/user/golden.conf", overwrite=True)
 
         :returns:
             RPC-reply as XML object.
@@ -513,6 +526,13 @@ class Config(Util):
                 rpc_contents = etree.XML(rpc_contents)
 
         if rpc_contents is not None:
+            return try_load(rpc_contents,
+                            rpc_xattrs,
+                            ignore_warning=ignore_warning)
+        elif 'url' in kvargs and rpc_contents is None:
+            url = kvargs['url']
+            _lset_fromfile(url)
+            rpc_xattrs['url'] = url
             return try_load(rpc_contents,
                             rpc_xattrs,
                             ignore_warning=ignore_warning)
@@ -724,11 +744,12 @@ class Config(Util):
                print cu.diff()
                cu.commit()
 
-        .. warning:: Ephemeral databases are an advanced Junos feature which
-        if used incorrectly can have serious negative impact on the operation
-        of the Junos device. We recommend you consult JTAC and/or you Juniper
-        account team before deploying the ephemeral database feature in your
-        network.
+        .. warning::
+            Ephemeral databases are an advanced Junos feature which
+            if used incorrectly can have serious negative impact on the operation
+            of the Junos device. We recommend you consult JTAC and/or you Juniper
+            account team before deploying the ephemeral database feature in your
+            network.
         """
         self.mode = mode
         if not kwargs.get('ephemeral_instance') and kwargs:

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -605,9 +605,10 @@ class SW(Util):
         4. SCP or FTP copies the :package: file from the local host to the
            :remote_path: directory on the remote Junos device under any of the
            following conditions:
+
            a) The :force_copy: argument is ``True``
            b) The :package: filename doesn't already exist in the :remote_path:
-              :remote_path: directory of the remote Junos device.
+              directory of the remote Junos device.
            c) The checksum computed in step 1 does not match the checksum
               computed in step 3.
         5. If step 4 was executed, computes the checksum of the :package:

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -730,6 +730,12 @@ class TestConfig(unittest.TestCase):
         self.assertRaises(RpcError, Config.__enter__,
                           Config(self.dev, mode='batch'))
 
+    def test_config_load_url(self):
+        self.conf.rpc.load_config = MagicMock()
+        self.conf.load(url="/var/home/user/golden.conf")
+        self.assertEqual(self.conf.rpc.load_config.call_args[1]['url'],
+                         '/var/home/user/golden.conf')
+
     def _read_file(self, fname):
         fpath = os.path.join(os.path.dirname(__file__),
                              'rpc-reply', fname)


### PR DESCRIPTION
Now user can load config using `url` attribute. with this user can load config file located on the device itself.
It should also support all the options with url as per [doc](https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-load-configuration.html)

Example:
```python
  cu.load(url="/var/home/user/golden.conf")
  cu.load(url="ftp://username@ftp.hostname.net/filename")
  cu.load(url="http://username:password@hostname/path/filename")
  cu.load(url="/var/home/user/golden.conf", overwrite=True)
```