### PR TITLE
hostname should not be overwritten, ncclient/paramiko to take care

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,12 @@ matrix:
     include:
         - python: 2.7
           dist: trusty
-          sudo: false
         - python: 3.5
           dist: trusty
-          sudo: false
         - python: 3.6
           dist: trusty
-          sudo: false
         - python: 3.7
           dist: xenial
-          sudo: true
 
 addons:
   apt:

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -428,8 +428,11 @@ class _Connection(object):
             with open(sshconf_path, 'r') as fp:
                 sshconf.parse(fp)
                 found = sshconf.lookup(self._hostname)
-                self._hostname = found.get('hostname', self._hostname)
-                self._port = found.get('port', self._port)
+                if 'proxycommand' not in found:
+                    # hostname and port will be used by proxy and should not
+                    # be set as host for PyEZ
+                    self._hostname = found.get('hostname', self._hostname)
+                    self._port = found.get('port', self._port)
                 self._conf_auth_user = found.get('user')
                 self._conf_ssh_private_key_file = found.get('identityfile')
             return sshconf_path

--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -35,8 +35,10 @@ def open_ssh_client(dev):
     if dev._ssh_private_key_file is not None:
         kwargs['key_filename'] = dev._ssh_private_key_file
 
-    ssh_client.connect(hostname=dev._hostname,
-                       port=(22, int(dev._port))[dev._hostname == 'localhost'],
+    # pick hostname from .ssh config if any
+    hostname = config.get('hostname', dev._hostname)
+    ssh_client.connect(hostname=hostname,
+                       port=(22, int(dev._port))[hostname == 'localhost'],
                        username=dev._auth_user,
                        password=dev._auth_password,
                        sock=sock, **kwargs


### PR DESCRIPTION
Fix: https://github.com/Juniper/py-junos-eznc/issues/1006