### PR TITLE
Fix for XML tag being recognized as cli prompt.

### DIFF
--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -271,5 +271,3 @@ class Terminal(object):
         else:
             # if we are here, then loop the event again
             self._login_state_machine(attempt + 1)
-
-        _ev_tbl.get()

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -52,7 +52,7 @@ class Terminal(object):
         '(?P<badpasswd>ogin incorrect)',
         '(?P<netconf_closed><!-- session end at .*-->\s*)',
         '(?P<shell>%|#\s*$)',
-        '(?P<cli>[^\\-"]>\s*$)',
+        '(?P<cli>[^/\-"]>\s*$)',
         '(?P<option>Enter your option:\s*$)',
         '(?P<hotkey>connection: <CTRL>Z)',
     ]
@@ -271,3 +271,5 @@ class Terminal(object):
         else:
             # if we are here, then loop the event again
             self._login_state_machine(attempt + 1)
+
+        _ev_tbl.get()


### PR DESCRIPTION
The 'cli' pattern in the _RE_PAT is matching an xml tag like `<solo-tag/>` as if it is the cli prompt host_name>. This has caused the login state machine to fail on console connections when connecting back to a console where an RPC call has initiated a reboot.

The following shows the change in behavior from a python shell session.
Current code:
`>>> _re_pat_login = '(?P<login>ogin:\s*$)'\s`
`>>> _RE_PAT = [ `
`...    '(?P<loader>oader>\s*$)',`
`...    _re_pat_login,`
`...    '(?P<passwd>assword:\s*$)',`
`...    '(?P<badpasswd>ogin incorrect)',`
`...    '(?P<netconf_closed><!-- session end at .*-->\s*)',`
`...    '(?P<shell>%|#\s*$)',`
`...    '(?P<cli>[^\\-"]>\s*$)',`
`...    '(?P<option>Enter your option:\s*$)',`
`...    '(?P<hotkey>connection: <CTRL>Z)',`
`... ]`
`>>> _PROMPT = re.compile(six.b('|').join([six.b(i) for i in _RE_PAT]))`
`>>> test_str = "<a_tag> 'Tag text'</a_tag> <solo_tag/>"`
`>>> found = _PROMPT.search(test_str)`
`>>> print found.lastgroup`
cli

New code changing the 'cli' pattern:

`>>> _RE_PAT = [`
`...     '(?P<loader>oader>\s*$)',`
`...     _re_pat_login,`
`...     '(?P<passwd>assword:\s*$)',`
`...     '(?P<badpasswd>ogin incorrect)',`
`...     '(?P<netconf_closed><!-- session end at .*-->\s*)',`
`...     '(?P<shell>%|#\s*$)',`
`...     '(?P<cli>[^/\-"]>\s*$)',`
`...     '(?P<option>Enter your option:\s*$)',`
`...     '(?P<hotkey>connection: <CTRL>Z)',`
`... ]`
`>>> _PROMPT = re.compile(six.b('|').join([six.b(i) for i in _RE_PAT]))`
`>>> test_str = "<a_tag> 'Tag text'</a_tag> <solo_tag/>"`
`>>> found = _PROMPT.search(test_str)`
`>>> print found.lastgroup`
Traceback (most recent call last):
  File "<input>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'lastgroup'

Which is correct behavior, the tag is not recognized as the cli prompt.
