### PR TITLE
fix typo in docker run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Installing from Git is also supported (OS must have git installed).
 
 Move to the local directory which contains your script(s) and run the container
 
-`docker run -it --rm --name -v $PWD:/scripts pyez juniper/pyez sh`
+`docker run -it --rm --name pyez -v $PWD:/scripts juniper/pyez sh`
 
 Your local scripts will be mounted to /scripts in the container
 


### PR DESCRIPTION
bring '--name pyez' back together in 'docker run' example.