### PR TITLE
handle sax parser input for nested fields

### DIFF
--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -133,17 +133,23 @@ def generate_sax_parser_input(obj):
                     # fields:
                     #    input-bytes: traffic-statistics/input-bytes
                     #    output-bytes: traffic-statistics/output-bytes
-                    existing_elem = parser_ingest.xpath(tags[0])
-                    if existing_elem:
-                        obj = existing_elem[0]
-                        for tag in tags[1:]:
-                            obj.append(E(tag))
+                    # or
+                    # fields:
+                    #     prefix-count: bgp-option-information/prefix-limit/prefix-count
+                    #     prefix-dummy: bgp-option-information/prefix-limit/prefix-dummy
+                    local_obj = parser_ingest
+                    for tag in tags[:-1]:
+                        existing_elem = local_obj.xpath(tag)
+                        if existing_elem:
+                            local_obj = existing_elem[0]
+                        else:
+                            continue
                     else:
-                        continue
+                        local_obj.append(E(tags[-1]))
                 else:
-                    obj = E(tags[0])
-                    for tag in tags[1:]:
-                        obj.append(E(tag))
+                    obj = E(tags[-1])
+                    for tag in tags[:-1][::-1]:
+                        obj = E(tag, obj)
                     map_multilayer_fields[tags[0]] = obj
                 parser_ingest.insert(i + 1, obj)
             else:

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -118,7 +118,7 @@ bgpNeighborView:
             b'</bgp-option-information></bgp-peer>'))
 
     def test_generate_sax_parser_item_with_many_slash(self):
-            yaml_data = """
+        yaml_data = """
 ---
 taskmallocdetail:
     rpc: get-task-memory-information
@@ -136,15 +136,15 @@ taskmallocview:
         tmmaxallocbytes: tm-max-alloc-bytes
         tmfunctioncalls: tm-function-calls
     """
-            globals().update(FactoryLoader().load(yaml.load(yaml_data,
-                                                            Loader=yaml.Loader)))
-            tbl = taskmallocdetail(self.dev)
-            data = generate_sax_parser_input(tbl)
-            self.assertEqual(data.tag, 'task-memory-malloc-usage-report')
-            self.assertEqual(len(etree.tostring(data)), len(
-                b'<task-memory-malloc-usage-report><task-malloc-list><task-malloc><tm-name/><t'
-                b'm-allocs/><tm-alloc-bytes/><tm-max-allocs/><tm-max-alloc-bytes/><tm-function'
-                b'-calls/></task-malloc></task-malloc-list></task-memory-malloc-usage-report>'))
+        globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                        Loader=yaml.Loader)))
+        tbl = taskmallocdetail(self.dev)
+        data = generate_sax_parser_input(tbl)
+        self.assertEqual(data.tag, 'task-memory-malloc-usage-report')
+        self.assertEqual(len(etree.tostring(data)), len(
+            b'<task-memory-malloc-usage-report><task-malloc-list><task-malloc><tm-name/><t'
+            b'm-allocs/><tm-alloc-bytes/><tm-max-allocs/><tm-max-alloc-bytes/><tm-function'
+            b'-calls/></task-malloc></task-malloc-list></task-memory-malloc-usage-report>'))
 
     def test_generate_sax_parser_same_parents_with_diff_fields(self):
         yaml_data = """

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -94,8 +94,31 @@ class TestFactoryOpTable(unittest.TestCase):
 
         self.assertRaises(ValueError, bad, 'bunk')
 
-    def test_generate_sax_parser_item_with_many_slash(self):
+    def test_generate_sax_parser_fields_with_many_slash(self):
         yaml_data = """
+---
+bgpNeighborTable:
+    rpc: get-bgp-neighbor-information
+    item: bgp-peer
+    key: peer-address
+    view: bgpNeighborView
+bgpNeighborView:
+    fields:
+        prefix-count: bgp-option-information/prefix-limit/prefix-count
+        prefix-dummy: bgp-option-information/prefix-limit/prefix-dummy
+"""
+        globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                        Loader=yaml.Loader)))
+        tbl = bgpNeighborTable(self.dev)
+        data = generate_sax_parser_input(tbl)
+        self.assertEqual(data.tag, 'bgp-peer')
+        self.assertEqual(len(etree.tostring(data)), len(
+            b'<bgp-peer><peer-address/><bgp-option-information><prefix-limit>'
+            b'<prefix-count/><prefix-dummy/></prefix-limit>'
+            b'</bgp-option-information></bgp-peer>'))
+
+    def test_generate_sax_parser_item_with_many_slash(self):
+            yaml_data = """
 ---
 taskmallocdetail:
     rpc: get-task-memory-information
@@ -112,16 +135,16 @@ taskmallocview:
         tmmaxallocs: tm-max-allocs
         tmmaxallocbytes: tm-max-alloc-bytes
         tmfunctioncalls: tm-function-calls
-"""
-        globals().update(FactoryLoader().load(yaml.load(yaml_data,
-                                                        Loader=yaml.Loader)))
-        tbl = taskmallocdetail(self.dev)
-        data = generate_sax_parser_input(tbl)
-        self.assertEqual(data.tag, 'task-memory-malloc-usage-report')
-        self.assertEqual(len(etree.tostring(data)), len(
-            b'<task-memory-malloc-usage-report><task-malloc-list><task-malloc><tm-name/><t'
-            b'm-allocs/><tm-alloc-bytes/><tm-max-allocs/><tm-max-alloc-bytes/><tm-function'
-            b'-calls/></task-malloc></task-malloc-list></task-memory-malloc-usage-report>'))
+    """
+            globals().update(FactoryLoader().load(yaml.load(yaml_data,
+                                                            Loader=yaml.Loader)))
+            tbl = taskmallocdetail(self.dev)
+            data = generate_sax_parser_input(tbl)
+            self.assertEqual(data.tag, 'task-memory-malloc-usage-report')
+            self.assertEqual(len(etree.tostring(data)), len(
+                b'<task-memory-malloc-usage-report><task-malloc-list><task-malloc><tm-name/><t'
+                b'm-allocs/><tm-alloc-bytes/><tm-max-allocs/><tm-max-alloc-bytes/><tm-function'
+                b'-calls/></task-malloc></task-malloc-list></task-memory-malloc-usage-report>'))
 
     def test_generate_sax_parser_same_parents_with_diff_fields(self):
         yaml_data = """

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -136,7 +136,7 @@ taskmallocview:
         tmmaxallocs: tm-max-allocs
         tmmaxallocbytes: tm-max-alloc-bytes
         tmfunctioncalls: tm-function-calls
-    """
+"""
         globals().update(FactoryLoader().load(yaml.load(yaml_data,
                                                         Loader=yaml.Loader)))
         tbl = taskmallocdetail(self.dev)

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -125,7 +125,6 @@ class TestFactoryTable(unittest.TestCase):
     def test_table_items(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.ppt.get('ge-0/0/0')
-        print (self.ppt.items())
         self.assertEqual(len(self.ppt.items()[1][1]), 8)
 
     def test_table_get_return_none(self):

--- a/tests/unit/facts/test_get_software_information.py
+++ b/tests/unit/facts/test_get_software_information.py
@@ -110,7 +110,6 @@ class TestGetSoftwareInformation(unittest.TestCase):
     @patch('jnpr.junos.Device.execute')
     def test_sw_info_dual_other_re_off(self, mock_execute):
         mock_execute.side_effect = self._mock_manager_dual_other_re_off
-        print (self.dev.facts)
         self.assertEqual(self.dev.facts['junos_info']['re1']['text'],
                          '18.3I20180716_1639')
         self.assertEqual(self.dev.facts['hostname'], 'R1_re01')


### PR DESCRIPTION
Fix for:

For below yml file

```
---
bgpNeighborTable:
    rpc: get-bgp-neighbor-information
    item: bgp-peer
    key: peer-address
    view: bgpNeighborView
bgpNeighborView:
    fields:
        prefix-count: bgp-option-information/prefix-limit/prefix-count
```
iagent uses **SAX parser**. prefix-count field is not generated

```
root@c19e2cbace78:/# salt '*' iagent.run bgpNeighborTable bgp_neighbor_new.yml /jfit/salt/_tables/
dut_check_r0:
    ----------
    changes:
        ----------
        hostname:
            10.221.131.40
        out:
            True
        reply:
            ----------
            2.2.2.2+179:
                ----------
                prefix-count:
                    None
            3.3.3.3+55918:
                ----------
                prefix-count:
                    None
        table:
            ----------
            bgpNeighborTable:
                ----------
                item:
                    bgp-peer
                key:
                    peer-address
                rpc:
                    get-bgp-neighbor-information
                view:
                    bgpNeighborView
            bgpNeighborView:
                ----------
                fields:
                    ----------
                    prefix-count:
                        bgp-option-information/prefix-limit/prefix-count
        tablename:
            bgpNeighborTable
    comment:
    name:
        'iagent.run'
    result:
        True
```
 
If we change the yml file to below for iagent to use **dom parser**, prefix-limit field is generated

```
---
bgpNeighborTable:
    rpc: get-bgp-neighbor-information
    item: //bgp-peer
    key: peer-address
    view: bgpNeighborView
bgpNeighborView:
    fields:
        prefix-count: bgp-option-information/prefix-limit/prefix-count

```

```
root@c19e2cbace78:/# salt '*' iagent.run bgpNeighborTable bgp_neighbor_new.yml /jfit/salt/_tables/
dut_check_r0:
    ----------
    changes:
        ----------
        hostname:
            10.221.131.40
        out:
            True
        reply:
            ----------
            2.2.2.2+179:
                ----------
                prefix-count:
                    5
            3.3.3.3+55918:
                ----------
                prefix-count:
                    None
        table:
            ----------
            bgpNeighborTable:
                ----------
                item:
                    //bgp-peer
                key:
                    peer-address
                rpc:
                    get-bgp-neighbor-information
                view:
                    bgpNeighborView
            bgpNeighborView:
                ----------
                fields:
                    ----------
                    prefix-count:
                        bgp-option-information/prefix-limit/prefix-count
        tablename:
            bgpNeighborTable
    comment:
    name:
        'iagent.run'
    result:
        True
```