### PR TITLE
load config with format text fixed

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -261,9 +261,9 @@ class _RpcMetaExec(object):
 
         if contents is None and 'url' in options:
             pass
-        elif 'action' in options and (options['action'] == 'set'):
+        elif ('action' in options) and (options['action'] == 'set'):
             rpc.append(E('configuration-set', contents))
-        elif 'action' in options and options['action'] == 'patch':
+        elif ('action' in options) and (options['action'] == 'patch'):
             rpc.append(E('configuration-patch', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -261,11 +261,10 @@ class _RpcMetaExec(object):
 
         if contents is None and 'url' in options:
             pass
-        elif 'action' in options:
-            if options['action'] == 'set':
-                rpc.append(E('configuration-set', contents))
-            elif options['action'] == 'patch':
-                rpc.append(E('configuration-patch', contents))
+        elif 'action' in options and (options['action'] == 'set'):
+            rpc.append(E('configuration-set', contents))
+        elif 'action' in options and options['action'] == 'patch':
+            rpc.append(E('configuration-patch', contents))
         elif ('format' in options) and (options['format'] == 'text'):
             rpc.append(E('configuration-text', contents))
         elif ('format' in options) and (options['format'] == 'json'):

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -822,6 +822,31 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(mock_exec.call_args[0][0].attrib,
                          {'format': 'text', 'action': 'patch'})
 
+    @patch('jnpr.junos.Device.execute')
+    def test_load_config_text(self, mock_exec):
+        textdata = """policy-options {
+            prefix-list TEST1-NETS {
+                100.0.0.0/24;
+            }
+            policy-statement TEST1-NETS {
+                term TEST1 {
+                    from {
+                        prefix-list TEST1-NETS;
+                    }
+                    then accept;
+                }
+                term REJECT {
+                    then reject;
+                }
+            }
+        }"""
+        self.conf.load(textdata, overwrite=True)
+        self.assertEqual(mock_exec.call_args[0][0].tag, 'load-configuration')
+        self.assertEqual(mock_exec.call_args[0][0].getchildren()[0].tag,
+                         'configuration-text')
+        self.assertEqual(mock_exec.call_args[0][0].attrib,
+                         {'format': 'text', 'action': 'override'})
+
     def _read_file(self, fname):
         fpath = os.path.join(os.path.dirname(__file__),
                              'rpc-reply', fname)


### PR DESCRIPTION
with 2.3.2 version for load config with text format

```python
    cu = Config(dev)
    cu.load(path='/var/tmp/xxxx.conf')
```
we were getting error 
```
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <load-configuration-results>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <rpc-error>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <error-type>protocol</error-type>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <error-tag>operation-failed</error-tag>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <error-severity>error</error-severity>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: <error-message>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: internal communications error (tag 'rpc') expecting  configuration-text
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: </error-message>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: </rpc-error>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: </load-configuration-results>
Apr  1 06:48:23 [NETCONF] - [4662] Outgoing: ]]>]]>
```
