### PR TITLE
Junos fact support json serialization

### DIFF
--- a/lib/jnpr/junos/factory/to_json.py
+++ b/lib/jnpr/junos/factory/to_json.py
@@ -2,6 +2,7 @@ from jnpr.junos.jxml import strip_comments_transform
 import json
 from lxml import etree
 from copy import deepcopy
+import collections
 
 
 class TableJSONEncoder(json.JSONEncoder):
@@ -53,6 +54,8 @@ class PyEzJSONEncoder(json.JSONEncoder):
             # JSON does not support comments - strip them
             obj = strip_comments_transform(deepcopy(obj)).getroot()
             _, obj = recursive_dict(obj)
+        elif isinstance(obj, collections.MutableMapping):
+            obj = {k: v for k, v in obj.items()}
         else:
             obj = super(PyEzJSONEncoder, self).default(obj)
         return obj


### PR DESCRIPTION
```
import json
from jnpr.junos import Device
from jnpr.junos.exception import ConnectError
dev = Device(host='x.x.x.x', user='xxx', password='xxx', gather_facts=False)
try:
    dev.open()
except ConnectError as err:
    print ("Cannot connect to device: {0}".format(err))
    sys.exit(1)
print json.dumps(dev.facts)
dev.close()
```

### Output
{"domain": "englab.juniper.net", "hostname_info": {"re0": "rabbit", "re1": "rabbit"}, "version_RE1": "17.4", "version_RE0": "17.4", "re_master": {"default": "0"}.........}