### PR TITLE
optimize docker image size by combining layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ ADD lib lib
 ## Install dependancies and Pyez
 RUN apk add --no-cache build-base python3-dev py-lxml \
     libxslt-dev libxml2-dev libffi-dev openssl-dev curl \
-    ca-certificates openssl wget 
-RUN pip3 install -r requirements.txt
-RUN apk del -r --purge gcc make g++ \
+    ca-certificates openssl wget \
+    && pip3 install -r requirements.txt \
+    && apk del -r --purge gcc make g++ \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && python setup.py install \
     && rm -rf /source/* \


### PR DESCRIPTION
Minor change in Dockerfile leads to much smaller image:

```
$ docker images|grep pyez
juniper/pyez          latest         ce7a1f35bd6e      5 minutes ago     135MB
juniper/pyez          2.2.0          6d2aa1c085ac      2 months ago      283MB
```
