### PR TITLE
Implement uptime property for Device instances. Addresses #750.

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -290,15 +290,14 @@ class _Connection(object):
         The current Routing Engine is the RE to which the NETCONF session is
         connected.
 
-        :returns: The number of seconds (int) the current Routing Engine has 
-                  been up. If there is a problem gathering information, None is
-                  returned.
+        :returns: The number of seconds (int) since the current Routing Engine
+                  was booted. If there is a problem gathering or parsing the
+                  uptime information, None is returned.
         :raises: May raise a specific jnpr.junos.RpcError or 
                  jnpr.junos.ConnectError subclass if there is a problem
                  communicating with the device.
         """
         uptime = None
-
         rsp = self.rpc.get_system_uptime_information(normalize=True)
         if rsp is not None:
             element = rsp.find('.//system-booted-time/time-length')
@@ -306,7 +305,6 @@ class _Connection(object):
                 uptime_string = element.get('seconds')
                 if uptime_string is not None:
                     uptime = int(uptime_string)
-
         return uptime
 
     @uptime.setter

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -293,7 +293,7 @@ class _Connection(object):
         :returns: The number of seconds (int) since the current Routing Engine
                   was booted. If there is a problem gathering or parsing the
                   uptime information, None is returned.
-        :raises: May raise a specific jnpr.junos.RpcError or 
+        :raises: May raise a specific jnpr.junos.RpcError or
                  jnpr.junos.ConnectError subclass if there is a problem
                  communicating with the device.
         """

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -279,6 +279,42 @@ class _Connection(object):
         raise RuntimeError("master is read-only!")
 
     # ------------------------------------------------------------------------
+    # property: uptime
+    # ------------------------------------------------------------------------
+
+    @property
+    def uptime(self):
+        """
+        The uptime of the current Routing Engine.
+
+        The current Routing Engine is the RE to which the NETCONF session is
+        connected.
+
+        :returns: The number of seconds (int) the current Routing Engine has 
+                  been up. If there is a problem gathering information, None is
+                  returned.
+        :raises: May raise a specific jnpr.junos.RpcError or 
+                 jnpr.junos.ConnectError subclass if there is a problem
+                 communicating with the device.
+        """
+        uptime = None
+
+        rsp = self.rpc.get_system_uptime_information(normalize=True)
+        if rsp is not None:
+            element = rsp.find('.//system-booted-time/time-length')
+            if element is not None:
+                uptime_string = element.get('seconds')
+                if uptime_string is not None:
+                    uptime = int(uptime_string)
+
+        return uptime
+
+    @uptime.setter
+    def uptime(self, value):
+        """ read-only property """
+        raise RuntimeError("uptime is read-only!")
+
+    # ------------------------------------------------------------------------
     # property: re_name
     # ------------------------------------------------------------------------
 

--- a/tests/unit/rpc-reply/get-system-uptime-information.xml
+++ b/tests/unit/rpc-reply/get-system-uptime-information.xml
@@ -1,0 +1,31 @@
+<rpc-reply>
+    <system-uptime-information>
+        <current-time>
+            <date-time seconds="1498780787">2017-06-29 16:59:47 PDT</date-time>
+        </current-time>
+        <time-source> NTP CLOCK </time-source>
+        <system-booted-time>
+            <date-time seconds="1498766553">2017-06-29 13:02:33 PDT</date-time>
+            <time-length seconds="14234">03:57:14</time-length>
+        </system-booted-time>
+        <protocols-started-time>
+            <date-time seconds="1498766692">2017-06-29 13:04:52 PDT</date-time>
+            <time-length seconds="14095">03:54:55</time-length>
+        </protocols-started-time>
+        <last-configured-time>
+            <date-time seconds="1498766651">2017-06-29 13:04:11 PDT</date-time>
+            <time-length seconds="14136">03:55:36</time-length>
+            <user>root</user>
+        </last-configured-time>
+        <uptime-information>
+            <date-time seconds="1498780787">4:59PM</date-time>
+            <up-time seconds="14220">3:57</up-time>
+            <active-user-count format="1 users">1</active-user-count>
+            <load-average-1>4.29</load-average-1>
+            <load-average-5>3.81</load-average-5>
+            <load-average-15>3.72</load-average-15>
+            <user-table>
+            </user-table>
+        </uptime-information>
+    </system-uptime-information>
+</rpc-reply>

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -166,6 +166,13 @@ class TestDevice(unittest.TestCase):
         except Exception as ex:
             self.assertEqual(type(ex), ValueError)
 
+    @patch('jnpr.junos.Device.execute')
+    def test_device_uptime(self, mock_execute):
+        localdev = Device(host='1.1.1.1', user='test', password='password123',
+                          gather_facts=False)
+        mock_execute.side_effect = self._mock_manager
+        self.assertEqual(localdev.uptime, 14234)
+
     def test_device_master_is_master(self):
         localdev = Device(host='1.1.1.1', user='test', password='password123',
                           gather_facts=False)


### PR DESCRIPTION
Add a new `uptime` property which provides the (int) number of seconds since the current Routing Engine was booted.

```
>>> from jnpr.junos.device import Device
>>> dev = Device(host='r0', user='user', passwd='user123')
>>> dev.open()
Device(r0)
>>> dev.uptime
69436
>>> 
```