### PR TITLE
Console ssh via device class through Device class

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -201,6 +201,7 @@ class Console(_Connection):
             self.results[
                 'errmsg'] = 'ERROR: Console SSH, Password-less connection is ' \
                             'not supported !!!'
+            logger.error(self.results['errmsg'])
             return self.results
 
         # --------------------

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -185,10 +185,22 @@ class Console(_Connection):
         # ---------------------------------------------------------------
         # validate device hostname or IP address
         # ---------------------------------------------------------------
-        if ((self._mode and self._mode.upper() == 'TELNET') or self.cs_user is not None) and self._hostname is None:
+        if ((self._mode and self._mode.upper() == 'TELNET') or
+                    self.cs_user is not None) and self._hostname is None:
             self.results['failed'] = True
             self.results[
                 'errmsg'] = 'ERROR: Device hostname/IP not specified !!!'
+            return self.results
+
+        # ---------------------------------------------------------------
+        # validate console server and password. Password-less connection
+        # is not supported
+        # ---------------------------------------------------------------
+        if self.cs_user is not None and self.cs_passwd is None:
+            self.results['failed'] = True
+            self.results[
+                'errmsg'] = 'ERROR: Console SSH, Password-less connection is ' \
+                            'not supported !!!'
             return self.results
 
         # --------------------

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1025,7 +1025,8 @@ class Device(_Connection):
     # -----------------------------------------------------------------------
 
     def __new__(cls, *args, **kwargs):
-        if kwargs.get('port') in [23, '23'] or kwargs.get('mode'):
+        if kwargs.get('port') in [23, '23'] or kwargs.get('mode') or \
+                        kwargs.get('cs_user') is not None:
             from jnpr.junos.console import Console
             instance = object.__new__(Console, *args, **kwargs)
             # Python only calls __init__() if the object returned from

--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -186,7 +186,7 @@ class SSH(Terminal):
                 timeout = time() + self.READ_PROMPT_DELAY
         else:
             return None, None
-
+        logger.debug('Got: %s' % rxb)
         return rxb, found.lastgroup
 
     def _read_until(self, match, timeout=None):

--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -30,6 +30,7 @@ class SSH(Terminal):
     RETRY_BACKOFF = 2  # seconds to wait between retries
     MAX_BUFFER = 65535
     READ_PROMPT_DELAY = 10.0
+    RECVSZ = 1024
 
     def __init__(self, host, port, **kvargs):
         """
@@ -151,7 +152,7 @@ class SSH(Terminal):
         """ read a single line """
         rxb = six.b('')
         while True:
-            data = self._ssh.recv(1)
+            data = self._ssh.recv(self.RECVSZ)
             if data is None or len(data) <= 0:
                 raise ValueError('Unable to detect device prompt')
             elif PY6.NEW_LINE in data:
@@ -178,7 +179,7 @@ class SSH(Terminal):
             rd, _, _ = select.select([self._ssh], [], [], 0.1)
             sleep(0.05)
             if rd:
-                rxb += self._ssh.recv(1)
+                rxb += self._ssh.recv(self.RECVSZ)
                 found = _PROMPT.search(rxb)
                 if found is not None:
                     break

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -634,22 +634,18 @@ class TestConfig(unittest.TestCase):
             self.dev.rpc.commit_configuration()
         except Exception as ex:
             self.assertTrue(isinstance(ex, RpcError))
-            if ncclient.__version__ > (0, 4, 5):
-                self.assertEqual(ex.message,
-                                 "error: interface-range 'axp' is not defined\n"
-                                 "error: interface-ranges expansion failed")
-                self.assertEqual(ex.errs, [
-                    {'source': None, 'message':
-                        "interface-range 'axp' is not defined",
-                     'bad_element': None, 'severity': 'error',
-                     'edit_path': None},
-                    {'source': None,
-                     'message': 'interface-ranges expansion failed',
-                     'bad_element': None, 'severity': 'error',
-                     'edit_path': None}])
-            else:
-                self.assertEqual(ex.message,
-                                 "interface-range 'axp' is not defined")
+            self.assertEqual(ex.message,
+                             "error: interface-range 'axp' is not defined\n"
+                             "error: interface-ranges expansion failed")
+            self.assertEqual(ex.errs, [
+                {'source': None, 'message':
+                    "interface-range 'axp' is not defined",
+                 'bad_element': None, 'severity': 'error',
+                 'edit_path': None},
+                {'source': None,
+                 'message': 'interface-ranges expansion failed',
+                 'bad_element': None, 'severity': 'error',
+                 'edit_path': None}])
 
     @patch('jnpr.junos.utils.config.Config.lock')
     @patch('jnpr.junos.utils.config.Config.unlock')
@@ -823,10 +819,7 @@ class TestConfig(unittest.TestCase):
             raw = etree.XML(foo)
             obj = RPCReply(raw)
             obj.parse()
-            if ncclient.__version__ > (0, 4, 5):
-                raise RPCError(etree.XML(foo), errs=obj._errors)
-            else:
-                raise RPCError(etree.XML(foo))
+            raise RPCError(etree.XML(foo), errs=obj._errors)
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:


### PR DESCRIPTION
Example for usage:

```python
from jnpr.junos import Device
import logging

logging.basicConfig(level=logging.DEBUG)

with Device(host="xx.xx.xx.xx", user="xxx", passwd="xxx", cs_user='xxxx', cs_passwd='xxx') as dev:
    print(dev.cli("show version"))
```