### PR TITLE
Update Shell prompts string patterns with '$' for bourne-style shell

### DIFF
--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -4,7 +4,7 @@ import re
 import datetime
 
 _JUNOS_PROMPT = '> '
-_SHELL_PROMPT = '(%|#)\s'
+_SHELL_PROMPT = '(%|#|$)\s'
 _SELECT_WAIT = 0.1
 _RECVSZ = 1024
 
@@ -97,7 +97,7 @@ class StartShell(object):
         self._client = client
         self._chan = chan
 
-        got = self.wait_for(r'(%|>|#)')
+        got = self.wait_for(r'(%|>|#|$)')
         if got[-1].endswith(_JUNOS_PROMPT):
             self.send('start shell')
             self.wait_for(_SHELL_PROMPT)


### PR DESCRIPTION
We have some JUNOS MX routers in the lab which require the user drop to bourne-style shell:

```
Last login: Sun Aug 19 11:05:14 2018 from 10.104.40.145
--- JUNOS 15.1R5.5 Kernel 64-bit  JNPR-10.3-20160927.337663_build
$
```

When using the `StartShell()` class to run commands against these devices, the 30 second default timeout kicks in during connection and for each run of a command to collect.  This causes the script to run quite longer than needed.

I've added the `$` prompt in 2 places so that session `.open()` and command `.run()` now work as expected with Bourne-style shell.  I've tested this in a script to two different devices, one with Bourne-style and one normal (operational mode `>`) with success.

Please consider adding.