### PR TITLE
add at parameter to SW.poweroff()

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1005,7 +1005,7 @@ class SW(Util):
     # poweroff - system shutdown
     # -------------------------------------------------------------------------
 
-    def poweroff(self, in_min=0, on_node=None):
+    def poweroff(self, in_min=0, at=None, on_node=None):
         """
         Perform a system shutdown, with optional delay (in minutes) .
 
@@ -1013,6 +1013,9 @@ class SW(Util):
         rebooted.  This code also handles EX/QFX VC.
 
         :param int in_min: time (minutes) before shutting down the device.
+
+        :param str at: date and time the poweroff should take place. The
+            string must match the junos cli poweroff syntax
 
         :param str on_node: In case of linux based device, function will by default
             shutdown the whole device. If any specific node is mentioned,
@@ -1035,7 +1038,10 @@ class SW(Util):
             cmd = E('request-power-off')
             if self._multi_RE is True and self._multi_VC is False:
                 cmd.append(E('both-routing-engines'))
-        cmd.append(E('in', str(in_min)))
+        if in_min >= 0 and at is None:
+            cmd.append(E('in', str(in_min)))
+        else:
+            cmd.append(E('at', str(at)))
         try:
             rsp = self.rpc(cmd)
             if self._dev.facts['_is_linux']:


### PR DESCRIPTION
SW.reboot() supports **at** parameter. but SW.poweroff() does not support.
This patch add **at** parameter to SW.poweroff().
Thank you. 