### PR TITLE
SRX Branch cluster fails SW.install().

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -972,7 +972,7 @@ class SW(Util):
         else:
             cmd = E('request-reboot', E('at', str(at)))
 
-        if all_re is True :
+        if all_re is True:
             if self._multi_RE is True and self._multi_VC is False:
                 cmd.append(E('both-routing-engines'))
             elif self._mixed_VC is True:

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -876,7 +876,9 @@ class SW(Util):
                     "NSSU: installing software ... please be patient ...")
                 return self.pkgaddNSSU(remote_package,
                                        dev_timeout=timeout, **kwargs)
-            elif self._multi_RE is False or all_re is False:
+            elif (self._multi_RE is False or all_re is False or
+                  (self._dev.facts.get('personality','') == 'SRX_BRANCH' and
+                   self._dev.facts.get('srx_cluster') is True)):
                 # simple case of single RE upgrade.
                 _progress("installing software ... please be patient ...")
                 add_ok = self.pkgadd(

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.1.7.dev0"
-DATE = "2017-Aug-31"
+VERSION = "2.1.7.dev1"
+DATE = "2017-Sep-23"
 
 # Augment with the internal version if present
 try:

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
 VERSION = "2.1.7.dev1"
-DATE = "2017-Sep-23"
+DATE = "2017-Sep-25"
 
 # Augment with the internal version if present
 try:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:2] == (2, 6):
 setup(
     name="junos-eznc",
     namespace_packages=['jnpr'],
-    version="2.1.7.dev0",
+    version="2.1.7.dev1",
     author="Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith",
     author_email="jnpr-community-netdev@juniper.net",
     description=("Junos 'EZ' automation for non-programmers"),

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -198,7 +198,7 @@ class TestSW(unittest.TestCase):
     @patch('jnpr.junos.Device.execute')
     def test_sw_install_srx_branch_cluster(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        self.sw._multi_RE = True
+        self.sw._multi_RE = False
         self.sw._dev.facts['personality'] = 'SRX_BRANCH'
         self.sw._dev.facts['srx_cluster'] = True
         self.assertTrue(self.sw.install('test.tgz', no_copy=True))

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -194,6 +194,15 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = False
         self.assertTrue(self.sw.install('test.tgz', no_copy=True))
 
+
+    @patch('jnpr.junos.Device.execute')
+    def test_sw_install_srx_branch_cluster(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        self.sw._multi_RE = True
+        self.sw._dev.facts['personality'] = 'SRX_BRANCH'
+        self.sw._dev.facts['srx_cluster'] = True
+        self.assertTrue(self.sw.install('test.tgz', no_copy=True))
+
     @patch('jnpr.junos.Device.execute')
     def test_sw_install_no_package_result(self, mock_execute):
         mock_execute.side_effect = self._mock_manager


### PR DESCRIPTION
On SRX branch devices configured in an SRX cluster, `SW.install()`
fails because it recognizes the cluster as `'2RE' == True`, and attempts
to upgrade both REs. However, this product doesn't not support the
`re0` and `re1` arguments.

This change avoids attempting to upgrade both REs of the cluster,
even when `all_re = True`.