### PR TITLE
option to ignore warnings in config diff

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -208,7 +208,7 @@ class Config(Util):
     # show | compare rollback <number|0*>
     # -------------------------------------------------------------------------
 
-    def diff(self, rb_id=0):
+    def diff(self, rb_id=0, ignore_warning=False):
         """
         Retrieve a diff (patch-format) report of the candidate config against
         either the current active config, or a different rollback.
@@ -224,9 +224,9 @@ class Config(Util):
             raise ValueError("Invalid rollback #" + str(rb_id))
 
         try:
-            rsp = self.rpc.get_configuration(dict(
-                compare='rollback', rollback=str(rb_id), format='text'
-            ))
+            rsp = self.rpc.get_configuration(
+                    dict(compare='rollback', rollback=str(rb_id), format='text'),
+                    ignore_warning=ignore_warning)
         except RpcTimeoutError:
             raise 
         except RpcError as err:

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -184,7 +184,8 @@ class TestConfig(unittest.TestCase):
         self.conf.diff()
         self.conf.rpc.get_configuration.\
             assert_called_with(
-                {'compare': 'rollback', 'rollback': '0', 'format': 'text'})
+                {'compare': 'rollback', 'rollback': '0', 'format': 'text'},
+                ignore_warning=False)
 
     def test_config_diff_exception_severity_warning(self):
         rpc_xml = '''


### PR DESCRIPTION
Some junos devices gives warnings when doing a diff of config. Probably a problem with how Junos reports it, but it doesn't hurt to be able to ignore warnings when doing a comparison.

Example of problem device and config:
```
root@QFX5120# show | compare               
[edit chassis fpc 0 pic 0 port 0 speed]
  'speed 1G'
    warning: 1g config will be applied to ports 0 to 3
[edit]
-  chassis {
-      fpc 0 {
-          pic 0 {
-              port 0 {
-                  speed 1G;
-              }
-          }
-      }
-  }
```