### PR TITLE
Change Receive Size to 1 for transport_ssh

### DIFF
--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -30,7 +30,7 @@ class SSH(Terminal):
     RETRY_BACKOFF = 2  # seconds to wait between retries
     MAX_BUFFER = 65535
     READ_PROMPT_DELAY = 10.0
-    RECVSZ = 1024
+    RECVSZ = 1
 
     def __init__(self, host, port, **kvargs):
         """


### PR DESCRIPTION
Fix for #877 
Based on @mzbroch, received size must be 1 for this library to work