### PR TITLE
fix package requirements for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_reqs = list(filter(None, req_lines))
 # should be removed when textfsm releases >=1.1.1
 if sys.platform == 'win32':
     install_reqs.append('textfsm==0.4.1')
+    install_reqs.append('ntc-templates==1.4.1')
 
 setup(
     name="junos-eznc",


### PR DESCRIPTION
#1019 no longer addresses issue of textfsm import in windows because of a change in ntc-templates==1.4.2  :

ImportError: cannot import name 'clitable' from 'textfsm' (<redacted>\lib\site-packages\textfsm\__init__.py)