### PR TITLE
Handle bound methods as progress callback to SCP(). Fixes #803

### DIFF
--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -43,7 +43,7 @@ class SCP(object):
             # https://github.com/jbardin/scp.py/blob/master/scp.py#L97
             spec = inspect.getargspec(self._user_progress)
             if ((len(spec.args) == 3 and spec.args[0] != 'self') or
-                (len(spec.args) == 4 and spec.args[0] == 'self'):
+                (len(spec.args) == 4 and spec.args[0] == 'self')):
                 self._scpargs['progress'] = self._user_progress
             else:
                 # this will override the function _progress defined for this

--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -42,7 +42,8 @@ class SCP(object):
             # expects. Function will take path, total size, transferred.
             # https://github.com/jbardin/scp.py/blob/master/scp.py#L97
             spec = inspect.getargspec(self._user_progress)
-            if len(spec.args) == 3:
+            if ((len(spec.args) == 3 and spec.args[0] != 'self') or
+                (len(spec.args) == 4 and spec.args[0] == 'self'):
                 self._scpargs['progress'] = self._user_progress
             else:
                 # this will override the function _progress defined for this


### PR DESCRIPTION
Correctly checks if `self.user_progress` is a function which accepts 3 parameters or a bound method (has first argument of `self`) which takes 4 parameters.

See #803 for additional analysis of the problem being fixed.