### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
@@ -16,7 +15,6 @@ addons:
     - libxslt1-dev
 
 install:
-  - if [ "$TRAVIS_PYTHON_VERSION" == "2.6" ]; then pip install importlib; fi
   - "pip install -r development.txt"
   - "pip install -r requirements.txt"
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ As of release 2.0.0, _Junos PyEZ_ requires [ncclient](https://pypi.python.org/py
 
 ## PIP
 
-Installation requires Python 2.6 or 2.7 or >=3.4 and associated `pip` tool
+Installation requires Python 2.7 or >=3.4 and associated `pip` tool
 
     pip install junos-eznc
 

--- a/lib/jnpr/junos/__init__.py
+++ b/lib/jnpr/junos/__init__.py
@@ -12,17 +12,6 @@ import json
 import yaml
 import logging
 
-import sys
-import warnings
-
-if sys.version_info[:2] == (2, 6):
-    warnings.warn(
-        "Python 2.6 is no longer supported by the Python core team, please "
-        "upgrade your Python. A future version of PyEZ will drop "
-        "support for Python 2.6",
-        DeprecationWarning
-    )
-
 __version__ = version.VERSION
 __date__ = version.DATE
 

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -188,13 +188,13 @@ class Console(_Connection):
         try:
             self._tty_login()
         except RuntimeError as err:
-            logger.error("ERROR:  {0}:{1}\n".format('login', str(err)))
+            logger.error("ERROR:  {}:{}\n".format('login', str(err)))
             logger.error(
-                "\nComplete traceback message: {0}".format(
+                "\nComplete traceback message: {}".format(
                     traceback.format_exc()))
             raise err
         except Exception as ex:
-            logger.error("Exception occurred: {0}:{1}\n".format('login',
+            logger.error("Exception occurred: {}:{}\n".format('login',
                                                                 str(ex)))
             raise ex
         self.connected = True
@@ -232,16 +232,16 @@ class Console(_Connection):
                 if "telnet connection closed" not in str(err):
                     raise err
             except Exception as err:
-                logger.error("ERROR {0}:{1}\n".format('logout', str(err)))
+                logger.error("ERROR {}:{}\n".format('logout', str(err)))
                 raise err
             self.connected = False
         elif self.connected is True:
             try:
                 self._tty._tty_close()
             except Exception as err:
-                logger.error("ERROR {0}:{1}\n".format('close', str(err)))
+                logger.error("ERROR {}:{}\n".format('close', str(err)))
                 logger.error(
-                    "\nComplete traceback message: {0}".format(
+                    "\nComplete traceback message: {}".format(
                         traceback.format_exc()))
                 raise err
             self.connected = False

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -69,7 +69,7 @@ class RpcError(Exception):
           pprints the response XML attribute
         """
         if self.rpc_error is not None:
-            return "{0}(severity: {1}, bad_element: {2}, message: {3})"\
+            return "{}(severity: {}, bad_element: {}, message: {})"\
                 .format(self.__class__.__name__, self.rpc_error['severity'],
                         self.rpc_error['bad_element'], self.message)
         else:
@@ -88,7 +88,7 @@ class CommitError(RpcError):
         RpcError.__init__(self, cmd, rsp, errs)
 
     def __repr__(self):
-        return "{0}(edit_path: {1}, bad_element: {2}, message: {3})"\
+        return "{}(edit_path: {}, bad_element: {}, message: {})"\
             .format(self.__class__.__name__, self.rpc_error['edit_path'],
                     self.rpc_error['bad_element'], self.message)
 
@@ -105,7 +105,7 @@ class ConfigLoadError(RpcError):
         RpcError.__init__(self, cmd, rsp, errs)
 
     def __repr__(self):
-        return "{0}(severity: {1}, bad_element: {2}, message: {3})"\
+        return "{}(severity: {}, bad_element: {}, message: {})"\
             .format(self.__class__.__name__, self.rpc_error['severity'],
                     self.rpc_error['bad_element'], self.message)
 
@@ -159,7 +159,7 @@ class RpcTimeoutError(RpcError):
         RpcError.__init__(self, dev=dev, cmd=cmd, timeout=timeout)
 
     def __repr__(self):
-        return "{0}(host: {1}, cmd: {2}, timeout: {3})"\
+        return "{}(host: {}, cmd: {}, timeout: {})"\
             .format(self.__class__.__name__, self.dev.hostname,
                     self.cmd, self.timeout)
 
@@ -177,10 +177,10 @@ class SwRollbackError(RpcError):
 
     def __repr__(self):
         if self.re:
-            return "{0}(re: {1}, output: {2})"\
+            return "{}(re: {}, output: {})"\
                 .format(self.__class__.__name__, self.re, self.rsp)
         else:
-            return "{0}(output: {1})".format(self.__class__.__name__,
+            return "{}(output: {})".format(self.__class__.__name__,
                                              self.rsp)
 
     __str__ = __repr__
@@ -225,11 +225,11 @@ class ConnectError(Exception):
 
     def __repr__(self):
         if self._orig:
-            return "{0}(host: {1}, msg: {2})".format(self.__class__.__name__,
+            return "{}(host: {}, msg: {})".format(self.__class__.__name__,
                                                      self.dev.hostname,
                                                      self._orig)
         else:
-            return "{0}({1})".format(self.__class__.__name__,
+            return "{}({})".format(self.__class__.__name__,
                                      self.dev.hostname)
 
     __str__ = __repr__
@@ -318,11 +318,11 @@ class JSONLoadError(Exception):
 
     def __repr__(self):
         if self.offending_line:
-            return "{0}(reason: {1}, \nThe offending config appears " \
-                   "to be: \n{2})".format(self.__class__.__name__, self.ex_msg,
+            return "{}(reason: {}, \nThe offending config appears " \
+                   "to be: \n{})".format(self.__class__.__name__, self.ex_msg,
                                           self.offending_line)
         else:
-            return "{0}(reason: {1})" \
+            return "{}(reason: {})" \
                 .format(self.__class__.__name__, self.ex_msg)
 
     __str__ = __repr__

--- a/lib/jnpr/junos/factory/cfgtable.py
+++ b/lib/jnpr/junos/factory/cfgtable.py
@@ -267,12 +267,12 @@ class CfgTable(Table):
 
     def _grindxpath(self, key_xpath, key_value):
         """ returns xpath elements for key values """
-        simple = lambda: "[{0}='{1}']".format(
+        simple = lambda: "[{}='{}']".format(
             key_xpath.replace('_', '-'),
             key_value
         )
-        composite = lambda: "[{0}]".format(' and '.join(
-                            ["{0}='{1}'".format(xp.replace('_', '-'), xv)
+        composite = lambda: "[{}]".format(' and '.join(
+                            ["{}='{}'".format(xp.replace('_', '-'), xv)
                                 for xp, xv in zip(key_xpath, key_value)]))
         return simple() if isinstance(key_xpath, str) else composite()
 
@@ -319,7 +319,7 @@ class CfgTable(Table):
                 dot.insert(_at, _add)
 
             # Add required key values to _get_xpath
-            xid = re.search(r"\b{0}\b".format(key_name),
+            xid = re.search(r"\b{}\b".format(key_name),
                             self._get_xpath).start() + len(key_name)
 
             self._get_xpath = self._get_xpath[:xid] + \

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -297,7 +297,7 @@ class Table(object):
 
         def get_xpath(find_value):
             namekey_xpath, item_xpath = self._keyspec()
-            xnkv = '[{0}="{1}"]'
+            xnkv = '[{}="{}"]'
 
             if isinstance(find_value, str):
                 # find by name, simple key

--- a/lib/jnpr/junos/factory/viewfields.py
+++ b/lib/jnpr/junos/factory/viewfields.py
@@ -63,7 +63,7 @@ class ViewFields(object):
         field is an apply group, results in value of group attr if the xpath
         element has the associated group attribute.
         """
-        xpath = './{0}/@group'.format(xpath)
+        xpath = './{}/@group'.format(xpath)
         return self.astype(name, xpath, str, **kvargs)
 
     def table(self, name, table):

--- a/lib/jnpr/junos/ofacts/routing_engines.py
+++ b/lib/jnpr/junos/ofacts/routing_engines.py
@@ -41,7 +41,7 @@ def facts_routing_engines(junos, facts):
         for member_id in vc_info.xpath(
                 ".//member-role[starts-with(.,'Master')]"
                 "/preceding-sibling::member-id"):
-            master.append("RE{0}".format(member_id.text))
+            master.append("RE{}".format(member_id.text))
 
     try:
         re_info = junos.rpc.get_route_engine_information()
@@ -70,7 +70,7 @@ def facts_routing_engines(junos, facts):
             m = RE.search('(\d)', x_re_name[0].text)
             if vc_info is not None:
                 # => RE0-RE0 | RE0-RE1
-                re_name = "RE{0}-RE{1}".format(m.group(0),
+                re_name = "RE{}-RE{}".format(m.group(0),
                                                re.find('slot').text)
             else:
                 re_name = "RE" + m.group(0)   # => RE0 | RE1

--- a/lib/jnpr/junos/ofacts/swver.py
+++ b/lib/jnpr/junos/ofacts/swver.py
@@ -47,10 +47,10 @@ def facts_software_version(junos, facts):
         versions = []
 
         if isinstance(f_master, list):
-            xpath = './multi-routing-engine-item[re-name="{0}"]/software-' \
+            xpath = './multi-routing-engine-item[re-name="{}"]/software-' \
                     'information/host-name'.format(f_master[0].lower())
         else:
-            xpath = './multi-routing-engine-item[re-name="{0}"' \
+            xpath = './multi-routing-engine-item[re-name="{}"' \
                     ']/software-information/host-name'.format(f_master.lower())
 
         facts['hostname'] = x_swver.findtext(xpath)

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -102,7 +102,7 @@ class Terminal(object):
         open the TTY connection and login.  once the login is successful,
         start the NETCONF XML API process
         """
-        logger.info('TTY: connecting to TTY:{0} ...'.format(self.tty_name))
+        logger.info('TTY: connecting to TTY:{} ...'.format(self.tty_name))
         self._tty_open()
 
         logger.info('TTY: logging in......')

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -112,8 +112,8 @@ class tty_netconf(object):
           performing by this routine.
         """
         if not cmd.startswith('<'):
-            cmd = '<{0}/>'.format(cmd)
-        rpc = six.b('<rpc>{0}</rpc>'.format(cmd))
+            cmd = '<{}/>'.format(cmd)
+        rpc = six.b('<rpc>{}</rpc>'.format(cmd))
         logger.info('Calling rpc: %s' % rpc)
         self._tty.rawwrite(rpc)
 

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -44,7 +44,7 @@ class Serial(Terminal):
         try:
             self._ser.open()
         except OSError as err:
-            raise RuntimeError("open_failed:{0}".format(err.strerror))
+            raise RuntimeError("open_failed:{}".format(err.strerror))
         self.write('\n\n\n')      # hit <ENTER> a few times, yo!
 
     def _tty_close(self):

--- a/lib/jnpr/junos/transport/tty_telnet.py
+++ b/lib/jnpr/junos/transport/tty_telnet.py
@@ -45,7 +45,7 @@ class Telnet(Terminal):
         self.port = port
         self.timeout = kvargs.get('timeout', self.TIMEOUT)
         self.baud = kvargs.get('baud', 9600)
-        self._tty_name = "{0}:{1}".format(host, port)
+        self._tty_name = "{}:{}".format(host, port)
 
         Terminal.__init__(self, **kvargs)
 
@@ -62,7 +62,7 @@ class Telnet(Terminal):
             except Exception:
                 retry -= 1
                 logger.info(
-                    "TTY busy: checking back in {0} ...".format(
+                    "TTY busy: checking back in {} ...".format(
                         self.RETRY_BACKOFF))
                 sleep(self.RETRY_BACKOFF)
         else:

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -714,7 +714,7 @@ class Config(Util):
                 return False
 
         def _unsupported_action():
-            raise ValueError("unsupported action: {0}".format(action))
+            raise ValueError("unsupported action: {}".format(action))
 
         result = {
             'get': _rescue_get,
@@ -809,7 +809,7 @@ class Config(Util):
 
         def _unsupported_option():
             if self.mode is not None:
-                raise ValueError("unsupported action: {0}".format(self.mode))
+                raise ValueError("unsupported action: {}".format(self.mode))
 
         if self.kwargs.get('ephemeral_instance'):
             ephemeral_kwargs = {

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -61,7 +61,7 @@ class StartShell(object):
                 if isinstance(data, bytes):
                     data = data.decode('utf-8', 'replace')
                 got.append(data)
-                if this is not None and re.search(r'{0}\s?$'.format(this),
+                if this is not None and re.search(r'{}\s?$'.format(this),
                                                   data):
                     break
         return got
@@ -146,8 +146,8 @@ class StartShell(object):
         if this is None:
             self.last_ok = got is not ''
         elif this != _SHELL_PROMPT:
-            self.last_ok = re.search(r'{0}\s?$'.format(this), got) is not None
-        elif re.search(r'{0}\s?$'.format(_SHELL_PROMPT), got) is not None:
+            self.last_ok = re.search(r'{}\s?$'.format(this), got) is not None
+        elif re.search(r'{}\s?$'.format(_SHELL_PROMPT), got) is not None:
             # use $? to get the exit code of the command
             self.send('echo $?')
             rc = ''.join(self.wait_for(_SHELL_PROMPT))

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -901,7 +901,7 @@ class SW(Util):
                             x).group(1) for x in self._RE_list]
                     for vc_id in vc_members:
                         _progress(
-                            "installing software on VC member: {0} ... please "
+                            "installing software on VC member: {} ... please "
                             "be patient ...".format(vc_id))
                         ok &= self.pkgadd(
                             remote_package,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'jnpr.junos.cfgro': ['*.yml'],
         'jnpr.junos.resources': ['*.yml']
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=install_reqs,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -36,8 +37,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Closes https://github.com/Juniper/py-junos-eznc/pull/806.

Python 2.6 is EOL and no longer receiving security updates. Due to this, dependencies have already dropped it and breaking the build.

Here's the pip installs for junos-eznc from PyPI for last month, showing it's also little used.


| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   71.8% |          6,535 |
| 3.5            |   10.5% |            958 |
| 3.6            |    9.1% |            825 |
| 3.4            |    8.4% |            763 |
| 2.6            |    0.2% |             21 |
| 3.3            |    0.1% |              5 |
| 3.7            |    0.0% |              1 |

Source: `pypinfo --start-date -46 --end-date -16 --percent --pip --markdown junos-eznc pyversion`