### PR TITLE
improve StartShell support for Bourne shell

### DIFF
--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -97,7 +97,7 @@ class StartShell(object):
         self._client = client
         self._chan = chan
 
-        got = self.wait_for(r'(%|>|#)')
+        got = self.wait_for(r'(%|>|#|\$)')
         if got[-1].endswith(_JUNOS_PROMPT):
             self.send('start shell')
             self.wait_for(_SHELL_PROMPT)
@@ -151,7 +151,7 @@ class StartShell(object):
             # use $? to get the exit code of the command
             self.send('echo $?')
             rc = ''.join(self.wait_for(_SHELL_PROMPT))
-            self.last_ok = rc.find('0') > 0
+            self.last_ok = rc.find('\r\n0\r\n') > 0
         return (self.last_ok, got)
 
     # -------------------------------------------------------------------------

--- a/tests/unit/utils/test_start_shell.py
+++ b/tests/unit/utils/test_start_shell.py
@@ -23,7 +23,7 @@ class TestStartShell(unittest.TestCase):
     def test_startshell_open_with_shell_term(self, mock_wait, mock_connect):
         mock_wait.return_value = ["user # "]
         self.shell.open()
-        mock_wait.assert_called_with('(%|>|#)')
+        mock_wait.assert_called_with('(%|>|#|\\$)')
 
     @patch('paramiko.SSHClient')
     @patch('jnpr.junos.utils.start_shell.StartShell.wait_for')
@@ -31,6 +31,13 @@ class TestStartShell(unittest.TestCase):
         mock_wait.return_value = ["user > "]
         self.shell.open()
         mock_wait.assert_called_with('(%|#|\\$)\\s')
+
+    @patch('paramiko.SSHClient')
+    @patch('jnpr.junos.utils.start_shell.StartShell.wait_for')
+    def test_startshell_open_with_bourne_shell(self, mock_wait, mock_connect):
+        mock_wait.return_value = ["foo@bar:~$ "]
+        self.shell.open()
+        mock_wait.assert_called_with('(%|>|#|\\$)')
 
     @patch('paramiko.SSHClient')
     def test_startshell_close(self, mock_connect):


### PR DESCRIPTION
two things in this merge request
1) add Bourne shell prompt to wait_for to prevent unnecessary wait for cmd to return
2) if hostname contains a '0', and the shell prints the hostname as part of StartShell.run() rc, then last_ok will always be True. 

Please consider merging this patch, thanks!