### PR TITLE
create generalized function for new ssh-client

### DIFF
--- a/lib/jnpr/junos/utils/scp.py
+++ b/lib/jnpr/junos/utils/scp.py
@@ -3,6 +3,7 @@ import inspect
 
 import paramiko
 from scp import SCPClient
+from jnpr.junos.utils.ssh_client import open_ssh_client
 
 """
 Secure Copy Utility
@@ -30,6 +31,8 @@ class SCP(object):
         :param kvargs scpargs: any additional args to be passed to paramiko SCP
         """
         self._junos = junos
+        self._ssh = None
+
         if self._junos.__dict__.get('_mode') is not None:
             raise RuntimeError('SCP is not supported with Console mode')
         self._scpargs = scpargs
@@ -79,39 +82,7 @@ class SCP(object):
 
         :returns: SCPClient object
         """
-        # @@@ should check for multi-calls to connect to ensure we don't keep
-        # @@@ opening new connections
-        junos = self._junos
-        self._ssh = paramiko.SSHClient()
-        self._ssh.load_system_host_keys()
-        self._ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-        # use junos._hostname since this will be correct if we are going
-        # through a jumphost.
-
-        config = {}
-        kwargs = {}
-        ssh_config = getattr(junos, '_sshconf_path')
-        if ssh_config:
-            config = paramiko.SSHConfig()
-            config.parse(open(ssh_config))
-            config = config.lookup(junos._hostname)
-        sock = None
-        if config.get("proxycommand"):
-            sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
-
-        if self._junos._ssh_private_key_file is not None:
-            kwargs['key_filename'] = self._junos._ssh_private_key_file
-
-        self._ssh.connect(hostname=junos._hostname,
-                          port=(
-                              22, int(
-                                  junos._port))[
-                              junos._hostname == 'localhost'],
-                          username=junos._auth_user,
-                          password=junos._auth_password,
-                          sock=sock, **kwargs
-                          )
+        self._ssh = open_ssh_client(junos=self._junos)
         return SCPClient(self._ssh.get_transport(), **scpargs)
 
     def close(self):

--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -1,0 +1,45 @@
+import paramiko
+
+
+def open_ssh_client(junos):
+    """
+    This function is used to return a new paramiko SSH client that uses the same login method &
+    credentials as the original Junos device instance.  The purpose of this function is to provide
+    the caller with the complete paramiko library of functionality based on the returned SSH client.
+
+    :param junos: jnpr.junos.Device instance
+    :return: paramiko.SSHClient instance
+    """
+
+    # note, the following code was extracted from the scp module, and then the scp module
+    # was refactored to use this function
+
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    config = {}
+    kwargs = {}
+    ssh_config = getattr(junos, '_sshconf_path')
+
+    if ssh_config:
+        config = paramiko.SSHConfig()
+        config.parse(open(ssh_config))
+        config = config.lookup(junos._hostname)
+
+    sock = None
+
+    if config.get("proxycommand"):
+        sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
+
+    if junos._ssh_private_key_file is not None:
+        kwargs['key_filename'] = junos._ssh_private_key_file
+
+    use_port = int(junos._port) if junos._hostname == 'localhost' else 22
+
+    client.connect(hostname=junos._hostname, port=use_port,
+                   username=junos._auth_user,
+                   password=junos._auth_password,
+                   sock=sock, **kwargs)
+
+    return client


### PR DESCRIPTION
open_ssh_client(device) was created so that a developer can create a new paramiko SSH client based on an existing device credentials.  By providing this function, the developer can then create any new connections to the Junos device, for example an SCP client or a SFTP client. 

This PR includes refactoring the existing scp module to use this new function.