### PR TITLE
create generalized function for ssh-client

### DIFF
--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -1,0 +1,44 @@
+import paramiko
+
+
+def open_ssh_client(dev):
+    """
+    This function is used to return a new paramiko SSH client that uses the same login method &
+    credentials as the original Junos device instance.  The purpose of this function is to provide
+    the caller with the complete paramiko library of functionality based on the returned SSH client.
+    :param dev: jnpr.junos.Device instance
+    :return: paramiko.SSHClient instance
+    """
+
+    # note, the following code was extracted from the scp module, and then the scp module
+    # was refactored to use this function
+    ssh_client = paramiko.SSHClient()
+    ssh_client.load_system_host_keys()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # use junos._hostname since this will be correct if we are going
+    # through a jumphost.
+
+    config = {}
+    kwargs = {}
+    ssh_config = getattr(dev, '_sshconf_path')
+    if ssh_config:
+        config = paramiko.SSHConfig()
+        with open(ssh_config) as open_ssh_config:
+            config.parse(open_ssh_config)
+        config = config.lookup(dev._hostname)
+
+    sock = None
+    if config.get("proxycommand"):
+        sock = paramiko.proxy.ProxyCommand(config.get("proxycommand"))
+
+    if dev._ssh_private_key_file is not None:
+        kwargs['key_filename'] = dev._ssh_private_key_file
+
+    ssh_client.connect(hostname=dev._hostname,
+                       port=(22, int(dev._port))[dev._hostname == 'localhost'],
+                       username=dev._auth_user,
+                       password=dev._auth_password,
+                       sock=sock, **kwargs
+                       )
+    return ssh_client


### PR DESCRIPTION
Cherry-picked code from #896. Cannot merge it due to merge conflicts
- Added generalized script for ssh_client open utility
- start_shell and scp modified to use the generalized utility.

### Test logs

**Script**
```
from jnpr.junos.device import Device
from jnpr.junos.utils.start_shell import StartShell
from jnpr.junos.utils.scp import SCP


with Device(host='xx.xx.xx.xx', user='xxxxx', password='xxxxx') as dev:
    with StartShell(dev) as shell:
        result = shell.run("ls /var/tmp/NSSULogs.pdf")
        print(result[1])

    with SCP(dev) as scp:
        scp.put(files='bin/NSSULogs.pdf', remote_path='/var/tmp')

    with StartShell(dev) as shell:
        result = shell.run("ls /var/tmp/NSSULogs.pdf")
        print(result[1])

```

**Output**
```
ls /var/tmp/NSSULogs.pdf
ls: /var/tmp/NSSULogs.pdf: No such file or directory
% 
ls /var/tmp/NSSULogs.pdf
/var/tmp/NSSULogs.pdf
% 

Process finished with exit code 0
```