### PR TITLE
ensures last_ok is correct when passing in custom 'this' to StartShell.run()

### DIFF
--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -136,7 +136,10 @@ class StartShell(object):
         if this is None:
             self.last_ok = got is not ''
         elif this != _SHELL_PROMPT:
-            self.last_ok = re.search(r'{}\s?$'.format(this), got) is not None
+            if re.search(r'{}\s?$'.format(this), got) is not None:
+                self.send('echo $?')
+                rc = ''.join(self.wait_for(this)
+                self.last_ok = rc.find('\r\n0\r\n') > 0
         elif re.search(r'{}\s?$'.format(_SHELL_PROMPT), got) is not None:
             # use $? to get the exit code of the command
             self.send('echo $?')

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -138,7 +138,7 @@ class StartShell(object):
         elif this != _SHELL_PROMPT:
             if re.search(r'{}\s?$'.format(this), got) is not None:
                 self.send('echo $?')
-                rc = ''.join(self.wait_for(this)
+                rc = ''.join(self.wait_for(this))
                 self.last_ok = rc.find('\r\n0\r\n') > 0
         elif re.search(r'{}\s?$'.format(_SHELL_PROMPT), got) is not None:
             # use $? to get the exit code of the command


### PR DESCRIPTION
use case was remote shell was tcsh, with a prompt ending in '> '. 

By passing in 'this = "(%|#|\$|\>)\s"' to StartShell.run(), the prompt is matched but, last_ok is not reflecting the cmd exit code. For example, this command returns an exit code of 1, yet ss.last_ok is True:
(True, 'cat /var/tmp/foo\r\r\ncat: /var/tmp/foo: No such file or directory\r\n\x1b[4mfoohost\x1b[m:\x1b[1m~\x1b[0m> ')