### PR TITLE
pass on huge_tree to ncclient

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -122,6 +122,7 @@ class Console(_Connection):
         self._attempts = kvargs.get('attempts', 10)
         self._gather_facts = kvargs.get('gather_facts', False)
         self._fact_style = kvargs.get('fact_style', 'new')
+        self._huge_tree = kvargs.get('huge_tree', False)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in '
                           'a future release.' %
@@ -275,7 +276,8 @@ class Console(_Connection):
             if isinstance(rpc_cmd_e, etree._Element) else rpc_cmd_e
         reply = self._tty.nc.rpc(rpc_cmd)
         rpc_rsp_e = NCElement(reply,
-                              self.junos_dev_handler.transform_reply()
+                              self.junos_dev_handler.transform_reply(),
+                              self._huge_tree
                               )._NCElement__doc
         return rpc_rsp_e
 
@@ -290,6 +292,7 @@ class Console(_Connection):
         tty_args['timeout'] = float(self._timeout)
         tty_args['attempts'] = int(self._attempts)
         tty_args['baud'] = self._baud
+        tty_args['huge_tree'] = self._huge_tree
         if self._mode and self._mode.upper() == 'TELNET':
             tty_args['host'] = self._hostname
             tty_args['port'] = self._port

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1145,6 +1145,9 @@ class Device(_Connection):
             default is ``False`` to use DOM.
             Select ``True`` to use SAX (if SAX input is provided).
 
+        :param bool huge_tree:
+            *OPTIONAL* parse XML with very deep trees and long text content.
+            default is ``False``.
         """
 
         # ----------------------------------------
@@ -1160,6 +1163,7 @@ class Device(_Connection):
         self._auto_probe = kvargs.get('auto_probe', self.__class__.auto_probe)
         self._fact_style = kvargs.get('fact_style', 'new')
         self._use_filter = kvargs.get('use_filter', False)
+        self._huge_tree = kvargs.get('huge_tree', False)
         if self._fact_style != 'new':
             warnings.warn('fact-style %s will be removed in a future '
                           'release.' %
@@ -1339,6 +1343,8 @@ class Device(_Connection):
             cnx_err._orig = err
             raise cnx_err
 
+        if self._huge_tree:
+            self._conn.huge_tree = True
         self.connected = True
 
         self._nc_transform = self.transform

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -82,6 +82,7 @@ class Terminal(object):
         self.cs_passwd = kvargs.get('cs_passwd')
         self.login_attempts = kvargs.get('attempts') or self.LOGIN_RETRY
         self.console_has_banner = kvargs.get('console_has_banner') or False
+        self._huge_tree = kvargs.get('huge_tree', False)
 
         # misc setup
         self.nc = tty_netconf(self)

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -119,7 +119,7 @@ class tty_netconf(object):
 
         rsp = self._receive()
         rsp = rsp.decode('utf-8') if isinstance(rsp, bytes) else rsp
-        reply = RPCReply(rsp)
+        reply = RPCReply(rsp, huge_tree=self._tty._huge_tree)
         errors = reply.errors
         if len(errors) > 1:
             raise RPCError(to_ele(reply._raw), errs=errors)
@@ -161,8 +161,10 @@ class tty_netconf(object):
             rxbuf = [i.strip() for i in rxbuf if i.strip() != PY6.EMPTY_STR]
             rcvd_data = PY6.NEW_LINE.join(rxbuf)
             logger.debug('Received: \n%s' % rcvd_data)
+            parser = etree.XMLParser(remove_blank_text=True,
+                                     huge_tree=self._tty._huge_tree)
             try:
-                etree.XML(rcvd_data)
+                etree.XML(rcvd_data, parser)
             except XMLSyntaxError:
                 if _NETCONF_EOM in rcvd_data:
                     rcvd_data = rcvd_data[:rcvd_data.index(_NETCONF_EOM)]


### PR DESCRIPTION
with huge_tree we used to get execpetion for big xml

```
  File "/Users/nitinkr/Coding/ncclient/ncclient/manager.py", line 236, in execute
    huge_tree=self._huge_tree).request(*args, **kwds)
  File "/Users/nitinkr/Coding/ncclient/ncclient/operations/third_party/juniper/rpc.py", line 52, in request
    return self._request(rpc)
  File "/Users/nitinkr/Coding/ncclient/ncclient/operations/rpc.py", line 338, in _request
    self._reply.parse()
  File "/Users/nitinkr/Coding/ncclient/ncclient/operations/rpc.py", line 148, in parse
    root = self._root = to_ele(self._raw, huge_tree=self._huge_tree) # The <rpc-reply> element
  File "/Users/nitinkr/Coding/ncclient/ncclient/xml_.py", line 124, in to_ele
    return x if etree.iselement(x) else etree.fromstring(x.encode('UTF-8'), parser=_get_parser(huge_tree))
  File "src/lxml/etree.pyx", line 3222, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1877, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1765, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1127, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 601, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 711, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 640, in lxml.etree._raiseParseError
  File "<string>", line 105629
lxml.etree.XMLSyntaxError: xmlSAX2Characters: huge text node, line 105629, column 
```