### PR TITLE
Junos sax parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 install:
   - "pip install -r development.txt"
   - "pip install -r requirements.txt"
-  - "pip install -U git+https://github.com/vnitinv/ncclient.git@rm_ns_without_xslt"
+  - "pip install -U git+https://github.com/vnitinv/ncclient.git@sax-parser"
 
 script: nosetests -v --with-coverage --cover-package=jnpr.junos --cover-inclusive -a unit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 install:
   - "pip install -r development.txt"
   - "pip install -r requirements.txt"
-  - "pip install -U git+https://github.com/vnitinv/ncclient.git@sax-parser"
+  - "pip install -U git+https://github.com/vnitinv/ncclient.git@junos-sax-parser"
 
 script: nosetests -v --with-coverage --cover-package=jnpr.junos --cover-inclusive -a unit
 

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -269,7 +269,7 @@ class Console(_Connection):
             self.connected = False
 
     @ignoreWarnDecorator
-    def _rpc_reply(self, rpc_cmd_e):
+    def _rpc_reply(self, rpc_cmd_e, *args, **kwargs):
         encode = None if sys.version < '3' else 'unicode'
         rpc_cmd = etree.tostring(rpc_cmd_e, encoding=encode) \
             if isinstance(rpc_cmd_e, etree._Element) else rpc_cmd_e

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -175,17 +175,17 @@ def ignoreWarnDecorator(function):
 def checkSAXParserDecorator(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
-        use_sax_parser = kwargs.pop('use_sax_parser', False)
-        if use_sax_parser:
+        use_filter = kwargs.pop('use_filter', False)
+        if use_filter:
             # args[0] is self
-            restore_value = args[0]._use_sax_parser
-            args[0]._use_sax_parser = True
+            restore_value = args[0]._use_filter
+            args[0]._filter_xml = True
             try:
                 result = function(*args, **kwargs)
-                args[0]._use_sax_parser = restore_value
+                args[0]._use_filter = restore_value
                 return result
             except Exception:
-                args[0]._use_sax_parser = restore_value
+                args[0]._use_filter = restore_value
                 raise
         else:
             try:

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -175,21 +175,15 @@ def ignoreWarnDecorator(function):
 def checkSAXParserDecorator(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
-        use_filter = kwargs.pop('use_filter', False)
-        if use_filter:
-            # args[0] is self
-            restore_value = args[0]._use_filter
-            args[0]._filter_xml = True
-            try:
-                result = function(*args, **kwargs)
-                args[0]._use_filter = restore_value
-                return result
-            except Exception:
-                args[0]._use_filter = restore_value
-                raise
-        else:
-            try:
-                return function(*args, **kwargs)
-            except Exception:
-                raise
+        # args[0] is self
+        use_filter = kwargs.pop('use_filter', args[0]._use_filter)
+        restore_value = args[0]._use_filter
+        args[0]._use_filter = use_filter
+        try:
+            result = function(*args, **kwargs)
+            args[0]._use_filter = restore_value
+            return result
+        except Exception:
+            args[0]._use_filter = restore_value
+            raise
     return wrapper

--- a/lib/jnpr/junos/decorators.py
+++ b/lib/jnpr/junos/decorators.py
@@ -170,3 +170,26 @@ def ignoreWarnDecorator(function):
         return rsp
 
     return wrapper
+
+
+def checkSAXParserDecorator(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        use_sax_parser = kwargs.pop('use_sax_parser', False)
+        if use_sax_parser:
+            # args[0] is self
+            restore_value = args[0]._use_sax_parser
+            args[0]._use_sax_parser = True
+            try:
+                result = function(*args, **kwargs)
+                args[0]._use_sax_parser = restore_value
+                return result
+            except Exception:
+                args[0]._use_sax_parser = restore_value
+                raise
+        else:
+            try:
+                return function(*args, **kwargs)
+            except Exception:
+                raise
+    return wrapper

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -771,7 +771,9 @@ class _Connection(object):
 
         try:
             rpc_rsp_e = self._rpc_reply(rpc_cmd_e,
-                                        ignore_warning=ignore_warning)
+                                        ignore_warning=ignore_warning,
+                                        sax_parser_ingest=kvargs.get(
+                                            'sax_parser_ingest'))
         except NcOpErrors.TimeoutExpiredError:
             # err is a TimeoutExpiredError from ncclient,
             # which has no such attribute as xml.
@@ -1336,8 +1338,8 @@ class Device(_Connection):
                 self.connected = False
 
     @ignoreWarnDecorator
-    def _rpc_reply(self, rpc_cmd_e):
-        return self._conn.rpc(rpc_cmd_e)._NCElement__doc
+    def _rpc_reply(self, rpc_cmd_e, sax_parser_ingest=None):
+        return self._conn.rpc(rpc_cmd_e, sax_parser_ingest)._NCElement__doc
 
     # -----------------------------------------------------------------------
     # Context Manager

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -772,8 +772,8 @@ class _Connection(object):
         try:
             rpc_rsp_e = self._rpc_reply(rpc_cmd_e,
                                         ignore_warning=ignore_warning,
-                                        sax_parser_ingest=kvargs.get(
-                                            'sax_parser_ingest'))
+                                        filter_xml=kvargs.get(
+                                            'filter_xml'))
         except NcOpErrors.TimeoutExpiredError:
             # err is a TimeoutExpiredError from ncclient,
             # which has no such attribute as xml.
@@ -1338,8 +1338,8 @@ class Device(_Connection):
                 self.connected = False
 
     @ignoreWarnDecorator
-    def _rpc_reply(self, rpc_cmd_e, sax_parser_ingest=None):
-        return self._conn.rpc(rpc_cmd_e, sax_parser_ingest)._NCElement__doc
+    def _rpc_reply(self, rpc_cmd_e, filter_xml=None):
+        return self._conn.rpc(rpc_cmd_e, filter_xml)._NCElement__doc
 
     # -----------------------------------------------------------------------
     # Context Manager

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1115,6 +1115,11 @@ class Device(_Connection):
         :param bool normalize:
             *OPTIONAL* default is ``False``.  If ``True`` then the
             XML returned by :meth:`execute` will have whitespace normalized
+
+        :param bool use_filter:
+            *OPTIONAL* To choose between SAX and DOM parsing.
+            default is ``True`` to use SAX.  Select ``False`` to use DOM.
+
         """
 
         # ----------------------------------------
@@ -1129,6 +1134,7 @@ class Device(_Connection):
         self._normalize = kvargs.get('normalize', False)
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
         self._fact_style = kvargs.get('fact_style', 'new')
+        self._use_filter = kvargs.get('use_filter', True)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in a future '
                           'release.' %
@@ -1263,8 +1269,9 @@ class Device(_Connection):
                 key_filename=self._ssh_private_key_file,
                 allow_agent=allow_agent,
                 ssh_config=self._sshconf_lkup(),
-                device_params={'name': 'junos', 'local':
-                    self.__class__.ON_JUNOS})
+                device_params={'name': 'junos',
+                               'local': self.__class__.ON_JUNOS,
+                               'use_filter': self._use_filter})
             self._conn._session.add_listener(DeviceSessionListener(self))
         except NcErrors.AuthenticationError as err:
             # bad authentication credentials

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1119,8 +1119,8 @@ class Device(_Connection):
 
         :param bool use_filter:
             *OPTIONAL* To choose between SAX and DOM parsing.
-            default is ``True`` to use SAX (if SAX input is provided).
-            Select ``False`` to use DOM.
+            default is ``False`` to use DOM.
+            Select ``True`` to use SAX (if SAX input is provided).
 
         """
 
@@ -1136,7 +1136,7 @@ class Device(_Connection):
         self._normalize = kvargs.get('normalize', False)
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
         self._fact_style = kvargs.get('fact_style', 'new')
-        self._use_filter = kvargs.get('use_filter', True)
+        self._use_filter = kvargs.get('use_filter', False)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in a future '
                           'release.' %

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1118,7 +1118,8 @@ class Device(_Connection):
 
         :param bool use_filter:
             *OPTIONAL* To choose between SAX and DOM parsing.
-            default is ``True`` to use SAX.  Select ``False`` to use DOM.
+            default is ``True`` to use SAX (if SAX input is provided).
+            Select ``False`` to use DOM.
 
         """
 

--- a/lib/jnpr/junos/factory/factory_cls.py
+++ b/lib/jnpr/junos/factory/factory_cls.py
@@ -82,13 +82,15 @@ def FactoryCMDChildTable(title=None, regex=None,
     return new_cls
 
 
-def FactoryTable(item, key=Table.ITEM_NAME_XPATH, view=None, table_name=None):
+def FactoryTable(item, key=Table.ITEM_NAME_XPATH, view=None, table_name=None,
+                 use_filter=True):
     if table_name is None:
         table_name = 'Table.' + item
     new_cls = type(table_name, (Table,), {})
     new_cls.ITEM_XPATH = item
     new_cls.ITEM_NAME_XPATH = key
     new_cls.VIEW = view
+    new_cls.USE_FILTER = use_filter
     new_cls.__module__ = __name__.replace('factory_cls', 'Table')
     return new_cls
 

--- a/lib/jnpr/junos/factory/factory_cls.py
+++ b/lib/jnpr/junos/factory/factory_cls.py
@@ -26,7 +26,8 @@ def FactoryCfgTable(table_name=None, data_dict={}):
 
 
 def FactoryOpTable(cmd, args=None, args_key=None, item=None,
-                   key=OpTable.ITEM_NAME_XPATH, view=None, table_name=None):
+                   key=OpTable.ITEM_NAME_XPATH, view=None, table_name=None,
+                   use_filter=True):
     if table_name is None:
         table_name = "OpTable." + cmd
     new_cls = type(table_name, (OpTable,), {})
@@ -37,6 +38,7 @@ def FactoryOpTable(cmd, args=None, args_key=None, item=None,
     new_cls.ITEM_XPATH = item
     new_cls.ITEM_NAME_XPATH = key
     new_cls.VIEW = view
+    new_cls.USE_FILTER = use_filter
     new_cls.__module__ = __name__.replace('factory_cls', 'OpTable')
     return new_cls
 

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -98,7 +98,13 @@ def generate_sax_parser_input(obj):
     Returns: lxml etree object to be used as sax parser input
 
     """
-    parser_ingest = E(obj.ITEM_XPATH, E(obj.ITEM_NAME_XPATH))
+    if '/' in obj.ITEM_XPATH:
+        tags = obj.ITEM_XPATH.split('/')
+        parser_ingest = E(tags.pop(-1), E(obj.ITEM_NAME_XPATH))
+        for tag in tags[::-1]:
+            parser_ingest = E(tag, parser_ingest)
+    else:
+        parser_ingest = E(obj.ITEM_XPATH, E(obj.ITEM_NAME_XPATH))
     local_field_dict = deepcopy(obj.VIEW.FIELDS)
     # first make element out of group fields
     if obj.VIEW.GROUPS:

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -68,7 +68,7 @@ class OpTable(Table):
                 filter_xml = generate_sax_parser_input(self)
                 rpc_args['filter_xml'] = filter_xml
             except ValueError as ex:
-                logger.warning("Not able to create SAX parser input due to "
+                logger.debug("Not able to create SAX parser input due to "
                                "'%s'" % ex)
 
         self.D.transform = lambda: remove_namespaces_and_spaces

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -92,14 +92,14 @@ def generate_sax_parser_input(obj):
     """
     parser_ingest = E(obj.ITEM_XPATH, E(obj.ITEM_NAME_XPATH))
     # first make element out of group fields
-    for group in obj.VIEW.GROUPS:
+    for group, group_xpath in obj.VIEW.GROUPS.items():
         local_field_dict = deepcopy(obj.VIEW.FIELDS)
         # need to pop out group items so that it wont be reused
         # with fields
         group_field_dict = ({k: obj.VIEW.FIELDS.pop(k)
                              for k, v in local_field_dict.items()
                              if v.get('group') == group})
-        group_ele = E(group)
+        group_ele = E(group_xpath)
         for key, val in group_field_dict.items():
             group_ele.append(E(val.get('xpath')))
         # print (etree.tostring(group_ele))

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -119,5 +119,14 @@ def generate_sax_parser_input(obj):
             child_table = field_dict.get('table')
             parser_ingest.insert(i + 1, generate_sax_parser_input(child_table))
         else:
-            parser_ingest.insert(i + 1, E(field_dict.get('xpath')))
+            xpath = field_dict.get('xpath')
+            # xpath can be multi level, for ex traffic-statistics/input-pps
+            if '/' in xpath:
+                tags = xpath.split('/')
+                obj = E(tags[0])
+                for tag in tags[1:]:
+                    obj.append(E(tag))
+                parser_ingest.insert(i + 1, obj)
+            else:
+                parser_ingest.insert(i + 1, E(xpath))
     return parser_ingest

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -67,7 +67,7 @@ class OpTable(Table):
             try:
                 filter_xml = generate_sax_parser_input(self)
                 rpc_args['filter_xml'] = filter_xml
-            except ValueError as ex:
+            except Exception as ex:
                 logger.debug("Not able to create SAX parser input due to "
                                "'%s'" % ex)
 

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -1,10 +1,13 @@
+from copy import deepcopy
+
 # 3rd-party
 from lxml import etree
+from lxml.builder import E
 
 # local
 from jnpr.junos.factory.table import Table
 from jnpr.junos.jxml import remove_namespaces, remove_namespaces_and_spaces
-
+from jnpr.junos.decorators import checkSAXParserDecorator
 
 class OpTable(Table):
 
@@ -12,6 +15,7 @@ class OpTable(Table):
     # PUBLIC METHODS
     # -------------------------------------------------------------------------
 
+    @checkSAXParserDecorator
     def get(self, *vargs, **kvargs):
         """
         Retrieve the XML table data from the Device instance and
@@ -54,6 +58,11 @@ class OpTable(Table):
         argkey = vargs[0] if len(vargs) else None
 
         rpc_args = {}
+
+        if self._use_filter:
+            filter_xml = generate_sax_parser_input(self)
+            rpc_args['filter_xml'] = filter_xml
+
         self.D.transform = lambda: remove_namespaces_and_spaces
         rpc_args.update(self.GET_ARGS)    # copy default args
         # saltstack get_table pass args as named keyword
@@ -70,3 +79,34 @@ class OpTable(Table):
 
         # returning self for call-chaining purposes, yo!
         return self
+
+
+def generate_sax_parser_input(obj):
+    """
+    Used to generate xml object from Table/view to be used in SAX parsing
+    Args:
+        obj: self object which cantains table/view details
+
+    Returns: lxml etree object to be used as sax parser input
+
+    """
+    parser_ingest = E(obj.ITEM_XPATH, E(obj.ITEM_NAME_XPATH))
+    # first make element out of group fields
+    for group in obj.VIEW.GROUPS:
+        local_field_dict = deepcopy(obj.VIEW.FIELDS)
+        # need to pop out group items so that it wont be reused
+        # with fields
+        group_field_dict = ({k: obj.VIEW.FIELDS.pop(k)
+                             for k, v in local_field_dict.items()
+                             if v.get('group') == group})
+        group_ele = E(group)
+        for key, val in group_field_dict.items():
+            group_ele.append(E(val.get('xpath')))
+        # print (etree.tostring(group_ele))
+        parser_ingest.append(group_ele)
+    for i, item in enumerate(obj._view.FIELDS.items()):
+        # i is the index and item will be taple of field key and value
+        field_dict = item[1]
+        parser_ingest.insert(i+1, E(field_dict.get('xpath')))
+    # print (etree.tostring(parser_ingest))
+    return parser_ingest

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import logging
 
 # 3rd-party
 from lxml import etree
@@ -8,6 +9,9 @@ from lxml.builder import E
 from jnpr.junos.factory.table import Table
 from jnpr.junos.jxml import remove_namespaces, remove_namespaces_and_spaces
 from jnpr.junos.decorators import checkSAXParserDecorator
+
+logger = logging.getLogger("jnpr.junos.factory.optable")
+
 
 class OpTable(Table):
 
@@ -60,8 +64,12 @@ class OpTable(Table):
         rpc_args = {}
 
         if self._use_filter:
-            filter_xml = generate_sax_parser_input(self)
-            rpc_args['filter_xml'] = filter_xml
+            try:
+                filter_xml = generate_sax_parser_input(self)
+                rpc_args['filter_xml'] = filter_xml
+            except ValueError as ex:
+                logger.warning("Not able to create SAX parser input due to "
+                               "'%s', hence using DOM" % ex)
 
         self.D.transform = lambda: remove_namespaces_and_spaces
         rpc_args.update(self.GET_ARGS)    # copy default args

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -69,7 +69,7 @@ class OpTable(Table):
                 rpc_args['filter_xml'] = filter_xml
             except ValueError as ex:
                 logger.warning("Not able to create SAX parser input due to "
-                               "'%s', hence using DOM" % ex)
+                               "'%s'" % ex)
 
         self.D.transform = lambda: remove_namespaces_and_spaces
         rpc_args.update(self.GET_ARGS)    # copy default args

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -18,12 +18,12 @@ class Table(object):
     ITEM_NAME_XPATH = 'name'
     VIEW = None
 
-    def __init__(self, dev=None, xml=None, path=None, use_filter=False):
+    def __init__(self, dev=None, xml=None, path=None, use_filter=True):
         """
         :dev: Device instance
         :xml: lxml Element instance
         :path: file path to XML, to be used rather than :dev:
-        :use_filter: Default usage is DOM parsing, enable this variable to use SAX
+        :use_filter: Default usage is SAX parsing, disable this variable to use DOM
         """
         self._dev = dev
         self.xml = xml

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -17,6 +17,7 @@ class Table(object):
     ITEM_XPATH = None
     ITEM_NAME_XPATH = 'name'
     VIEW = None
+    USE_FILTER = None
 
     def __init__(self, dev=None, xml=None, path=None, use_filter=True):
         """

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -23,7 +23,7 @@ class Table(object):
         :dev: Device instance
         :xml: lxml Element instance
         :path: file path to XML, to be used rather than :dev:
-        :use_filter: Default usage is DOM parsing, disable this variable to use SAX
+        :use_filter: Default usage is SAX parsing, disable this variable to use DOM
         """
         self._dev = dev
         self.xml = xml
@@ -31,7 +31,7 @@ class Table(object):
         self._key_list = []
         self._path = path
         self._lxml = xml
-        self._use_filter = self._dev._use_filter and use_filter
+        self._use_filter = self.USE_FILTER and self._dev._use_filter and use_filter
 
     # -------------------------------------------------------------------------
     # PROPERTIES

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -31,9 +31,11 @@ class Table(object):
         self._key_list = []
         self._path = path
         self._lxml = xml
-        self._use_filter = self.USE_FILTER and self._dev._use_filter and use_filter
+        self._use_filter = self.USE_FILTER and use_filter
+        if self._dev is not None:
+            self._use_filter = self._use_filter and self._dev._use_filter
 
-    # -------------------------------------------------------------------------
+            # -------------------------------------------------------------------------
     # PROPERTIES
     # -------------------------------------------------------------------------
 

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -18,7 +18,7 @@ class Table(object):
     ITEM_NAME_XPATH = 'name'
     VIEW = None
 
-    def __init__(self, dev=None, xml=None, path=None, use_filter=False):
+    def __init__(self, dev=None, xml=None, path=None, use_filter=True):
         """
         :dev: Device instance
         :xml: lxml Element instance
@@ -31,7 +31,7 @@ class Table(object):
         self._key_list = []
         self._path = path
         self._lxml = xml
-        self._use_filter = use_filter
+        self._use_filter = self._dev._use_filter and use_filter
 
     # -------------------------------------------------------------------------
     # PROPERTIES

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -18,11 +18,12 @@ class Table(object):
     ITEM_NAME_XPATH = 'name'
     VIEW = None
 
-    def __init__(self, dev=None, xml=None, path=None):
+    def __init__(self, dev=None, xml=None, path=None, use_sax_parser=False):
         """
         :dev: Device instance
         :xml: lxml Element instance
         :path: file path to XML, to be used rather than :dev:
+        :use_sax_parser: Default usage is DOM parsing, enable this variable to use SAX
         """
         self._dev = dev
         self.xml = xml
@@ -30,6 +31,7 @@ class Table(object):
         self._key_list = []
         self._path = path
         self._lxml = xml
+        self._use_sax_parser = use_sax_parser
 
     # -------------------------------------------------------------------------
     # PROPERTIES

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -18,12 +18,12 @@ class Table(object):
     ITEM_NAME_XPATH = 'name'
     VIEW = None
 
-    def __init__(self, dev=None, xml=None, path=None, use_sax_parser=False):
+    def __init__(self, dev=None, xml=None, path=None, use_filter=False):
         """
         :dev: Device instance
         :xml: lxml Element instance
         :path: file path to XML, to be used rather than :dev:
-        :use_sax_parser: Default usage is DOM parsing, enable this variable to use SAX
+        :use_filter: Default usage is DOM parsing, enable this variable to use SAX
         """
         self._dev = dev
         self.xml = xml
@@ -31,7 +31,7 @@ class Table(object):
         self._key_list = []
         self._path = path
         self._lxml = xml
-        self._use_sax_parser = use_sax_parser
+        self._use_filter = use_filter
 
     # -------------------------------------------------------------------------
     # PROPERTIES

--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -18,12 +18,12 @@ class Table(object):
     ITEM_NAME_XPATH = 'name'
     VIEW = None
 
-    def __init__(self, dev=None, xml=None, path=None, use_filter=True):
+    def __init__(self, dev=None, xml=None, path=None, use_filter=False):
         """
         :dev: Device instance
         :xml: lxml Element instance
         :path: file path to XML, to be used rather than :dev:
-        :use_filter: Default usage is SAX parsing, disable this variable to use DOM
+        :use_filter: Default usage is DOM parsing, disable this variable to use SAX
         """
         self._dev = dev
         self.xml = xml

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -307,7 +307,8 @@ class _RpcMetaExec(object):
             rpc = etree.Element(rpc_cmd)
 
             # Gather decorator keywords into dec_args and remove from kvargs
-            dec_arg_keywords = ['dev_timeout', 'normalize', 'ignore_warning']
+            dec_arg_keywords = ['dev_timeout', 'normalize', 'ignore_warning',
+                                'sax_parser_ingest']
             dec_args = {}
             for keyword in dec_arg_keywords:
                 if keyword in kvargs:

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -308,7 +308,7 @@ class _RpcMetaExec(object):
 
             # Gather decorator keywords into dec_args and remove from kvargs
             dec_arg_keywords = ['dev_timeout', 'normalize', 'ignore_warning',
-                                'sax_parser_ingest']
+                                'filter_xml']
             dec_args = {}
             for keyword in dec_arg_keywords:
                 if keyword in kvargs:

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -104,7 +104,7 @@ class TestFactoryOpTable(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
-            if 'normalize' in kwargs and args:
+            if args and ('normalize' in kwargs or 'filter_xml' in kwargs):
                 return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -158,7 +158,7 @@ class TestFactoryTable(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
-            if 'normalize' in kwargs and args:
+            if args and ('normalize' in kwargs or 'filter_xml' in kwargs):
                 return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)

--- a/tests/unit/factory/test_to_json.py
+++ b/tests/unit/factory/test_to_json.py
@@ -84,7 +84,7 @@ class TestToJson(unittest.TestCase):
 
     def _mock_manager(self, *args, **kwargs):
         if kwargs:
-            if 'normalize' in kwargs and args:
+            if args and ('normalize' in kwargs or 'filter_xml' in kwargs):
                 return self._read_file(args[0].tag + '.xml')
             device_params = kwargs['device_params']
             device_handler = make_device_handler(device_params)


### PR DESCRIPTION

ncclient by default uses DOM parsing. In DOM parsing the whole XML is converted into an lxml object, making it memory intensive. For example for a 100 MB XML file, the lxml object can be around 800 MB.

In the majority of cases, the user only needs to fetch a few tag values from the XML, hence loading full XML using the DOM object is suboptimal. 

On the other hand, SAX parsing will only store the desired tag values.

Wherever we just need to retrieve only few tag values (as in case of PyEZ table/views) from XML output, DOM parsing should be replaced with SAX parsing.

For 100 MB XML data consuming 800 MB in case of DOM parsing is expected to reduce to 100MB with SAX parser.


```python
with Device(host='xxxx', user='xxxxx', password='xxxx', use_filter=True) as dev:
    sax_input = "<interface-information><physical-interface><name/></physical-interface></interface- 
    information>"
    dev.rpc.get_interface_information(filter_xml=sax_input)
```