### PR TITLE
Add vmhost parameter to SW.install() to support upgrading the VM Host.

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -679,21 +679,21 @@ class SW(Util):
                    to reboot the device.
 
         :param str package:
-          Either the full file path to the install package tarball on the local 
-          (PyEZ host's) filesystem OR a URL (from the target device's 
-          perspcective) from which the device retrieves installed. When the 
+          Either the full file path to the install package tarball on the local
+          (PyEZ host's) filesystem OR a URL (from the target device's
+          perspcective) from which the device retrieves installed. When the
           value is a URL, then the :no_copy: and :remote_path: values are
           unused. The acceptable formats for a URL value may be found at:
           https://www.juniper.net/documentation/en_US/junos/topics/concept/junos-software-formats-filenames-urls.html
 
         :param list pkg_set:
-          A list/tuple of :package: values which will be installed on a mixed VC 
-          setup.
+          A list/tuple of :package: values which will be installed on a mixed
+          VC setup.
 
         :param str remote_path:
           If the value of :package: or :pkg_set: is a file path on the local
-          (PyEZ host's) filesystem, then the image is copied from the local 
-          filesystem to the :remote_path: directory on the target Junos 
+          (PyEZ host's) filesystem, then the image is copied from the local
+          filesystem to the :remote_path: directory on the target Junos
           device. The default is ``/var/tmp``. If the value of :package: or
           :pkg_set: is a URL, then the value of :remote_path: is unused.
 
@@ -729,7 +729,7 @@ class SW(Util):
           directory of the target Junos device. When the value of :no_copy: is
           ``False`` (the default), then the package is copied from the local
           PyEZ host to the :remote_path: directory of the target Junos device.
-          If the value of :package: or :pkg_set: is a URL, then the value of 
+          If the value of :package: or :pkg_set: is a URL, then the value of
           :no_copy: is unused.
 
         :param bool issu:
@@ -881,7 +881,7 @@ class SW(Util):
                 _progress("installing software ... please be patient ...")
                 add_ok = self.pkgadd(
                     remote_package,
-                    vmhost = vmhost,
+                    vmhost=vmhost,
                     dev_timeout=timeout,
                     **kwargs)
                 return add_ok
@@ -913,7 +913,7 @@ class SW(Util):
                         "installing software on RE0 ... please be patient ...")
                     ok &= self.pkgadd(
                         remote_package,
-                        vmhost = vmhost,
+                        vmhost=vmhost,
                         re0=True,
                         dev_timeout=timeout,
                         **kwargs)
@@ -921,7 +921,7 @@ class SW(Util):
                         "installing software on RE1 ... please be patient ...")
                     ok &= self.pkgadd(
                         remote_package,
-                        vmhost = vmhost,
+                        vmhost=vmhost,
                         re1=True,
                         dev_timeout=timeout,
                         **kwargs)

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -869,6 +869,7 @@ class SW(Util):
                 _progress(
                     "ISSU: installing software ... please be patient ...")
                 return self.pkgaddISSU(remote_package,
+                                       vmhost=vmhost,
                                        dev_timeout=timeout, **kwargs)
             elif nssu is True:
                 _progress(
@@ -880,6 +881,7 @@ class SW(Util):
                 _progress("installing software ... please be patient ...")
                 add_ok = self.pkgadd(
                     remote_package,
+                    vmhost = vmhost,
                     dev_timeout=timeout,
                     **kwargs)
                 return add_ok
@@ -898,6 +900,7 @@ class SW(Util):
                             "be patient ...".format(vc_id))
                         ok &= self.pkgadd(
                             remote_package,
+                            vmhost=vmhost,
                             member=vc_id,
                             dev_timeout=timeout,
                             **kwargs)
@@ -910,6 +913,7 @@ class SW(Util):
                         "installing software on RE0 ... please be patient ...")
                     ok &= self.pkgadd(
                         remote_package,
+                        vmhost = vmhost,
                         re0=True,
                         dev_timeout=timeout,
                         **kwargs)
@@ -917,6 +921,7 @@ class SW(Util):
                         "installing software on RE1 ... please be patient ...")
                     ok &= self.pkgadd(
                         remote_package,
+                        vmhost = vmhost,
                         re1=True,
                         dev_timeout=timeout,
                         **kwargs)
@@ -924,7 +929,10 @@ class SW(Util):
 
         elif len(remote_pkg_set) > 1 and self._mixed_VC:
             _progress("installing software ... please be patient ...")
-            add_ok = self.pkgadd(remote_pkg_set, dev_timeout=timeout, **kwargs)
+            add_ok = self.pkgadd(remote_pkg_set,
+                                 vmhost=vmhost,
+                                 dev_timeout=timeout,
+                                 **kwargs)
             return add_ok
 
     # -------------------------------------------------------------------------

--- a/tests/unit/utils/rpc-reply/request-vmhost-package-add.xml
+++ b/tests/unit/utils/rpc-reply/request-vmhost-package-add.xml
@@ -1,0 +1,246 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/15.1F6/junos">
+    <output>
+        Junos Validation begin. Procedure will take few minutes.
+        Initializing...
+        Verified os-libs-10-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-libs-10-x86-64-20170607.351421_builder_stable_10
+        Verified os-runtime-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-runtime-x86-64-20170607.351421_builder_stable_10
+        Verified os-zoneinfo-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-zoneinfo-x86-64-20170607.351421_builder_stable_10
+        Verified os-libs-compat32-10-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-libs-compat32-10-x86-64-20170607.351421_builder_stable_10
+        Verified os-compat32-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-compat32-x86-64-20170607.351421_builder_stable_10
+        Verified py-base-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting py-base-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified os-vmguest-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-vmguest-x86-64-20170607.351421_builder_stable_10
+        Verified os-crypto-x86-64-20170607 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting os-crypto-x86-64-20170607.351421_builder_stable_10
+        Verified junos-net-prd-x86-64-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-net-prd-x86-64-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-modules-x86-64-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-modules-x86-64-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-libs-compat32-x86-64-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-libs-compat32-x86-64-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-runtime-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-runtime-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-platform-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-platform-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-libs-x86-64-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-libs-x86-64-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-dp-crypto-support-mtx-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-dp-crypto-support-mtx-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified junos-daemons-x86-64-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting junos-daemons-x86-64-20170630.054423_builder_junos_151_f6_s7
+        Verified jservices-voice-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-ssl-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-sfw-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-rpm-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-ptsp-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-nat-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-mss-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-mobile-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-llpdf-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-jflow-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-ipsec-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-idp-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-hcm-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-crypto-base-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-cpcd-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-cos-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-bgf-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-appid-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-alg-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jservices-aacl-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Verified jpfe-common-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting jpfe-common-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified jdocs-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting jdocs-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Verified fips-mode-x86-32-20170630 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Mounting fips-mode-x86-32-20170630.054423_builder_junos_151_f6_s7
+        Hardware Database regeneration succeeded
+        Validating against /config/juniper.conf.gz
+        mgd: commit complete
+        Validation succeeded
+    </output>
+    <pipe>
+        <more-no-more/>
+    </pipe>
+    <cli>
+        <ignore-signals>
+            hup
+        </ignore-signals>
+    </cli>
+    <output>
+        Verified junos-vmhost-install-ptx-x86-64-15.1F6-S7.2 signed by PackageProductionEc_2017 method ECDSA256+SHA256
+        Copied the config and other data to the aux disk.
+        Transfer junos-host-upgrade.sh
+        Transfer Done
+        Transfer /packages/db/pkginst.69723/junos-vmhost-install*.tgz
+        Transfer Done
+        Starting upgrade ...
+        Preparing for upgrade...
+        /tmp/pkg-QWC/unpack/install/
+        tar --directory=/tmp/pkg-QWC/unpack/install/ -xvf /tmp/install.tgz
+        ./
+        ./vm/
+        ./vm/re_fpga-1.0-0.x86_64.rpm
+        ./vm/vsmartd-1.0-0.x86_64.rpm
+        ./vm/grub.cfg.ngre
+        ./vm/resild-1.0-0.x86_64.rpm
+        ./vm/note
+        ./junos/
+        ./junos/junos-mtre-install.sh
+        ./junos/junos-mtre-upgrade.sh
+        ./vmhost/
+        ./vmhost/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img.gz
+        ./vmhost/README
+        ./vmhost-core-x86_64-15.1F6-S7-20170608_0128_builder.tgz
+        ./vmhost-version.sh
+        ./vmhost-pkgs-version
+        ./hostd/
+        ./hostd/jhost_core-1.0-1706080443.x86_64.rpm
+        ./hostd/vehostd-note.txt
+        ./hostd/vehostd-ovp-install.sh
+        ./vmhost-version
+        ./scripts/
+        ./scripts/mount-usb-img.sh
+        ./scripts/target-scripts/
+        ./scripts/target-scripts/mk-mtre-rollback.sh
+        ./scripts/target-scripts/savelog
+        ./scripts/target-scripts/mk-mtre-zeroize.sh
+        ./scripts/target-scripts/vmhost-partition.inc
+        ./scripts/target-scripts/02setmac.sh
+        ./scripts/target-scripts/S05rootunion.sh
+        ./scripts/target-scripts/S05ovprootrwS.sh
+        ./scripts/target-scripts/S05ovprootrw.sh
+        ./scripts/target-scripts/vmhost-kdump.inc
+        ./scripts/target-scripts/mtre-ssd-version.sh
+        ./scripts/target-scripts/mk-mtre-partition.sh
+        ./scripts/target-scripts/vmhost-kdump-configure
+        ./scripts/target-scripts/vmhost-kdump-process.sh
+        ./scripts/target-scripts/mtre-ssd-snapshot.sh
+        ./scripts/target-scripts/01vehostd_setup.sh
+        ./scripts/target-scripts/gt-mtre-version.sh
+        ./scripts/target-scripts/platfom_specific_init
+        ./scripts/target-scripts/mtre-ssd-zeroize.sh
+        ./scripts/target-scripts/S05rootunionS.sh
+        ./scripts/target-scripts/mk-mtre-snapshot.sh
+        ./scripts/target-scripts/03boot_info.sh
+        ./scripts/target-scripts/vmhost-misc.inc
+        ./scripts/target-scripts/01boot_setup.sh
+        ./scripts/target-scripts/vmhost-kdump-input.sh
+        ./scripts/target-scripts/mtre-ssd-rollback.sh
+        ./scripts/target-scripts/S08jhostrpminstall.sh
+        ./scripts/target-scripts/vmhost_version_get_major.sh
+        ./scripts/target-scripts/vmhost-kdump-usb-format.sh
+        ./scripts/target-scripts/00read_only_root.sh
+        ./scripts/target-scripts/S04modutilsPost.sh
+        ./scripts/target-scripts/00junos_setup.sh
+        ./scripts/target-scripts/rc.local
+        ./scripts/mk-mtre-partition.sh
+        ./scripts/ddimage
+        ./scripts/mtre-installer.sh
+        ./scripts/mtre-ssd-installer.sh
+        ./scripts/mk-mtre-upgrade.sh
+        ./scripts/ssd-ovp-installer.sh
+        ./scripts/grub.cfg.ngre
+        ./scripts/mk-part-mtre-install.sh
+        ./scripts/mtre-ssd-upgrade.sh
+        ./bin/
+        ./bin/telnet.netkit
+        junos/
+        junos/junos-install-x86-64-15.1F6-S7.2.img.gz
+        /tmp/pkg-QWC/unpack/install//
+        sh /tmp/pkg-QWC/unpack/install///scripts/mtre-ssd-upgrade.sh /tmp/pkg-QWC/unpack/install//
+        Current root details, Device sda, Label: jrootb_P, Partition: sda4
+        Copying /tmp/pkg-QWC/unpack/install///vmhost/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img.gz to tmp dir: /tmp/install-31a ...
+        Testing /tmp/install-31a/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img.gz for compression ...
+        Uncompressing Linux: /tmp/install-31a/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img.gz ...
+        Image details
+        =============
+            image: '/tmp/install-31a/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img'
+             size: 1998585856 bytes
+         modified: 2017-08-16 16:39:22.462996193 +0200
+             type: x86 boot sector
+        
+        Finding alternate root for upgrade
+        Upgrading software on jrootp_P ...
+        Inputs: jrootp_P p /dev/sda /tmp/install-31a/vmhost-x86_64-15.1F6-S7-20170608_0128_builder.img P /tmp/pkg-QWC/unpack/install//
+        
+        Mounting images and device in preparation for upgrade...
+        USBIMG_BOOT_OFFSET: 1048576, USBIMG_BOOT_SIZELIMIT: 134217728, USBIMG_ROOT_OFFSET: 135266304, USBIMG_ROOT_SIZELIMIT: 1863319552
+        Cleaning target ROOTFS jrootp_P
+        Copying ROOTFS files...
+        Upgrading administrative Junos context ...
+        Testing /tmp/partdisk-cfO/jlvmjunosfs/Current.p/junos-install-x86-64-15.1F6-S7.2.img.gz for compression ...
+        Uncompressing Junos: /tmp/partdisk-cfO/jlvmjunosfs/Current.p/junos-install-x86-64-15.1F6-S7.2.img.gz ...
+        Done with Junos Upgrade
+        Upgrading hostd content ...
+        ./
+        ./rasdaemon_install.sh
+        ./i40e_pkg_install.sh
+        ./resild_install.sh
+        ./jhost_core-1.0-1706080443.x86_64.rpm
+        ./re_fpga-1.0-0.x86_64.rpm
+        ./i40e_pkg-1.0-0.x86_64.rpm
+        ./bios_pkg-1.0-0.x86_64.rpm
+        ./vsmartd-1.0-0.x86_64.rpm
+        ./monit_install.sh
+        ./vmhost-version.sh
+        ./vmhost-version
+        ./vmhost-firmware-x86_64-15.1F6-S7-20170608_0128_builder.tar
+        ./vsmartd_install.sh
+        ./rasdaemon-0.5.6-1.x86_64.rpm
+        ./bios_pkg_install.sh
+        ./vehostd_install.sh
+        ./resild-1.0-0.x86_64.rpm
+        ./monit-5.12.2-1.x86_64.rpm
+        ./re_fpga_install.sh
+        Copying /tmp/partdisk-cfO/unpack/jhost_core-1.0-1706080443.x86_64.rpm to /tmp/partdisk-cfO/jrootfs/hostd ...
+        Installing Hostd image jhost_core-1.0-1706080443.x86_64.rpm ...
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs/ --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs//var/lib/rpm /tmp/partdisk-cfO/unpack/jhost_core-1.0-1706080443.x86_64.rpm
+        Preparing...                ##################################################
+        jhost_core                  ##################################################
+        Please wait while configuration is in progress...
+        Installation successful...
+        Done with hostd Install
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs/var/lib/rpm /tmp/partdisk-cfO/unpack/re_fpga-1.0-0.x86_64.rpm
+        Preparing...                ##################################################
+        preparing install ...
+        re_fpga                     ##################################################
+        adding module to kernel...
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs/var/lib/rpm /tmp/partdisk-cfO/unpack/vsmartd-1.0-0.x86_64.rpm
+        Preparing...                ##################################################
+        preparing install ...
+        vsmartd                     ##################################################
+        adding module to kernel...
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs/var/lib/rpm /tmp/partdisk-cfO/unpack/resild-1.0-0.x86_64.rpm
+        Preparing...                ##################################################
+        preparing install ...
+        resild                      ##################################################
+        adding module to kernel...
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs/var/lib/rpm /tmp/partdisk-cfO/unpack/rasdaemon-0.5.6-1.x86_64.rpm
+        Preparing...                ##################################################
+        rasdaemon                   ##################################################
+        Installing Monit image monit-5.12.2-1.x86_64.rpm ...
+        rpm -ivh --prefix=/tmp/partdisk-cfO/jrootfs/ --nodeps --dbpath=/tmp/partdisk-cfO/jrootfs//var/lib/rpm /tmp/partdisk-cfO/unpack/monit-5.12.2-1.x86_64.rpm
+        Preparing...                ##################################################
+        monit                       ##################################################
+        Installation successful...
+        Done with Monit Install...
+        Target kernel version: 3.10.79-ovp-rt74-WR6.0.0.20_preempt-rt
+        Creating moint points for JUNOSFS and VMFS: /junos, /vm
+        Updating boot partition...
+        Upgrade complete.
+        Cmos Write successfull
+        Cmos Write successfull for Boot_retry
+        Cmos Write successfull for Boot_retry
+        ... upgrade complete.
+        A REBOOT IS REQUIRED TO LOAD THIS SOFTWARE CORRECTLY.
+        Use the 'request vmhost reboot' command to reboot the system.
+    </output>
+    <package-result>0</package-result>
+</rpc-reply>

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -170,7 +170,7 @@ class TestSW(unittest.TestCase):
         mock_md5.return_value = '96a35ab371e1ca10408c3caecdbd8a67'
         mock_execute.side_effect = self._mock_manager
         self.sw.put = MagicMock()
-        self.sw._mixed_VC=True
+        self.sw._mixed_VC = True
         self.assertTrue(self.sw.install(
                             pkg_set=['safecopy.tgz', 'safecopy.tgz',
                                      'ftp://server/path/test.tgz']))
@@ -485,6 +485,12 @@ class TestSW(unittest.TestCase):
             self.sw.remote_checksum(package, algorithm='sha256'),
             '27bccf64babe4ea6687d3461e6d724d165aa140933e77b582af615dad4f02170')
 
+    def test_sw_remote_checksum_unknown_alg(self):
+        self.assertRaises(ValueError,
+                          self.sw.remote_checksum,
+                          'foo.tgz',
+                          algorithm='foo')
+
     @patch('jnpr.junos.Device.execute')
     def test_sw_safe_copy(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
@@ -615,8 +621,14 @@ class TestSW(unittest.TestCase):
         sw = self.get_sw()
         sw.install(package='abc.tgz', no_copy=True)
         self.assertFalse(sw._multi_VC)
-        calls = [call('/var/tmp/abc.tgz', dev_timeout=1800, re0=True),
-                 call('/var/tmp/abc.tgz', dev_timeout=1800, re1=True)]
+        calls = [call('/var/tmp/abc.tgz',
+                      dev_timeout=1800,
+                      vmhost=False,
+                      re0=True),
+                 call('/var/tmp/abc.tgz',
+                      dev_timeout=1800,
+                      re1=True,
+                      vmhost=False)]
         mock_pkgadd.assert_has_calls(calls)
 
     @patch('jnpr.junos.utils.sw.SW.pkgadd')
@@ -671,6 +683,12 @@ class TestSW(unittest.TestCase):
     @patch('jnpr.junos.utils.sw.SW.pkgadd')
     def test_sw_install_mixed_vc_TypeError(self, mock_pkgadd):
         self.assertRaises(TypeError, self.sw.install, cleanfs=False)
+
+    @patch('jnpr.junos.Device.execute')
+    def test_sw_install_vmhost(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        package = 'test.tgz'
+        self.assertTrue(self.sw.install(package, no_copy=True, vmhost=True))
 
     @patch('jnpr.junos.Device.execute')
     def test_sw_install_kwargs_force_host(self, mock_execute):
@@ -863,3 +881,7 @@ class TestSW(unittest.TestCase):
                 return self._read_file('request-reboot-at.xml')
             else:
                 return self._read_file(args[0].tag + '.xml')
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestSW)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Some Junos REs/platforms run Junos in a VM on a Linux host os. On those platforms, `junos-vmhost-* ` packages are published which upgrade both the Linux host os and the Junos VM. These `junos-vmhost-*` packages are installed with a different NETCONF RPC, `<request-vmhost-package-add>`.

Adding a new `vmhost` parameter to `SW.install()` if `vmhost=True` is specified, then the package is installed using the `<request-vmhost-package-add>` RPC. If `vmhost=False` (the default), then the package continues to be installed with the `<request-vmhost-package-add>` RPC.