### PR TITLE
fix pdiff rpc timeout exception #830

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -224,6 +224,8 @@ class Config(Util):
             rsp = self.rpc.get_configuration(dict(
                 compare='rollback', rollback=str(rb_id), format='text'
             ))
+        except RpcTimeoutError:
+            raise 
         except RpcError as err:
             if (err.rpc_error['severity'] == 'warning' and
                 err.message == "mgd: statement must contain additional "


### PR DESCRIPTION

```python
from jnpr.junos import Device
from jnpr.junos.utils.config import Config
dev = Device(host='x.x.x.x', user='usr', password='pass')
dev.open()
dev.timeout = 0.1
cu = Config(dev)
data = """interfaces { 
    x-1/0/1 {
        description "interface";
        unit 0 {
            family x;
        }      
    }     
}
"""
cu.pdiff()
```

```
Traceback (most recent call last):
  File "/automation_development/pyez/pyez_example/unittest/myTables/mytest.py", line 17, in <module>
    cu.pdiff()
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/utils/config.py", line 251, in pdiff
    print (self.diff(rb_id))
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/utils/config.py", line 225, in diff
    compare='rollback', rollback=str(rb_id), format='text'
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/rpcmeta.py", line 345, in _exec_rpc
    return self._junos.execute(rpc, **dec_args)
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/decorators.py", line 76, in wrapper
    return function(*args, **kwargs)
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/decorators.py", line 31, in wrapper
    return function(*args, **kwargs)
  File "/automation_development/pyez/pyez_vir/lib/python2.7/site-packages/jnpr/junos/device.py", line 778, in execute
    raise EzErrors.RpcTimeoutError(self, rpc_cmd_e.tag, self.timeout)
jnpr.junos.exception.RpcTimeoutError: RpcTimeoutError(host: x.x.x.x, cmd: get-configuration, timeout: 0)

```