### PR TITLE
call MetaPathLoader only for jnpr.junos* modules

### DIFF
--- a/lib/jnpr/junos/op/__init__.py
+++ b/lib/jnpr/junos/op/__init__.py
@@ -10,10 +10,11 @@ __all__ = []
 
 class MetaPathFinder(object):
     def find_module(self, fullname, path=None):
-        mod = fullname.split('.')[-1]
-        if mod in [os.path.splitext(i)[0] for i in os.listdir(
-                os.path.dirname(__file__))]:
-            return MetaPathLoader()
+        if fullname.startswith('jnpr.junos'):
+            mod = fullname.split('.')[-1]
+            if mod in [os.path.splitext(i)[0] for i in os.listdir(
+                    os.path.dirname(__file__))]:
+                return MetaPathLoader()
 
 
 class MetaPathLoader(object):


### PR DESCRIPTION
Fix #973 