### PR TITLE
Properly handle normalize argument to the open() Device method. Fixes #757

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -205,9 +205,7 @@ class Console(_Connection):
         # normalize argument to open() overrides normalize argument value
         # to __init__(). Save value to self._normalize where it is used by
         # normalizeDecorator()
-        normalize = kvargs.get('normalize')
-        if normalize is not None:
-            self._normalize = normalize
+        self._normalize = kvargs.get('normalize', self._normalize)
         if self._normalize is True:
             self.transform = self._norm_transform
 

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -109,8 +109,6 @@ class Console(_Connection):
         self._mode = kvargs.get('mode', 'telnet')
         self._timeout = kvargs.get('timeout', '0.5')
         self._normalize = kvargs.get('normalize', False)
-        # self.timeout needed by PyEZ utils
-        # self.timeout = self._timeout
         self._attempts = kvargs.get('attempts', 10)
         self._gather_facts = kvargs.get('gather_facts', False)
         self._fact_style = kvargs.get('fact_style', 'new')
@@ -204,8 +202,13 @@ class Console(_Connection):
         self._nc_transform = self.transform
         self._norm_transform = lambda: JXML.normalize_xslt.encode('UTF-8')
 
-        normalize = kvargs.get('normalize', self._normalize)
-        if normalize is True:
+        # normalize argument to open() overrides normalize argument value
+        # to __init__(). Save value to self._normalize where it is used by
+        # normalizeDecorator()
+        normalize = kvargs.get('normalize')
+        if normalize is not None:
+            self._normalize = normalize
+        if self._normalize is True:
             self.transform = self._norm_transform
 
         gather_facts = kvargs.get('gather_facts', self._gather_facts)

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1278,9 +1278,7 @@ class Device(_Connection):
         # normalize argument to open() overrides normalize argument value
         # to __init__(). Save value to self._normalize where it is used by
         # normalizeDecorator()
-        normalize = kvargs.get('normalize')
-        if normalize is not None:
-            self._normalize = normalize
+        self._normalize = kvargs.get('normalize', self._normalize)
         if self._normalize is True:
             self.transform = self._norm_transform
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1275,8 +1275,13 @@ class Device(_Connection):
         self._nc_transform = self.transform
         self._norm_transform = lambda: JXML.normalize_xslt.encode('UTF-8')
 
-        normalize = kvargs.get('normalize', self._normalize)
-        if normalize is True:
+        # normalize argument to open() overrides normalize argument value
+        # to __init__(). Save value to self._normalize where it is used by
+        # normalizeDecorator()
+        normalize = kvargs.get('normalize')
+        if normalize is not None:
+            self._normalize = normalize
+        if self._normalize is True:
             self.transform = self._norm_transform
 
         gather_facts = kvargs.get('gather_facts', self._gather_facts)


### PR DESCRIPTION
If the `normalize` argument was specified to the `open()` method, then
later RPC invocations which attempted to override the `normalize` value
might not work correctly.

This was because `normalizeDecorator()` depends on the value of `dev._normalize`,
but `open()` was not properly setting the value of `dev._normalize`.

This change properly sets the value of `dev._normalize` when the
`normalize` argument is specified in the call to the `open()` device method.

Also removed unnecessary commented out code in console.py.
