### PR TITLE
provide option to pass Null as alternate key with pipe

### DIFF
--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -99,6 +99,9 @@ class Table(object):
             try:
                 keys.append(this.xpath(k)[0].text)
             except:
+                # Case where key is provided like key: re-name | Null
+                if ' | ' in k and 'Null' in k:
+                    continue
                 keys.append(None)
         return tuple(keys)
 
@@ -134,8 +137,9 @@ class Table(object):
             # Check if pipe is in the key_value, if so append xpath
             # to each value
             if ' | ' in key_value:
-                return self._keys_simple(' | '.join([xpath + '/' + x for x in
-                                                     key_value.split(' | ')]))
+                return self._keys_simple(' | '.join(
+                    [xpath + '/' + x for x in key_value.split(' | ') if
+                     x != 'Null']))
             return self._keys_simple(xpath + '/' + key_value)
 
         # user explicitly passed key as Null in Table

--- a/tests/unit/factory/rpc-reply/show-utmd-status-use-Null.xml
+++ b/tests/unit/factory/rpc-reply/show-utmd-status-use-Null.xml
@@ -1,0 +1,5 @@
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/19.4I0/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:d002acd0-0f28-4ba2-a78c-042aeb5cc910">
+<utmd-status xmlns="http://xml.juniper.net/junos/19.4I0/junos-utmd">
+<running/>
+</utmd-status>
+</rpc-reply>

--- a/tests/unit/factory/rpc-reply/show-utmd-status.xml
+++ b/tests/unit/factory/rpc-reply/show-utmd-status.xml
@@ -1,0 +1,21 @@
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/20.2I0/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:c9c57ecd-dc9f-44cf-803b-5487182b9475">
+<multi-routing-engine-results>
+
+<multi-routing-engine-item>
+
+<re-name>node0</re-name>
+
+<utmd-status xmlns="http://xml.juniper.net/junos/20.2I0/junos-utmd"><running/>
+</utmd-status>
+</multi-routing-engine-item>
+
+<multi-routing-engine-item>
+
+<re-name>node1</re-name>
+
+<utmd-status xmlns="http://xml.juniper.net/junos/20.2I0/junos-utmd"><running/>
+</utmd-status>
+</multi-routing-engine-item>
+
+</multi-routing-engine-results>
+</rpc-reply>

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -4,6 +4,7 @@ __credits__ = "Jeremy Schulman"
 import unittest
 import os
 import yaml
+import json
 from nose.plugins.attrib import attr
 
 from jnpr.junos import Device
@@ -174,6 +175,71 @@ VtepTunnelView:
             b'</vtep-info><traffic-statistics><input-bytes/><output-bytes/>'
             b'</traffic-statistics></logical-interface></physical-interface>')
         )
+
+    @patch('jnpr.junos.Device.execute')
+    def test_key_pipe_delim_with_Null(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        yaml_data = """
+---
+UTMStatusTable:
+    rpc: show-utmd-status
+    item: //utmd-status
+    view: UTMStatusView
+    key: ../re-name | Null
+
+UTMStatusView:
+    fields:
+        running: { running: flag }
+    """
+        globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                        Loader=yaml.Loader)))
+        tbl = UTMStatusTable(self.dev)
+        data = tbl.get()
+        self.assertEqual(json.loads(data.to_json()),
+                         {'node0': {'running': True}, 'node1': {'running': True}})
+
+    @patch('jnpr.junos.Device.execute')
+    def test_key_pipe_delim_with_Null_use_Null(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        yaml_data = """
+---
+UTMStatusTable:
+    rpc: show-utmd-status_use_Null
+    item: //utmd-status
+    view: UTMStatusView
+    key: ../re-name | Null
+
+UTMStatusView:
+    fields:
+        running: { running: flag }
+    """
+        globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                        Loader=yaml.Loader)))
+        tbl = UTMStatusTable(self.dev)
+        data = tbl.get()
+        self.assertEqual(json.loads(data.to_json()), {'running': True})
+
+    @patch('jnpr.junos.Device.execute')
+    def test_key_and_item_pipe_delim_with_Null_use_Null(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        yaml_data = """
+---
+UTMStatusTable:
+    rpc: show-utmd-status_use_Null
+    item: //multi-routing-engine-item/utmd-status | //utmd-status
+    view: UTMStatusView
+    key: 
+      - ../re-name | Null
+
+UTMStatusView:
+    fields:
+        running: { running: flag }
+    """
+        globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                        Loader=yaml.Loader)))
+        tbl = UTMStatusTable(self.dev)
+        data = tbl.get()
+        self.assertEqual(json.loads(data.to_json()), {'running': True})
 
     def _read_file(self, fname):
         from ncclient.xml_ import NCElement


### PR DESCRIPTION
Need the logical OR support for the key. 

```yaml
UTMStatusTable:
    rpc: show-utmd-status
    item:  //utmd-status
    view: UTMStatusView
    key: re-name | Null

UTMStatusView:
    fields:
        running: { running: flag }
```

We should be also able to support both item and key as logical OR operator
```yaml
UTMStatusTable:
    rpc: show-utmd-status
    item: //multi-routing-engine-item/utmd-status | //utmd-status
    view: UTMStatusView
    key: 
      - re-name | Null

UTMStatusView:
    fields:
        running: { running: flag }
```
Note: When the item is using OR operator, key need to be passed as list (the way code handles it)

Standalone Output:

root@snpsrx4600h> show security utm status | display xml 
```xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/19.2R0/junos">
    <utmd-status xmlns="http://xml.juniper.net/junos/19.2R0/junos-utmd">
        <running/>
    </utmd-status>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```

In case of standalone, above table should return
```python
{'running': True}
```
High-Availability Output:

root@riad-srx4200-4> show security utm status | display xml 
```
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/20.1I0/junos">
    <multi-routing-engine-results>
        
        <multi-routing-engine-item>
            
            <re-name>node0</re-name>
            
            <utmd-status xmlns="http://xml.juniper.net/junos/20.1I0/junos-utmd"><running/>
        </utmd-status>
    </multi-routing-engine-item>
    
    <multi-routing-engine-item>
        
        <re-name>node1</re-name>
        
        <utmd-status xmlns="http://xml.juniper.net/junos/20.1I0/junos-utmd"><running/>
    </utmd-status>
</multi-routing-engine-item>

    </multi-routing-engine-results>
    <cli>
<banner>{primary:node0}</banner>
    </cli>
</rpc-reply>
```

In case of cluster, above table/view should return
```python
{'node0': {'running': True}, 'node1': {'running': True}}
```