### PR TITLE
Python 3.5 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ _Junos PyEZ_ is designed to provide the same capabilities as a user would have o
 
 ## PIP
 
-Installation requires Python 2.7 or >=3.4 and associated `pip` tool
+Installation requires Python 2.7 or >=3.5 and associated `pip` tool
 
     pip install junos-eznc
 


### PR DESCRIPTION
Changing Installation Python version from 3.4 to 3.5 per discussion with Juniper Eng.