### PR TITLE
Table view key null

### DIFF
--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -133,6 +133,10 @@ class Table(object):
                                                      key_value.split(' | ')]))
             return self._keys_simple(xpath + '/' + key_value)
 
+        # user explicitly passed key as Null in Table
+        if key_value is None:
+            return []
+
         if not isinstance(key_value, list):
             raise RuntimeError(
                 "What to do with key, table:'%s'" %

--- a/lib/jnpr/junos/factory/to_json.py
+++ b/lib/jnpr/junos/factory/to_json.py
@@ -15,7 +15,13 @@ class TableJSONEncoder(json.JSONEncoder):
         if isinstance(obj, View):
             obj = dict(obj.items())
         elif isinstance(obj, Table):
-            obj = dict((str(item.name), item) for item in obj)
+            ret = dict()
+            for item in obj:
+                if isinstance(item.name, list) and len(item.name) == 0:
+                    ret.update(item)
+                else:
+                    ret[str(item.name)] = item
+            return ret
         else:
             obj = super(TableJSONEncoder, self).default(obj)
         return obj

--- a/lib/jnpr/junos/factory/view.py
+++ b/lib/jnpr/junos/factory/view.py
@@ -78,7 +78,8 @@ class View(object):
     def name(self):
         """ return the name of view item """
         if self.ITEM_NAME_XPATH is None:
-            return self._table.D.hostname
+            return []
+            # return self._table.D.hostname
         if isinstance(self.ITEM_NAME_XPATH, str):
             # xpath union key
             if ' | ' in self.ITEM_NAME_XPATH:

--- a/tests/unit/factory/test_view.py
+++ b/tests/unit/factory/test_view.py
@@ -46,7 +46,7 @@ class TestFactoryView(unittest.TestCase):
 
     def test_view_name_xpath_none(self):
         self.v.ITEM_NAME_XPATH = None
-        self.assertEqual(self.v.name, '1.1.1.1')
+        self.assertEqual(self.v.name, [])
 
     def test_view_name_xpath_composite(self):
         self.v.ITEM_NAME_XPATH = ['name', 'missing', 'admin-status']


### PR DESCRIPTION
In PyEZ Table/View we need to provide key even when the xml output is pretty simple (for example show below). If user doesn’t provide, we assume key as “name”
```
<aaa-module-statistics>
        <aaa-module-accounting-statistics>
            <requests>4599084</requests>
            <timeouts>47</timeouts>
            <accounting-response-failures>31905</accounting-response-failures>
            <accounting-response-success>4567132</accounting-response-success>
        </aaa-module-accounting-statistics>
    </aaa-module-statistics>
 ```
I am trying out a change, where if user provide explicit key: Null (None in yaml is Null), then Table/View would consider xml response where key is not needed and return simple data/dict/json rather than nested one.
 
Below example is old style where we provide a dummy key. For above rpc ouput key doesn’t make sense.
```yaml
---
accountingStats:
  rpc: get-aaa-module-statistics
  args:
    accounting: True
  key: requests
  item: aaa-module-accounting-statistics
  view: accountingStatsView

accountingStatsView:
  fields:
    requests: {requests: int}
    timeouts: {timeouts: int}
    failures: {accounting-response-failures: int}
    success: {accounting-response-success: int}
 ```
Hence the o/p is nested.
 ```json
{'4599084': {'failures': 31905,
             'requests': 4599084,
             'success': 4567132,
             'timeouts': 47}}
 ```
Proposed change
```yaml
---
accountingStats:
  rpc: get-aaa-module-statistics
  args:
    accounting: True
  key: Null
  item: aaa-module-accounting-statistics
  view: accountingStatsView

accountingStatsView:
  fields:
    requests: {requests: int}
    timeouts: {timeouts: int}
    failures: {accounting-response-failures: int}
    success: {accounting-response-success: int}
 ```
Simple output
 ```json
{'failures': 31905, 'requests': 4599084, 'success': 4567132, 'timeouts': 47}
 ```
Similarly another example for software information
```yaml
---
SoftInfoTable:
  rpc: get-software-information
  item: .
  key: Null
  view: SoftInfoView

SoftInfoView:
  fields:
    host-name: host-name
    product-model: product-model
    junos-version: junos-version
 ```
```json
{'host-name': 'eza',
'junos-version': '18.4-20180905_dev_common.1',
'product-model': 'mx960'}
```
 