### PR TITLE
Replaced "python setup.py install" with "pip3 install" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache build-base python3-dev py-lxml \
     && pip3 install -r requirements.txt \
     && apk del -r --purge gcc make g++ \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && python setup.py install \
+    && pip3 install . \
     && rm -rf /source/* \
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Because `junos-eznc` is a namespaced package, installing it with `python setup.py install` does not correctly generate `.pth` files in `/var/lib/python3.6/site-packages/`.
If other packages that belong to the `jnpr` package are installed with `pip` (which is almost always the case), the namespace mechanism breaks and imports fail.
Replacing `python setup.py install` with `pip3 install .` fixes this issue.