### PR TITLE
no commit confirmed in private mode

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -110,6 +110,8 @@ class Config(Util):
 
         confirm = kvargs.get('confirm')
         if confirm:
+            if self.mode == 'private':
+                raise ValueError('commit confirmed not supported for private configuration')
             rpc_args['confirmed'] = True
             confirm_val = str(confirm)
             if 'True' != confirm_val:


### PR DESCRIPTION
Junos raises an error when `commit confirmed` in `private` mode. This PR forces the same behavior
```
root@router-vme> configure private
warning: uncommitted changes will be discarded on exit
Entering configuration mode

root@router-vme# commit confirmed
error: commit confirmed not supported for private configuration
```
