### PR TITLE
Adds allow_agent option to Device() object

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1109,6 +1109,10 @@ class Device(_Connection):
         :param bool normalize:
             *OPTIONAL* default is ``False``.  If ``True`` then the
             XML returned by :meth:`execute` will have whitespace normalized
+
+        :param bool allow_agent:
+            *OPTIONAL* default is ``False``.  If ``True`` then the
+            SSH config file is not parsed by Pyez and passed down to ncclient
         """
 
         # ----------------------------------------
@@ -1123,6 +1127,7 @@ class Device(_Connection):
         self._normalize = kvargs.get('normalize', False)
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
         self._fact_style = kvargs.get('fact_style', 'new')
+        self.allow_agent = kvargs.get('allow_agent', False)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in a future '
                           'release.' %
@@ -1155,10 +1160,14 @@ class Device(_Connection):
             self._ssh_config = kvargs.get('ssh_config')
             self._sshconf_lkup()
             # but if user or private key is explicit from call, then use it.
-            self._auth_user = kvargs.get('user') or self._conf_auth_user or \
-                self._auth_user
-            self._ssh_private_key_file = kvargs.get('ssh_private_key_file') \
-                or self._conf_ssh_private_key_file
+            if self.allow_agent is True:
+                self._auth_user = kvargs.get('user')
+                self._ssh_private_key_file = kvargs.get('ssh_private_key_file')
+            else:
+                self._auth_user = kvargs.get('user') or self._conf_auth_user or \
+                                  self._auth_user
+                self._ssh_private_key_file = kvargs.get('ssh_private_key_file') \
+                                             or self._conf_ssh_private_key_file
             self._auth_password = kvargs.get(
                 'password') or kvargs.get('passwd')
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1254,10 +1254,12 @@ class Device(_Connection):
         try:
             ts_start = datetime.datetime.now()
 
-            # we want to enable the ssh-agent if-and-only-if we are
-            # not given a password or an ssh key file.
-            # in this condition it means we want to query the agent
-            # for available ssh keys
+            # if allow_agent is provided in the call, then the same
+            # value is passed to the ncclient.
+            # if allow_agent isn't provided in the call, then it is
+            # set to True if we are not able to find password or
+            # ssh_keyfile. user provided allow_agent value should be
+            # preferred over the runtime value
 
             if self._allow_agent is None:
                 allow_agent = bool((self._auth_password is None) and

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1113,6 +1113,10 @@ class Device(_Connection):
         :param bool allow_agent:
             *OPTIONAL* default is ``False``.  If ``True`` then the
             SSH config file is not parsed by Pyez and passed down to ncclient
+
+        .. note::
+            value of allow_agent may change to ``True``, in case the user passes
+            ``False`` without specifying **passwd** or **ssh_private_key_file**
         """
 
         # ----------------------------------------


### PR DESCRIPTION
### Problem
User currently cannot control the value of `allow_agent` being passed to ncclient.connect().

### Analysis
PyEZ internally sets the value of `allow_agent` before passing it to ncclient. It is set to `True` only if PyEZ cannot gather the `passwd` or `ssh_private_keyfile`. 

In case the user has not specified `passwd` or `ssh_private_keyfile`, PyEZ will use the `ssh_config` to populate the variables. In this case, since PyEZ is able to gather the credentials `allow_agent` is set to `False`. 

The above logic works fine for a simpler SSH configuration, where only `ssh_private_keyfile`, `port`  and `user` are mentioned int SSH configuration, any additional options mentioned in the file are ignored. 

### Solution

To add a new optional argument `bool allow_agent`. There are 3 cases:

1.  `allow_agent is True`: PyEZ will not load the values of ssh_private_key_file or passwd and allow_agent will be passed as True to ncclient.connect().

2. `allow_agent is Fale`: PyEZ will load the values of above variables if it is able to gather and allow_agent will be passed as False to ncclient.connect().

3. `allow_agent is not provided`: PyEZ will fallback to default behavior and set the value of allow_agent at runtime, based on whether it is able to gather the credentials or not.

**_Note_: PyEZ will prefer the user-provided value of `allow_agent` over the runtime value**

Related issues:
#648 
