### PR TITLE
Allow user to set the timeout used during connection open()

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1174,6 +1174,8 @@ class Device(_Connection):
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
         self._fact_style = kvargs.get('fact_style', 'new')
         self._use_filter = kvargs.get('use_filter', False)
+        # Specifying timeout for opening connection is now possible after
+        # https://github.com/ncclient/ncclient/pull/314
         self._conn_open_timeout = kvargs.get('conn_open_timeout', None)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in a future '


### PR DESCRIPTION
### Problem
The ask is to allow the user to set timeout used during connection open( this is different from the RPC timeout ). This wasn't possible earlier as it required changes to `ncclient`.

Link: https://github.com/ncclient/ncclient/pull/314

The recent release of `ncclient==0.6.6` has the required changes to allow PyEZ to specify timeout during connection open.

### Solution
A new option `conn_open_timeout` to allow the user to specify the timeout that will be used during connection open(). The option will be supported in all modes of transport: `telnet`, `ssh` and `serial`. 

Also, updated the `requirements.txt` to pick up latest ncclient.

@sstancu Can you please confirm is this the right way to use `timeout` in ncclient ??