### PR TITLE
Support inactive and active options in table view configuration

### DIFF
--- a/lib/jnpr/junos/factory/cfgtable.py
+++ b/lib/jnpr/junos/factory/cfgtable.py
@@ -246,7 +246,7 @@ class CfgTable(Table):
                         'to field %s.\n' % (value, field_name)
                     )
 
-        if isinstance(value, dict) and 'operation' in value:
+        if isinstance(value, dict):
             # in case user want to pass operation attr for ex:
             # <unit operation="delete"/>
             pass
@@ -287,7 +287,7 @@ class CfgTable(Table):
                 lst.append(E(xpath.replace('_', '-')))
             elif value is False:
                 lst.append(E(xpath.replace('_', '-'), {'operation': 'delete'}))
-        elif isinstance(value, dict) and 'operation' in value:
+        elif isinstance(value, dict):
             lst.append(E(xpath.replace('_', '-'), value))
         else:
             lst.append(E(xpath.replace('_', '-'), str(value)))


### PR DESCRIPTION
# Table/view config:

```
---
UserConfigTable2:
  set: system/login
  key-field:
    - username
  view: UserConfigView2

UserConfigView2:
  groups:
    auth: authentication
  fields:
    user: user
    username: user/name
    classname: { user/class : { 'type' : { 'enum' : ['operator', 'read-only', 'super-user'] }} }
    uid: { user/uid : { 'type' : 'int', 'minValue' : 100, 'maxValue' : 64000 } }
  fields_auth:
    password: user/encrypted-passwordcd py
```

# Login user config :

[edit]
user@host# show system login                 
user user2 {
    uid 1004;
    class super-user;
}

# Inactivate user config:
```
uc = UserConfigTable2(dev)
uc.username = 'user2'
uc.user = {'inactive':'inactive'}
uc.append()
uc.set()
```
```
<configuration>
  <system>
    <login>
      <user inactive="inactive">
        <name>user2</name>
        <class>super-user</class>
        <uid>1004</uid>
      </user>
    </login>
  </system>
</configuration>
```
[edit]
user@host# show system login    
inactive: user user2 {
    uid 1004;
    class super-user;
}

# Activate user config:
```
uc = UserConfigTable2(dev)
uc.username = 'user2'
uc.user = {'active':'active'}
uc.append()
uc.set()
```
```
<configuration>
  <system>
    <login>
      <user active="active">
        <name>user2</name>
        <class>super-user</class>
        <uid>1004</uid>
      </user>
    </login>
  </system>
</configuration>
```
[edit]
user@host# show system login    
user user2 {
    uid 1004;
    class super-user;
}

# Delete user config:
```
uc = UserConfigTable2(dev)
uc.username = 'user2'
uc.user = {'operation':'delete'}
uc.append()
uc.set()
```
```
<configuration>
  <system>
    <login>
      <user operation="delete">
        <name>user2</name>
      </user>
    </login>
  </system>
</configuration>
```
[edit]
user@host# show system login    

[edit]
user@host#