### PR TITLE
Handled case where RPC may not exist for a given RPC.

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -458,6 +458,8 @@ class _Connection(object):
                 encode = None if sys.version < '3' else 'unicode'
                 return etree.tostring(rsp[0], encoding=encode)
             return rsp[0]
+        except TypeError:
+            return "No RPC equivalent found for: " + command
         except:
             return "invalid command: " + command
 


### PR DESCRIPTION
The current implementation prints "invalid command: " for both an invalid command and cases where RPC might not exist while the command is valid.

__Script__
```
from jnpr.junos import Device

with Device('xxxx', user='xxxx', password='xxxx') as dev:
    print(dev.display_xml_rpc('show fan'))
    print(dev.display_xml_rpc('show chassis fan'))
    print(dev.display_xml_rpc('show version'))
```

__Output__
```
invalid command: show fan| display xml rpc
No RPC equivalent found for: show chassis fan| display xml rpc
<Element get-software-information at 0x106c47fc8>
```