### PR TITLE
Added a 'Search' function to PyEZ Tables and Views

### DIFF
--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -78,14 +78,15 @@ class FactoryLoader(object):
             return x != value_rhs
         return false_test
     
-    def _fieldfunc_Search(self, pattern):
-        def search_text(text):
-            ''' Searches for first occurrence of pattern within text.'''
-            if re.search(pattern,text, re.M|re.I):
-                return  re.search(pattern,text, re.M|re.I).groups()[0]
+    def _fieldfunc_Search(self, regex_pattern):
+        def search_field(field_text):
+            ''' Returns the first occurrence of regex_pattern within given field_text.'''
+            match = re.search(regex_pattern,field_text)
+            if match:
+                return  match.groups()[0]
             else:
                 return	None
-        return search_text
+        return search_field
 
     def _add_dictfield(self, fields, f_name, f_dict, kvargs):
         """ add a field based on its associated dictionary """

--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -77,6 +77,12 @@ class FactoryLoader(object):
                                                x)) else True
             return x != value_rhs
         return false_test
+    
+    def _fieldfunc_Search(self, pattern):
+        def search_text(text):
+            ''' Searches for first occurrence of pattern within text.'''
+            return  re.search(pattern,text, re.M|re.I).groups(1)[0]
+        return search_text
 
     def _add_dictfield(self, fields, f_name, f_dict, kvargs):
         """ add a field based on its associated dictionary """

--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -81,7 +81,10 @@ class FactoryLoader(object):
     def _fieldfunc_Search(self, pattern):
         def search_text(text):
             ''' Searches for first occurrence of pattern within text.'''
-            return  re.search(pattern,text, re.M|re.I).groups(1)[0]
+            if re.search(pattern,text, re.M|re.I):
+                return  re.search(pattern,text, re.M|re.I).groups()[0]
+            else:
+                return	None
         return search_text
 
     def _add_dictfield(self, fields, f_name, f_dict, kvargs):


### PR DESCRIPTION
I wanted Junos PyEZ Tables and Views to Regex a field. 
For Example, if the returned xml had the following element:

```
...
<interface-set-name>ae100-8080</interface-set-name>
...
```

With the new 'Search' function added to Factory_loader, it is now possible to extract the 'ae100' part. 
The PyEZ view will look like:

```
myView:
 fields:
  lag:  { interface-set-name : Search=(ae.+)- }
```