### PR TITLE
Get configuration from device failed, through PyEZ with customize table and view, mode telnet

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -72,6 +72,10 @@ _Jinja2ldr = jinja2.Environment(loader=_MyTemplateLoader())
 
 class _Connection(object):
 
+    ON_JUNOS = platform.system().upper() == 'JUNOS' or \
+        platform.release().startswith('JNPR')
+    auto_probe = 0          # default is no auto-probe
+
     # ------------------------------------------------------------------------
     # property: hostname
     # ------------------------------------------------------------------------
@@ -990,9 +994,6 @@ class Device(_Connection):
             dev.open()   # this will probe before attempting NETCONF connect
 
     """
-    ON_JUNOS = platform.system().upper() == 'JUNOS' or \
-        platform.release().startswith('JNPR')
-    auto_probe = 0          # default is no auto-probe
 
     # -------------------------------------------------------------------------
     # PROPERTIES


### PR DESCRIPTION
Issue is fixed by assigning on_junos variable in global level.

```
---
LinkMapTable:
  get: interfaces/interface
  args_key: interface_name
  view: UserView

UserView:
  fields:
    interface_name: name
    unit_id: unit/name
    ip_address: unit/family/inet/address/name

```

```python
dev = Device(host='x.x.x.x', user='user', password='pass',mode='telnet',port=23).open()         
name = LinkMapTable(dev)                                                                                     
name.get()                                                                                                   
for namelist in name:                                                                                        
     print namelist.interface_name                                                                           
                                                                               
```
```
Output:
lo0
fxp0
```