### PR TITLE
updating docs to close #936

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ _Junos PyEZ_ is designed to provide the same capabilities as a user would have o
 * Make configuration changes in unstructured and structured ways
 * Provide common utilities for tasks such as secure copy of files and software updates
 
-# NOTICE
+# NOTICES
 
-As of release 2.0.0, _Junos PyEZ_ requires [ncclient](https://pypi.python.org/pypi/ncclient) version 0.5.2 or later.
+- As of release 2.0.0, _Junos PyEZ_ requires [ncclient](https://pypi.python.org/pypi/ncclient) version 0.5.2 or later.
+- When using the `ssh_private_key_file` argument of the Device constructor on MacOS Mojave and higher, ensure that the SSH keys are in the RSA format, and not the newer OPENSSH format.
+  - New key: `ssh-keygen -p -m PEM -f ~/.ssh/id_rsa`
+  - Convert an existing OPENSSH key: ``ssh-keygen -p -m PEM -f ~/.ssh/private_key`
+  - Check if a given key is RSA or OPENSSH format: `head -n1 ~/.ssh/private_key`
+    - RSA: `-----BEGIN RSA PRIVATE KEY-----`
+    - OPENSSH: `-----BEGIN OPENSSH PRIVATE KEY-----` 
 
 # INSTALLATION
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -391,7 +391,15 @@ class _Connection(object):
         raise RuntimeError("re_name is read-only!")
 
     def _sshconf_lkup(self):
-        # When sockfd passed to device for 'outbound ssh'
+        """ Controls the ssh connection:
+            If using ssh_private_key_file on MacOS Mojave or greater
+            (specifically > OpenSSH_7.4p1) ensure that the keys are generated
+            in PEM format or convert existing 'new' keys to the PEM format:
+            Check format: `head -n1 ~/.ssh/some_key`
+            Correct RSA fomat: -----BEGIN RSA PRIVATE KEY-----
+            Incorrect OPENSSH format: -----BEGIN OPENSSH PRIVATE KEY-----
+            Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
+            """
         if self.__class__.__name__ == 'Device' and self._sock_fd is not None:
             return None
         if self._ssh_config:


### PR DESCRIPTION
Updated docs to explain the `ssh_private_key_file` usage with newer MacOS versions. Fixes #936 
Signed-off-by: Stephen Steiner <ssteiner@juniper.net>