### PR TITLE
Add the _j2ldr instance variable to the Console class.

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -124,6 +124,7 @@ class Console(_Connection):
         self.junos_dev_handler = JunosDeviceHandler(
                                      device_params={'name': 'junos',
                                                     'local': False})
+        self._j2ldr = _Jinja2ldr
         if self._fact_style == 'old':
             self.facts = self.ofacts
         else:

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -22,6 +22,7 @@ from jnpr.junos.factcache import _FactCache
 from jnpr.junos import jxml as JXML
 from jnpr.junos.ofacts import *
 from jnpr.junos.decorators import ignoreWarnDecorator
+from jnpr.junos.device import _Jinja2ldr
 
 logger = logging.getLogger("jnpr.junos.console")
 


### PR DESCRIPTION
The `Console` class was missing the `_j2ldr` instance variable which prevented loading a configuration from a Jinja template via the console.
