### PR TITLE
textfsm support for table/view

### DIFF
--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("jnpr.junos.factory.cmdtable")
 
 class CMDTable(object):
 
-    def __init__(self, dev=None, data=None, path=None, template_dir=None):
+    def __init__(self, dev=None, raw=None, path=None, template_dir=None):
         """
         :dev: Device instance
         :data: string blob of the command output
@@ -38,7 +38,7 @@ class CMDTable(object):
         self._path = path
         self._parser = None
         self.output = None
-        self.data = data
+        self.data = raw
         self.template_dir = template_dir
 
     # -------------------------------------------------------------------------
@@ -149,7 +149,7 @@ class CMDTable(object):
         if self.USE_TEXTFSM:
             self.output = self._parse_textfsm(platform=self.PLATFORM,
                                               command=self.GET_CMD,
-                                              data=self.data)
+                                              raw=self.data)
         else:
             # state machine
             sm = StateMachine(self)
@@ -312,13 +312,13 @@ class CMDTable(object):
     # textfsm
     # ------------------------------------------------------------------------
 
-    def _parse_textfsm(self, platform=None, command=None, data=None):
+    def _parse_textfsm(self, platform=None, command=None, raw=None):
         """
         textfsm returns list of dict, make it JSON/dict
 
         :param platform: vendor platform, for ex cisco_xr
         :param command: cli command to be parsed
-        :param data: string blob output from the cli command execution
+        :param raw: string blob output from the cli command execution
         :return: dict of parsed data.
         """
         attrs = dict(
@@ -348,7 +348,7 @@ class CMDTable(object):
 
         cli_table = ntc_parse.clitable.CliTable(index, template_dir)
         try:
-            cli_table.ParseCmd(data, attrs, template)
+            cli_table.ParseCmd(raw, attrs, template)
         except ntc_parse.clitable.CliTableError as ex:
             logger.error('Unable to parse command "%s" on platform %s' % (
                 command, platform))

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -26,7 +26,7 @@ class CMDTable(object):
     def __init__(self, dev=None, raw=None, path=None, template_dir=None):
         """
         :dev: Device instance
-        :data: string blob of the command output
+        :raw: string blob of the command output
         :path: file path to XML, to be used rather than :dev:
         :template_dir: To look for textfsm templates in this folder first
         """

--- a/lib/jnpr/junos/factory/factory_cls.py
+++ b/lib/jnpr/junos/factory/factory_cls.py
@@ -45,9 +45,8 @@ def FactoryOpTable(cmd, args=None, args_key=None, item=None,
 
 def FactoryCMDTable(cmd, args=None, item=None, key_items=None,
                     key='name', view=None, table_name=None, title=None,
-                    delimiter=None, eval=None, **kwargs):
-    # if table_name is None:
-    #     table_name = "CMDTable." + cmd
+                    delimiter=None, eval=None, platform='juniper_junos', use_textfsm=False,
+                    **kwargs):
     new_cls = type(table_name, (CMDTable,), {})
     new_cls.GET_CMD = cmd
     if 'target' in kwargs:
@@ -60,6 +59,8 @@ def FactoryCMDTable(cmd, args=None, item=None, key_items=None,
     new_cls.TITLE = title
     new_cls.DELIMITER = delimiter
     new_cls.EVAL = eval
+    new_cls.PLATFORM = platform
+    new_cls.USE_TEXTFSM = use_textfsm
     new_cls.__module__ = __name__.replace('factory_cls', 'CMDTable')
     return new_cls
 
@@ -67,8 +68,6 @@ def FactoryCMDTable(cmd, args=None, item=None, key_items=None,
 def FactoryCMDChildTable(title=None, regex=None,
                          key='name', delimiter=None, table_name=None, view=None,
                          key_items=None, item=None, eval=None):
-    # if table_name is None:
-    #     table_name = "CMDTable." + title
     new_cls = type(table_name, (CMDTable,), {})
     new_cls.DELIMITER = delimiter
     new_cls.KEY = key

--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -196,11 +196,16 @@ class FactoryLoader(object):
             #     self._add_dictfield(fields, f_name, f_data, kvargs)
             #     continue
 
+            # self._fields.update(field)
+
             if f_data in self._catalog_dict:
                 # f_data is the table name
                 cls_tbl = self.catalog.get(f_data, self._build_cmdtable(f_data))
                 fields.table(f_name, cls_tbl)
                 continue
+
+            # if we are here, then it means that the field is a string value
+            fields.update({f_name: f_data})
     # -------------------------------------------------------------------------
 
     def _build_view(self, view_name):

--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -176,36 +176,14 @@ class FactoryLoader(object):
     def _add_cmd_view_fields(self, view_dict, fields_name, fields):
         """ add a group of fields to the view """
         fields_dict = view_dict[fields_name]
-        # try:
-        #     # see if this is a 'fields_<group>' collection, and if so
-        #     # then we automatically setup using the group mechanism
-        #     mark = fields_name.index('_')
-        #     group = {'group': fields_name[mark + 1:]}
-        # except:
-        #     # otherwise, no group, just standard 'fields'
-        #     group = {}
-
         for f_name, f_data in fields_dict.items():
-            # each field could have its own unique set of properties
-            # so create a kvargs <dict> each time.  but copy in the
-            # groups <dict> (single item) generically.
-            # kvargs = {}
-            # kvargs.update(group)
-
-            # if isinstance(f_data, dict):
-            #     self._add_dictfield(fields, f_name, f_data, kvargs)
-            #     continue
-
-            # self._fields.update(field)
-
             if f_data in self._catalog_dict:
-                # f_data is the table name
                 cls_tbl = self.catalog.get(f_data, self._build_cmdtable(f_data))
                 fields.table(f_name, cls_tbl)
                 continue
 
-            # if we are here, then it means that the field is a string value
-            fields.update({f_name: f_data})
+            # if we are here, it means we need to filter fields from textfsm
+            fields._fields.update({f_name: f_data})
     # -------------------------------------------------------------------------
 
     def _build_view(self, view_name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pyserial
 yamlordereddictloader
 pyparsing
 transitions
+ntc_template

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pyserial
 yamlordereddictloader
 pyparsing
 transitions
-ntc_template
+ntc_templates

--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -469,7 +469,7 @@ _FPCTTPQueueSizesTable:
   key_items:
     - High
     - Low
-  view: _FPCTTPQueueSizesView
+  # view: _FPCTTPQueueSizesView
 
 _FPCTTPQueueSizesTable2:
   title: TTP Receive Queue Sizes
@@ -477,7 +477,7 @@ _FPCTTPQueueSizesTable2:
   key_items:
     - High
     - Low
-  view: _FPCTTPQueueSizesView
+  # view: _FPCTTPQueueSizesView
 
 _FPCTTPQueueSizesView:
   fields:


### PR DESCRIPTION
```yaml
---
InterfaceTable:
    command: show interfaces
    key: interface
    platform: juniper_junos
    use_texfsm: True
```

uses templates from n2c module
https://github.com/networktocode/ntc-templates

Can also be used for other vendors if string blob is provided as raw input
for example:
```
---
PanosSecurityPolicyTable:
  command: show running security-policy
  platform: paloalto_panos
  key: NAME
  use_textfsm: True
```

```python
globals().update(FactoryLoader().load(yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)))
with open('/path-to-content/palo-alto.txt') as fp:
    data = fp.read()
    # use template from n2c templates
    stats = PanosSecurityPolicyTable(raw=data)

    # use templates from custom location, useful when user written template need to be used
    stats = PanosSecurityPolicyTable(raw=data, template_dir='/Users/nitinkr/Desktop/templates')
    stats.get()
    pprint(json.loads(stats.to_json()))
```

output:
```python
{'"interzone-default; index: 2"': {'ACTION': 'deny',
                                   'APPLICATION_SERVICE': '0:any/any/any/any',
                                   'CATEGORY': 'any',
                                   'DESTINATION': 'any',
                                   'DESTINATION_REGION': 'none',
                                   'FROM': 'any',
                                   'ICMP_UNREACHABLE': 'no',
                                   'SOURCE': 'any',
                                   'SOURCE_REGION': 'none',
                                   'TERMINAL': 'yes',
                                   'TO': 'any',
                                   'TYPE': 'interzone',
                                   'USER': ''},
 '"intrazone-default; index: 1"': {'ACTION': 'allow',
                                   'APPLICATION_SERVICE': '0:any/any/any/any',
                                   'CATEGORY': 'any',
                                   'DESTINATION': 'any',
                                   'DESTINATION_REGION': 'none',
                                   'FROM': 'any',
                                   'ICMP_UNREACHABLE': 'no',
                                   'SOURCE': 'any',
                                   'SOURCE_REGION': 'none',
                                   'TERMINAL': 'yes',
                                   'TO': 'any',
                                   'TYPE': 'intrazone',
                                   'USER': ''}}
```