### PR TITLE
Load patch support

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -261,10 +261,11 @@ class _RpcMetaExec(object):
 
         if contents is None and 'url' in options:
             pass
-        elif ('action' in options) and (options['action'] == 'set'):
-            rpc.append(E('configuration-set', contents))
-        elif ('format' in options) and (options['action'] == 'patch'):
-            rpc.append(E('configuration-patch', contents))
+        elif 'action' in options:
+            if options['action'] == 'set':
+                rpc.append(E('configuration-set', contents))
+            elif options['action'] == 'patch':
+                rpc.append(E('configuration-patch', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))
         elif ('format' in options) and (options['format'] == 'json'):

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -263,6 +263,8 @@ class _RpcMetaExec(object):
             pass
         elif ('action' in options) and (options['action'] == 'set'):
             rpc.append(E('configuration-set', contents))
+        elif ('format' in options) and (options['action'] == 'patch'):
+            rpc.append(E('configuration-patch', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))
         elif ('format' in options) and (options['format'] == 'json'):

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -311,6 +311,9 @@ class Config(Util):
 
           .. note:: This option cannot be used if **format** is "set".
 
+        :param bool patch:
+          If set to ``True`` will set the load-config action to load patch.
+
         :param str template_path:
           Similar to the **path** parameter, but this indicates that
           the file contents are ``Jinja2`` format and will require
@@ -382,7 +385,7 @@ class Config(Util):
         rpc_contents = None
 
         actions = filter(lambda item: kvargs.get(item, False),
-                         ('overwrite', 'merge', 'update'))
+                         ('overwrite', 'merge', 'update', 'patch'))
         if len(list(actions)) >= 2:
             raise ValueError('actions can be only one among %s'
                              % ', '.join(actions))
@@ -397,6 +400,8 @@ class Config(Util):
             rpc_xattrs['action'] = 'update'
         elif kvargs.get('merge') is True:
             del rpc_xattrs['action']
+        elif kvargs.get('patch') is True:
+            rpc_xattrs['action'] = 'patch'
 
         ignore_warning = kvargs.get('ignore_warning', False)
 

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -809,6 +809,18 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(self.conf.rpc.load_config.call_args[1]['url'],
                          '/var/home/user/golden.conf')
 
+    @patch('jnpr.junos.Device.execute')
+    def test_load_config_patch(self, mock_exec):
+        conf = \
+            """[edit system]
+            -  host-name pakzds904;
+            +  host-name pakzds904_set;
+            """
+        self.conf.load(conf, format='text', patch=True)
+        self.assertEqual(mock_exec.call_args[0][0].tag, 'load-configuration')
+        self.assertEqual(mock_exec.call_args[0][0].attrib,
+                         {'format': 'text', 'action': 'patch'})
+
     def _read_file(self, fname):
         fpath = os.path.join(os.path.dirname(__file__),
                              'rpc-reply', fname)


### PR DESCRIPTION
example
```python
from jnpr.junos import Device
from jnpr.junos.utils.config import Config
import logging
logging.basicConfig(level=logging.DEBUG)

with Device(host="xxxxx", passwd="xxxx", user="xxx") as dev:
    cu = Config(dev)
    conf = \
"""[edit system]
-  host-name pakzds904;
+  host-name pakzds904_set;
"""
    cu.load(conf, format='text', patch=True)
    cu.pdiff()
```