### PR TITLE
LACP Op YML provides insufficient information

### DIFF
--- a/lib/jnpr/junos/op/lacp.yml
+++ b/lib/jnpr/junos/op/lacp.yml
@@ -26,13 +26,12 @@ _LacpPortView:
 
 _LacpPortStateTable:
   item: lag-lacp-state
-  key:
-    - name 
-    - lacp-role 
   view: _LacpPortStateView
 
 _LacpPortStateView:
   fields:
+    name: name
+    role: lacp-role
     activity: lacp-activity
     timeout: lacp-timeout   
     expired: { lacp-expired: True=Yes }
@@ -52,6 +51,7 @@ _LacpPortProtoTable:
 
 _LacpPortProtoView:
   fields:
+    name: name
     rx_state: lacp-receive-state
     tx_state: lacp-transmit-state
     mx_state: lacp-mux-state

--- a/lib/jnpr/junos/op/lacp.yml
+++ b/lib/jnpr/junos/op/lacp.yml
@@ -8,20 +8,21 @@ LacpPortTable:
   args_key: interface_name
   item: lacp-interface-information
   key: lag-lacp-header/aggregate-name
-  view: LacpPortView
-
-# the view provides access to two tables states and protocols
-
-LacpPortView:
-  fields:
-    state: _LacpPortStateTable
-    proto: _LacpPortProtoTable
+  view: _LacpPortView
 
 # -----------------------------------------------------------------------------
 # Each LACP port maintains a "state" table that ha a composite key of the
 # interface name and it's role (Actor/Partner).  name with the "_" so this 
 # item does not get exported to the global namespace
 # -----------------------------------------------------------------------------
+
+# the view provides access to two tables states and protocols
+
+_LacpPortView:
+  fields:
+    name: lag-lacp-header/aggregate-name
+    state: _LacpPortStateTable
+    proto: _LacpPortProtoTable
 
 _LacpPortStateTable:
   item: lag-lacp-state


### PR DESCRIPTION
- Move the LACPPortView to a non-exported variable
- Add name field to _LACPPortView, _LACPPortStateView, and _LACPPortProtoView

Closes #1002