### PR TITLE
fix UnicodeDecodeError due to \ufeff char before <rpc-reply>

### DIFF
--- a/tests/unit/factory/rpc-reply/get-configuration-user.xml
+++ b/tests/unit/factory/rpc-reply/get-configuration-user.xml
@@ -1,21 +1,22 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos">
-	<configuration junos:commit-seconds="1400665891" junos:commit-localtime="2014-05-21 09:51:31 UTC" junos:commit-user="rick">
-		<system>
-			<login>
-				<user group="global">
-					<name group="global">test</name>
-					<full-name group="member0">Test User</full-name>
-					<uid group="global">928</uid>
-					<class group="global">superuser</class>
-					<undocumented><shell group="global">csh</shell></undocumented>
-					<authentication group="global">
-						<encrypted-password group="global">$encryptedpass.</encrypted-password>
-					</authentication>
-				</user>
-			</login>
-		</system>
-	</configuration>
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos">
+        <configuration junos:commit-seconds="1400665891" junos:commit-localtime="2014-05-21 09:51:31 UTC" junos:commit-user="rick">
+                <system>
+                        <login>
+                                <user group="global">
+                                        <name group="global">test</name>
+                                        <full-name group="member0">Test User</full-name>
+                                        <uid group="global">928</uid>
+                                        <class group="global">superuser</class>
+                                        <undocumented><shell group="global">csh</shell></undocumented>
+                                        <authentication group="global">
+                                                <encrypted-password group="global">$encryptedpass.</encrypted-password>
+                                        </authentication>
+                                </user>
+                        </login>
+                </system>
+        </configuration>
     <cli>
         <banner></banner>
-    </cli>	
+    </cli>
 </rpc-reply>
+

--- a/tests/unit/factory/rpc-reply/user.xml
+++ b/tests/unit/factory/rpc-reply/user.xml
@@ -1,4 +1,4 @@
-﻿<configuration changed-seconds="1435177642" changed-localtime="2015-06-24 13:27:22 PDT">
+<configuration changed-seconds="1435177642" changed-localtime="2015-06-24 13:27:22 PDT">
     <system group="global">
         <login group="global">
             <user group="global">
@@ -12,3 +12,4 @@
         </login>
     </system>
 </configuration>
+

--- a/tests/unit/facts/rpc-reply/vc_mmvc_get-virtual-chassis-information.xml
+++ b/tests/unit/facts/rpc-reply/vc_mmvc_get-virtual-chassis-information.xml
@@ -1,4 +1,4 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
     <virtual-chassis-information>
         <virtual-chassis-id-information>
             <virtual-chassis-id>f0e9.b6b2.378b</virtual-chassis-id>

--- a/tests/unit/facts/rpc-reply/vc_mmvcf_get-virtual-chassis-information.xml
+++ b/tests/unit/facts/rpc-reply/vc_mmvcf_get-virtual-chassis-information.xml
@@ -1,4 +1,4 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
     <virtual-chassis-information>
         <virtual-chassis-id-information junos:style="fabric">
             <virtual-chassis-id>f0e9.b6b2.378b</virtual-chassis-id>

--- a/tests/unit/ofacts/rpc-reply/get-virtual-chassis-information.xml
+++ b/tests/unit/ofacts/rpc-reply/get-virtual-chassis-information.xml
@@ -1,4 +1,4 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
 	<virtual-chassis-information>
 		<preprovisioned-virtual-chassis-information>
 			<virtual-chassis-id>4b43.17d9.1dcf</virtual-chassis-id>

--- a/tests/unit/ofacts/rpc-reply/get-virtual-chassis-information_mmvcf.xml
+++ b/tests/unit/ofacts/rpc-reply/get-virtual-chassis-information_mmvcf.xml
@@ -1,4 +1,4 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/13.2X51/junos">
     <virtual-chassis-information>
         <virtual-chassis-id-information junos:style="fabric">
             <virtual-chassis-id>f0e9.b6b2.378b</virtual-chassis-id>

--- a/tests/unit/rpc-reply/get-permission-denied.xml
+++ b/tests/unit/rpc-reply/get-permission-denied.xml
@@ -1,7 +1,7 @@
-﻿<rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
-	<error-severity>error</error-severity>
-	<error-info>
-		<bad-element>get-permission-denied</bad-element>
-	</error-info>
-	<error-message>permission denied</error-message>
+<rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/12.1X46/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+        <error-severity>error</error-severity>
+        <error-info>
+                <bad-element>get-permission-denied</bad-element>
+        </error-info>
+        <error-message>permission denied</error-message>
 </rpc-error>

--- a/tests/unit/utils/rpc-reply/request-package-rollback-multi-error.xml
+++ b/tests/unit/utils/rpc-reply/request-package-rollback-multi-error.xml
@@ -1,22 +1,22 @@
-﻿<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/14.2I0/junos">
     <multi-routing-engine-results>
 
-		<multi-routing-engine-item>
+                <multi-routing-engine-item>
 
-			<re-name>fpc0</re-name>
+                        <re-name>fpc0</re-name>
 
-			<output>JUNOS version "D10.2" will become active at next reboot</output>
-			<package-result>0</package-result>
-		</multi-routing-engine-item>	
-        
+                        <output>JUNOS version "D10.2" will become active at next reboot</output>
+                        <package-result>0</package-result>
+                </multi-routing-engine-item>
+
         <multi-routing-engine-item>
-            
+
             <re-name>member1</re-name>
-            
+
             <output>ERROR: cannot locate jroute-14.2I20140424_0657_ramas: rollback aborted</output>
             <package-result>1</package-result>
         </multi-routing-engine-item>
-        
+
     </multi-routing-engine-results>
     <cli>
         <banner>{master:member1-re0}</banner>

--- a/tests/unit/utils/rpc-reply/request-package-validate.xml
+++ b/tests/unit/utils/rpc-reply/request-package-validate.xml
@@ -1,40 +1,40 @@
 <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/10.4R3/junos">
-    <cli>
-        <ignore-signals>
-            hup
-        </ignore-signals>
-    </cli>
-    <output>
-        Checking compatibility with configuration
-        Initializing...
-        rm: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
-        rm: /var/validate/chroot/var/etc: Directory not empty
-        rm: /var/validate/chroot/var: Directory not empty
-        rm: /var/validate/chroot: Directory not empty
-        Using jbase-13.2I20140401_1054_katharh
-        Using /var/tmp/py-extensions-i386-13.2I20140430_1237_katharh.tgz
-        Checking py-extensions-i386 requirements on /
-        Verified py-extensions-i386-13.2I20140430_1237_katharh signed by PackageDevelopment_13_2_0
-        Registering py-extensions-i386 as unsupported
-        Using jruntime-13.2I20140401_1054_katharh
-        Using jkernel-13.2I20140401_1054_katharh
-        Using jroute-13.2I20140401_1054_katharh
-        Using jcrypto-13.2I20140401_1054_katharh
-        cp: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
-        Hardware Database regeneration succeeded
-        Validating against /config/juniper.conf.gz
-        mgd: error: schema: dbs_remap_daemon_index: could not find daemon name 'analyticsd'
-        mgd: warning: schema: init: 'logical-systems-vlans' contains-node 'juniper-config vlans': not found
-        mgd: error: rename failed for /var/etc/pam.conf
-        mgd: commit complete
-        Validation succeeded
-        rm: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
-        rm: /var/validate/chroot/var/etc: Directory not empty
-        rm: /var/validate/chroot/var: Directory not empty
-        rm: /var/validate/chroot: Directory not empty
-    </output>
-    <package-result>0</package-result>
-    <cli>
-        <banner></banner>
-    </cli>
+    <cli>
+        <ignore-signals>
+            hup
+        </ignore-signals>
+    </cli>
+    <output>
+        Checking compatibility with configuration
+        Initializing...
+        rm: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
+        rm: /var/validate/chroot/var/etc: Directory not empty
+        rm: /var/validate/chroot/var: Directory not empty
+        rm: /var/validate/chroot: Directory not empty
+        Using jbase-13.2I20140401_1054_katharh
+        Using /var/tmp/py-extensions-i386-13.2I20140430_1237_katharh.tgz
+        Checking py-extensions-i386 requirements on /
+        Verified py-extensions-i386-13.2I20140430_1237_katharh signed by PackageDevelopment_13_2_0
+        Registering py-extensions-i386 as unsupported
+        Using jruntime-13.2I20140401_1054_katharh
+        Using jkernel-13.2I20140401_1054_katharh
+        Using jroute-13.2I20140401_1054_katharh
+        Using jcrypto-13.2I20140401_1054_katharh
+        cp: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
+        Hardware Database regeneration succeeded
+        Validating against /config/juniper.conf.gz
+        mgd: error: schema: dbs_remap_daemon_index: could not find daemon name 'analyticsd'
+        mgd: warning: schema: init: 'logical-systems-vlans' contains-node 'juniper-config vlans': not found
+        mgd: error: rename failed for /var/etc/pam.conf
+        mgd: commit complete
+        Validation succeeded
+        rm: /var/validate/chroot/var/etc/pam.conf: Operation not permitted
+        rm: /var/validate/chroot/var/etc: Directory not empty
+        rm: /var/validate/chroot/var: Directory not empty
+        rm: /var/validate/chroot: Directory not empty
+    </output>
+    <package-result>0</package-result>
+    <cli>
+        <banner></banner>
+    </cli>
 </rpc-reply>


### PR DESCRIPTION
For example:

```
>>> fp = open("tests/unit/ofacts/rpc-reply/get-virtual-chassis-information.xml")
>>> fp.read()
'\ufeff<rpc-reply.......
```

Error while running UT
```
  File ".../tests/unit/test_device.py", line 883, in _mock_manager
    return self._read_file(args[0].tag + '.xml')
  File ".../pyez/tests/unit/test_device.py", line 817, in _read_file
    foo = fp.read()
  File "/.tox/unittest/bin/../lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 0: ordinal not in range(128)