### PR TITLE
fix python2/3 compatibility

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -320,9 +320,8 @@ class _RpcMetaExec(object):
                     if not isinstance(arg_value, (tuple, list)):
                         arg_value = [arg_value]
                     for a in arg_value:
-                        if ((sys.version < '3' and
-                           not isinstance(a, (bool, str, unicode))) or
-                           not isinstance(a, (bool, str))):
+                        if not isinstance(a, (bool, str, unicode)
+                                          if sys.version < '3' else (bool, str)):
                             raise TypeError("The value %s for argument %s"
                                             " is of %s. Argument "
                                             "values must be a string, "


### PR DESCRIPTION
The former code does not allow python 2 unicode strings.
Because of the "OR" the second "isinstance" is evaluated
for python 2 and 3 but should be used for python 3 only.

### OLD:
```python
>>> sys.version
'2.7.10 (default, Feb  7 2017, 00:08:15) \n[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]'
>>> type(a)
<type 'unicode'>
>>> (sys.version < '3' and not isinstance(a, (bool, str, unicode))) or not isinstance(a, (bool, str))
True
```

### NEW: 
```python
>>> not isinstance(a, (bool, str, unicode) if sys.version < '3' else (bool, str))
False
```