### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Installing from Git is also supported (OS must have git installed).
 
 Move to the local directory which contains your script(s) and run the container
 
-`docker run -it --rm --name pyez -v $PWD:/scripts juniper/pyez sh`
+`docker run -it --rm --name pyez -v "$(pwd)":/scripts juniper/pyez sh`
 
 Your local scripts will be mounted to /scripts in the container
 


### PR DESCRIPTION
The provided docker example causes an error when mapping paths with spaces. Using -v "$(pwd)":/scripts is more correct as per https://docs.docker.com/storage/bind-mounts/