### PR TITLE
Support Junos version fact for QFX/EX-series devices in FIPS mode.

### DIFF
--- a/lib/jnpr/junos/facts/get_software_information.py
+++ b/lib/jnpr/junos/facts/get_software_information.py
@@ -25,6 +25,9 @@ def _get_software_information(device):
             pass
         try:
             sw_info = device.rpc.get_software_information(normalize=True)
+        except Exception:
+            sw_info = True
+        try:
             if sw_info is True:
                 # Possibly an NFX which requires 'local' and 'detail' args.
                 sw_info = device.rpc.get_software_information(local=True,

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.1.8dev0"
-DATE = "2017-Sep-30"
+VERSION = "2.1.8dev1"
+DATE = "2017-Nov-14"
 
 # Augment with the internal version if present
 try:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:2] == (2, 6):
 setup(
     name="junos-eznc",
     namespace_packages=['jnpr'],
-    version="2.1.8dev0",
+    version="2.1.8dev1",
     author="Jeremy Schulman, Nitin Kumar, Rick Sherman, Stacy Smith",
     author_email="jnpr-community-netdev@juniper.net",
     description=("Junos 'EZ' automation for non-programmers"),


### PR DESCRIPTION
QFX/EX-series devices in FIPS mode require the `<local/>` tag to `<get-software-information>` and return an `<rpc-error>` if it's not present. This change handles this behavior.