### PR TITLE
do not depend on deprecated nose and yamlordereddictloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
-nosetests.xml
 tests/unit/cover
 
 # Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION > 3.5 ]]; then black --check --exclude=docs/* . ; fi
-  - nosetests -v --with-coverage --cover-package=jnpr.junos --cover-inclusive -a unit
+  - pytest --cov=jnpr.junos -m unit
 
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION > 3.5 ]]; then black --check --exclude=docs/* . ; fi
-  - pytest --cov=jnpr.junos -m unit
+  - pytest --cov=jnpr.junos -m unit --forked
 
 after_success:
   coveralls

--- a/development.txt
+++ b/development.txt
@@ -3,6 +3,7 @@
 coverage     # http://nedbatchelder.com/code/coverage/
 mock         # http://www.voidspace.org.uk/python/mock/
 pytest       # https://docs.pytest.org/
+pytest-cov
 pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes
 coveralls	 # https://coveralls.io/

--- a/development.txt
+++ b/development.txt
@@ -4,6 +4,7 @@ coverage     # http://nedbatchelder.com/code/coverage/
 mock         # http://www.voidspace.org.uk/python/mock/
 pytest       # https://docs.pytest.org/
 pytest-cov
+yamlloader
 pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes
 coveralls	 # https://coveralls.io/

--- a/development.txt
+++ b/development.txt
@@ -2,7 +2,7 @@
 
 coverage     # http://nedbatchelder.com/code/coverage/
 mock         # http://www.voidspace.org.uk/python/mock/
-nose         # http://nose.readthedocs.org/en/latest/
+pytest       # https://docs.pytest.org/
 pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes
 coveralls	 # https://coveralls.io/

--- a/development.txt
+++ b/development.txt
@@ -4,6 +4,7 @@ coverage     # http://nedbatchelder.com/code/coverage/
 mock         # http://www.voidspace.org.uk/python/mock/
 pytest       # https://docs.pytest.org/
 pytest-cov
+pytest-forked
 yamlloader
 pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes

--- a/lib/jnpr/junos/cfg/phyport/__init__.py
+++ b/lib/jnpr/junos/cfg/phyport/__init__.py
@@ -7,8 +7,9 @@ __all__ = ["PhyPort"]
 
 class PhyPort(object):
     def __new__(cls, dev, name=None):
-        supercls = {"CLASSIC": PhyPortClassic, "SWITCH": PhyPortSwitch,}.get(
-            dev.facts["ifd_style"]
-        )
+        supercls = {
+            "CLASSIC": PhyPortClassic,
+            "SWITCH": PhyPortSwitch,
+        }.get(dev.facts["ifd_style"])
         newcls = type(cls.__name__, (supercls,), {})
         return newcls(dev, name)

--- a/lib/jnpr/junos/cfg/resource.py
+++ b/lib/jnpr/junos/cfg/resource.py
@@ -535,11 +535,11 @@ class Resource(object):
 
     def __repr__(self):
         """
-          stringify for debug/printing
+        stringify for debug/printing
 
-          this will show the resource manager (class) name,
-          the resource (Junos) name, and the contents
-          of the :has: dict and the contents of the :should: dict
+        this will show the resource manager (class) name,
+        the resource (Junos) name, and the contents
+        of the :has: dict and the contents of the :should: dict
         """
         mgr_name = self.__class__.__name__
         return (
@@ -600,9 +600,9 @@ class Resource(object):
 
     def _xml_build_change(self):
         """
-          iterate through the :should: properties creating the
-          necessary configuration change structure.  if there
-          are no changes, then return :None:
+        iterate through the :should: properties creating the
+        necessary configuration change structure.  if there
+        are no changes, then return :None:
         """
         edit_xml = self._xml_edit_at_res()
 
@@ -638,8 +638,8 @@ class Resource(object):
 
     def _r_config_write_xml(self, xml):
         """
-          write the xml change to the Junos device,
-          trapping on exceptions.
+        write the xml change to the Junos device,
+        trapping on exceptions.
         """
         top_xml = xml.getroottree().getroot()
 
@@ -757,8 +757,8 @@ class Resource(object):
 
     def _r_when_new(self):
         """
-          called by :read(): when the resource is new; i.e.
-          there is no existing Junos configuration
+        called by :read(): when the resource is new; i.e.
+        there is no existing Junos configuration
         """
         pass
 
@@ -786,7 +786,7 @@ class Resource(object):
     @classmethod
     def _r_has_xml_status(klass, as_xml, as_py):
         """
-          set the 'exists' and 'active' :has: values
+        set the 'exists' and 'active' :has: values
         """
         as_py[P_JUNOS_ACTIVE] = False if as_xml.attrib.get("inactive") else True
         as_py[P_JUNOS_EXISTS] = True

--- a/lib/jnpr/junos/command/__init__.py
+++ b/lib/jnpr/junos/command/__init__.py
@@ -5,7 +5,7 @@ import types
 
 from jnpr.junos.factory.factory_loader import FactoryLoader
 
-import yamlordereddictloader
+import yamlloader
 
 __all__ = []
 
@@ -30,7 +30,7 @@ class MetaPathLoader(object):
         with open(os.path.join(os.path.dirname(__file__), mod + ".yml"), "r") as stream:
             try:
                 modules = FactoryLoader().load(
-                    yaml.load(stream, Loader=yamlordereddictloader.Loader)
+                    yaml.load(stream, Loader=yamlloader.ordereddict.Loader)
                 )
             except yaml.YAMLError as exc:
                 raise ImportError("%s is not loaded" % mod)

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -422,15 +422,15 @@ class _Connection(object):
         raise RuntimeError("re_name is read-only!")
 
     def _sshconf_lkup(self):
-        """ Controls the ssh connection:
-            If using ssh_private_key_file on MacOS Mojave or greater
-            (specifically > OpenSSH_7.4p1) ensure that the keys are generated
-            in PEM format or convert existing 'new' keys to the PEM format:
-            Check format: `head -n1 ~/.ssh/some_key`
-            Correct RSA fomat: -----BEGIN RSA PRIVATE KEY-----
-            Incorrect OPENSSH format: -----BEGIN OPENSSH PRIVATE KEY-----
-            Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
-            """
+        """Controls the ssh connection:
+        If using ssh_private_key_file on MacOS Mojave or greater
+        (specifically > OpenSSH_7.4p1) ensure that the keys are generated
+        in PEM format or convert existing 'new' keys to the PEM format:
+        Check format: `head -n1 ~/.ssh/some_key`
+        Correct RSA fomat: -----BEGIN RSA PRIVATE KEY-----
+        Incorrect OPENSSH format: -----BEGIN OPENSSH PRIVATE KEY-----
+        Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
+        """
         if self.__class__.__name__ == "Device" and self._sock_fd is not None:
             return None
         if self._ssh_config:
@@ -1116,7 +1116,7 @@ class Device(_Connection):
 
         :param str sock_fd:
             **REQUIRED** file descriptor of an existing socket instead of providing a host.
-            Used for outbound ssh. 
+            Used for outbound ssh.
 
         :param str user:
             *OPTIONAL* login user-name, uses $USER if not provided

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -21,12 +21,12 @@ class RpcError(Exception):
 
     def __init__(self, cmd=None, rsp=None, errs=None, dev=None, timeout=None, re=None):
         """
-          :cmd: is the rpc command
-          :rsp: is the rpc response (after <rpc-reply>)
-          :errs: is a list of dictionaries of extracted <rpc-error> elements.
-          :dev: is the device rpc was executed on
-          :timeout: is the timeout value of the device
-          :re: is the RE or member exception occured on
+        :cmd: is the rpc command
+        :rsp: is the rpc response (after <rpc-reply>)
+        :errs: is a list of dictionaries of extracted <rpc-error> elements.
+        :dev: is the device rpc was executed on
+        :timeout: is the timeout value of the device
+        :re: is the RE or member exception occured on
         """
         self.cmd = cmd
         self.rsp = rsp
@@ -71,7 +71,7 @@ class RpcError(Exception):
 
     def __repr__(self):
         """
-          pprints the response XML attribute
+        pprints the response XML attribute
         """
         if self.rpc_error is not None:
             return "{}(severity: {}, bad_element: {}, message: {})".format(

--- a/lib/jnpr/junos/factory/cfgtable.py
+++ b/lib/jnpr/junos/factory/cfgtable.py
@@ -181,9 +181,12 @@ class CfgTable(Table):
         """
 
         def _get_field_type(ftype):
-            ft = {"str": str, "int": int, "float": float, "bool": bool,}.get(
-                ftype, None
-            )
+            ft = {
+                "str": str,
+                "int": int,
+                "float": float,
+                "bool": bool,
+            }.get(ftype, None)
 
             if ft is None:
                 raise TypeError("Unsupported type %s\n" % (ftype))

--- a/lib/jnpr/junos/facts/current_re.py
+++ b/lib/jnpr/junos/facts/current_re.py
@@ -37,7 +37,9 @@ def get_facts(device):
                 current_re.append(re_name[0].text)
         else:
             rsp = device.rpc.get_interface_information(
-                normalize=True, routing_instance="__juniper_private1__", terse=True,
+                normalize=True,
+                routing_instance="__juniper_private1__",
+                terse=True,
             )
 
             # Get the local IPv4 addresses from the response.

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -193,8 +193,8 @@ def remove_namespaces_and_spaces(xml):
 
 def rpc_error(rpc_xml):
     """
-      extract the various bits from an <rpc-error> element
-      into a dictionary
+    extract the various bits from an <rpc-error> element
+    into a dictionary
     """
     remove_namespaces(rpc_xml)
 

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -13,9 +13,9 @@ class _RpcMetaExec(object):
 
     def __init__(self, junos):
         """
-          ~PRIVATE CLASS~
-          creates an RPC meta-executor object bound to the provided
-          ez-netconf :junos: object
+        ~PRIVATE CLASS~
+        creates an RPC meta-executor object bound to the provided
+        ez-netconf :junos: object
         """
         self._junos = junos
 
@@ -303,12 +303,12 @@ class _RpcMetaExec(object):
 
     def __getattr__(self, rpc_cmd_name):
         """
-          metaprograms a function to execute the :rpc_cmd_name:
+        metaprograms a function to execute the :rpc_cmd_name:
 
-          the caller will be passing (*vargs, **kvargs) on
-          execution of the meta function; these are the specific
-          rpc command arguments(**kvargs) and options bound
-          as XML attributes (*vargs)
+        the caller will be passing (*vargs, **kvargs) on
+        execution of the meta function; these are the specific
+        rpc command arguments(**kvargs) and options bound
+        as XML attributes (*vargs)
         """
 
         rpc_cmd = re.sub("_", "-", rpc_cmd_name)
@@ -378,10 +378,10 @@ class _RpcMetaExec(object):
 
     def __call__(self, rpc_cmd, **kvargs):
         """
-          callable will execute the provided :rpc_cmd: against the
-          attached :junos: object and return the RPC response per
-          :junos:execute()
+        callable will execute the provided :rpc_cmd: against the
+        attached :junos: object and return the RPC response per
+        :junos:execute()
 
-          kvargs is simply passed 'as-is' to :junos:execute()
+        kvargs is simply passed 'as-is' to :junos:execute()
         """
         return self._junos.execute(rpc_cmd, **kvargs)

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -346,7 +346,7 @@ class Config(Util):
         :param dict template_vars:
           Used in conjunction with the other template options.  This parameter
           contains a dictionary of variables to render into the template.
-          
+
         :param ignore_warning: A boolean, string or list of string.
           If the value is True, it will ignore all warnings regardless of the
           warning message. If the value is a string, it will ignore

--- a/tests/functional/test_core.py
+++ b/tests/functional/test_core.py
@@ -4,11 +4,11 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from jnpr.junos.exception import RpcTimeoutError
 
 
-@attr("functional")
+@pytest.mark.functional
 class TestCore(unittest.TestCase):
     @classmethod
     def setUpClass(self):

--- a/tests/functional/test_device_ssh.py
+++ b/tests/functional/test_device_ssh.py
@@ -1,12 +1,12 @@
 __author__ = "rsherman, vnitinv"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 
 
-@attr("functional")
+@pytest.mark.functional
 class TestDeviceSsh(unittest.TestCase):
     def tearDown(self):
         self.dev.close()

--- a/tests/functional/test_outbound_ssh.py
+++ b/tests/functional/test_outbound_ssh.py
@@ -1,13 +1,13 @@
 __author__ = "mwiget"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 import socket
 from jnpr.junos import Device
 
 
-@attr("functional")
+@pytest.mark.functional
 class TestDeviceSsh(unittest.TestCase):
     def tearDown(self):
         self.dev.close()

--- a/tests/functional/test_table.py
+++ b/tests/functional/test_table.py
@@ -4,13 +4,13 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos.op.routes import RouteTable
 import json
 
 
-@attr("functional")
+@pytest.mark.functional
 class TestTable(unittest.TestCase):
     @classmethod
     def setUpClass(self):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,14 +1,14 @@
 import unittest
 import sys
 
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 
 __author__ = "Nitin Kumar"
 __credits__ = "Jeremy Schulman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestJunosInit(unittest.TestCase):
     def test_warning(self):
         with patch.object(sys.modules["sys"], "version_info", (2, 6, 3)) as mock_sys:

--- a/tests/unit/factory/test_cfgtable.py
+++ b/tests/unit/factory/test_cfgtable.py
@@ -5,7 +5,7 @@ import unittest
 import os
 import sys
 
-from nose.plugins.attrib import attr
+import pytest
 import yaml
 
 from jnpr.junos import Device
@@ -85,7 +85,7 @@ yaml_bgp_data = """---
 globals().update(FactoryLoader().load(yaml.load(yaml_bgp_data, Loader=yaml.FullLoader)))
 
 
-@attr("unit")
+@pytest.mark.unit
 @unittest.skipIf(sys.platform == "win32", "will work for windows in coming days")
 class TestFactoryCfgTable(unittest.TestCase):
     @patch("ncclient.manager.connect")

--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -11,7 +11,7 @@ from jnpr.junos.exception import RpcError
 from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 from mock import MagicMock, patch
-import yamlordereddictloader
+import yamlloader
 from jnpr.junos.factory.factory_loader import FactoryLoader
 import yaml
 import json
@@ -50,7 +50,7 @@ CMErrorView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -85,7 +85,7 @@ sysctlView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = sysctlVeriexecTable(self.dev)
@@ -126,7 +126,7 @@ CMErrorView:
     """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -188,7 +188,7 @@ CMErrorView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -212,7 +212,7 @@ CMErrorView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -240,7 +240,7 @@ CMErrorView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -267,7 +267,7 @@ CMErrorView:
     """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev)
@@ -293,7 +293,7 @@ CMErrorView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CMErrorTable(self.dev).get()
@@ -327,7 +327,7 @@ FPCLinkStatTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCLinkStatTable(self.dev)
@@ -371,7 +371,7 @@ ShowLuchipView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ShowLuchipTable(self.dev)
@@ -474,7 +474,7 @@ FPCLinkStatTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCLinkStatTable(self.dev)
@@ -518,7 +518,7 @@ XMChipStatsView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = XMChipStatsTable(self.dev)
@@ -537,7 +537,7 @@ FPCLinkStatTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCLinkStatTable(self.dev)
@@ -636,7 +636,7 @@ FPCTTPReceiveStatsView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCTTPStatsTable(self.dev)
@@ -710,7 +710,7 @@ MtipCgeStatisticsTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = MtipCgeSummaryTable(self.dev)
@@ -804,7 +804,7 @@ _ICMPRateView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ICMPStatsTable(self.dev)
@@ -905,7 +905,7 @@ _ThrottleStatsTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = IthrottleIDTable(self.dev).get(target="fpc2")
@@ -946,7 +946,7 @@ ShowPciErrorsView:
     """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ShowPciErrorsTable(self.dev).get()
@@ -988,7 +988,7 @@ FPCMemoryView:
         """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCMemory(self.dev).get()
@@ -1046,7 +1046,7 @@ PQ3PCI:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = PQ3PCITable(self.dev)
@@ -1172,7 +1172,7 @@ _TopThreadTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = SchedulerTable(self.dev)
@@ -1209,7 +1209,7 @@ HostlbStatusSummaryView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = HostlbStatusSummaryTable(self.dev)
@@ -1235,7 +1235,7 @@ HostlbStatusSummaryView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = HostlbStatusSummaryTable(
@@ -1311,7 +1311,7 @@ _TransmitPerQueueView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = DevicesLocalTable(self.dev)
@@ -1382,7 +1382,7 @@ _ReceiveView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = DevicesLocalTable(self.dev)
@@ -1402,7 +1402,7 @@ EthernetSwitchStatisticsIterTable:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = EthernetSwitchStatisticsIterTable(self.dev)
@@ -1532,7 +1532,7 @@ _EthSwitchStatsFpc5Table:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = EthernetSwitchStatistics(self.dev)
@@ -1689,7 +1689,7 @@ _ShowToePfePacketStatsStream_rx_errors:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ShowToePfePacketStatsTable(self.dev)
@@ -1757,7 +1757,7 @@ _ShowToePfePacketStatsStream_rx_errors:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ShowToePfePacketStatsTable(self.dev)
@@ -2094,7 +2094,7 @@ XMChipInterruptStatsView:
     """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = XMChipInterruptStatsTable(self.dev)
@@ -2127,7 +2127,7 @@ XMChipInterruptStatsView:
         """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = XMChipInterruptStatsTable(self.dev)
@@ -2161,7 +2161,7 @@ FPCThreadView:
             """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = FPCThreads(self.dev)
@@ -2328,7 +2328,7 @@ CChipLoStatsView:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = CChipLoStatsTable(self.dev)
@@ -2356,7 +2356,7 @@ ARPview:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ARPtable(self.dev)
@@ -2387,7 +2387,7 @@ ARPview:
 """
         globals().update(
             FactoryLoader().load(
-                yaml.load(yaml_data, Loader=yamlordereddictloader.Loader)
+                yaml.load(yaml_data, Loader=yamlloader.ordereddict.Loader)
             )
         )
         stats = ARPtable(self.dev)

--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import os
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.exception import RpcError
@@ -17,7 +17,7 @@ import yaml
 import json
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryCMDTable(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/factory/test_factory_cls.py
+++ b/tests/unit/factory/test_factory_cls.py
@@ -2,13 +2,13 @@ __author__ = "Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos.factory.factory_cls import FactoryCfgTable, FactoryOpTable
 from jnpr.junos.factory.factory_cls import FactoryTable, FactoryView
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryCls(unittest.TestCase):
     def test_factory_cls_cfgtable(self):
         t = FactoryCfgTable()

--- a/tests/unit/factory/test_factory_loader.py
+++ b/tests/unit/factory/test_factory_loader.py
@@ -2,12 +2,12 @@ __author__ = "Rick Sherman, Nitin Kumar"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from jnpr.junos.factory import FactoryLoader
 from mock import patch
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryLoader(unittest.TestCase):
     def setUp(self):
         self.fl = FactoryLoader()

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -5,7 +5,7 @@ import unittest
 import os
 import yaml
 import json
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.op.phyport import PhyPortStatsTable
@@ -22,7 +22,7 @@ from lxml import etree
 from mock import patch
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryOpTable(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -2,7 +2,7 @@ __author__ = "Rick Sherman, Nitin Kumar"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 import os
 
 from jnpr.junos import Device
@@ -23,7 +23,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryTable(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/factory/test_to_json.py
+++ b/tests/unit/factory/test_to_json.py
@@ -4,7 +4,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 import os
 import json
@@ -21,7 +21,7 @@ from ncclient.transport import SSHSession
 from ncclient.operations.rpc import RPCReply
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestToJson(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/factory/test_view.py
+++ b/tests/unit/factory/test_view.py
@@ -2,7 +2,7 @@ __author__ = "Rick Sherman, Nitin Kumar"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 from jnpr.junos import Device
 from jnpr.junos.factory.view import View
@@ -10,7 +10,7 @@ from jnpr.junos.op.phyport import PhyPortStatsTable, PhyPortStatsView
 from lxml import etree
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryView(unittest.TestCase):
     def setUp(self):
         self.dev = Device(

--- a/tests/unit/factory/test_view_fields.py
+++ b/tests/unit/factory/test_view_fields.py
@@ -2,12 +2,12 @@ __author__ = "Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos.factory.viewfields import ViewFields
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactoryViewFields(unittest.TestCase):
     def setUp(self):
         self.vf = ViewFields()

--- a/tests/unit/facts/test__init__.py
+++ b/tests/unit/facts/test__init__.py
@@ -5,14 +5,14 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 import importlib
 import sys
 
 import jnpr.junos.facts
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactInitialization(unittest.TestCase):
     def test_duplicate_facts(self):
         module = importlib.import_module("tests.unit.facts.dupe_foo1")

--- a/tests/unit/facts/test_current_re.py
+++ b/tests/unit/facts/test_current_re.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestCurrentRe(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_domain.py
+++ b/tests/unit/facts/test_domain.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestDomain(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_ethernet_mac_table.py
+++ b/tests/unit/facts/test_ethernet_mac_table.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestEthernetMacTable(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_file_list.py
+++ b/tests/unit/facts/test_file_list.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 
@@ -12,7 +12,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFileList(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_get_chassis_cluster_status.py
+++ b/tests/unit/facts/test_get_chassis_cluster_status.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestGetChassisClusterStatus(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_get_chassis_inventory.py
+++ b/tests/unit/facts/test_get_chassis_inventory.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 
@@ -12,7 +12,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestChassis(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_get_route_engine_information.py
+++ b/tests/unit/facts/test_get_route_engine_information.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -13,7 +13,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestGetRouteEngineInformation(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_get_software_information.py
+++ b/tests/unit/facts/test_get_software_information.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestGetSoftwareInformation(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_get_virtual_chassis_information.py
+++ b/tests/unit/facts/test_get_virtual_chassis_information.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 import sys
@@ -15,7 +15,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestGetVirtualChassisInformation(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_ifd_style.py
+++ b/tests/unit/facts/test_ifd_style.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from lxml import etree
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestIfdStyle(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_iri_mapping.py
+++ b/tests/unit/facts/test_iri_mapping.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 
@@ -12,7 +12,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestIriMapping(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_personality.py
+++ b/tests/unit/facts/test_personality.py
@@ -2,7 +2,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 from jnpr.junos.exception import RpcError
@@ -13,7 +13,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestPersonality(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_swver.py
+++ b/tests/unit/facts/test_swver.py
@@ -7,12 +7,12 @@ try:
     import unittest2 as unittest
 except:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos.facts.swver import version_info, get_facts
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestVersionInfo(unittest.TestCase):
     if six.PY2:
         assertCountEqual = unittest.TestCase.assertItemsEqual

--- a/tests/unit/ofacts/test_chassis.py
+++ b/tests/unit/ofacts/test_chassis.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 from lxml import etree
 import os
@@ -16,7 +16,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestChassis(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.device.warnings")

--- a/tests/unit/ofacts/test_domain.py
+++ b/tests/unit/ofacts/test_domain.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 from lxml import etree
 
@@ -11,7 +11,7 @@ from jnpr.junos import Device
 from jnpr.junos.exception import RpcError
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestDomain(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.device.warnings")

--- a/tests/unit/ofacts/test_ifd_style.py
+++ b/tests/unit/ofacts/test_ifd_style.py
@@ -3,13 +3,13 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 from mock import patch
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.ofacts.ifd_style import facts_ifd_style as ifd_style
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestIFDStyle(unittest.TestCase):
     @patch("jnpr.junos.device.warnings")
     def setUp(self, mock_warnings):

--- a/tests/unit/ofacts/test_personality.py
+++ b/tests/unit/ofacts/test_personality.py
@@ -3,13 +3,13 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 from mock import patch
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.ofacts.personality import facts_personality as personality
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestPersonality(unittest.TestCase):
     @patch("jnpr.junos.device.warnings")
     def setUp(self, mock_warnings):

--- a/tests/unit/ofacts/test_routing_engines.py
+++ b/tests/unit/ofacts/test_routing_engines.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 import sys
@@ -14,7 +14,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestRoutingEngines(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.device.warnings")

--- a/tests/unit/ofacts/test_srx_cluster.py
+++ b/tests/unit/ofacts/test_srx_cluster.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 import os
 
@@ -13,7 +13,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSrxCluster(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.device.warnings")

--- a/tests/unit/ofacts/test_switch_style.py
+++ b/tests/unit/ofacts/test_switch_style.py
@@ -3,13 +3,13 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 from mock import patch
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.ofacts.switch_style import facts_switch_style as switch_style
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSwitchStyle(unittest.TestCase):
     @patch("jnpr.junos.device.warnings")
     def setUp(self, mock_warnings):

--- a/tests/unit/ofacts/test_swver.py
+++ b/tests/unit/ofacts/test_swver.py
@@ -5,7 +5,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock
 import os
 
@@ -17,7 +17,7 @@ from ncclient.transport import SSHSession
 from jnpr.junos.exception import RpcError
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSwver(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.device.warnings")

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import unittest
 from jnpr.junos.utils.config import Config
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock, call
 import re
 import sys
@@ -23,7 +23,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestConsole(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_telnet.Telnet._tty_open")
     @patch("jnpr.junos.transport.tty_telnet.telnetlib.Telnet.expect")

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -2,7 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from lxml.etree import XML
 
@@ -22,7 +22,7 @@ from ncclient.xml_ import qualify
 __author__ = "Rick Sherman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class Test_Decorators(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -2,7 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch, mock_open, call
 import os
 from lxml import etree
@@ -53,7 +53,7 @@ facts = {
 }
 
 
-@attr("unit")
+@pytest.mark.unit
 class Test_MyTemplateLoader(unittest.TestCase):
     def setUp(self):
         from jnpr.junos.device import _MyTemplateLoader
@@ -78,7 +78,7 @@ class Test_MyTemplateLoader(unittest.TestCase):
             self.template_loader.get_source(None, None)
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestDevice(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 from jnpr.junos.exception import (
     RpcError,
     CommitError,
@@ -81,7 +81,7 @@ config_json = """{
 }"""
 
 
-@attr("unit")
+@pytest.mark.unit
 class Test_RpcError(unittest.TestCase):
     def test_rpcerror_repr(self):
         rsp = etree.XML(rpc_xml)

--- a/tests/unit/test_factcache.py
+++ b/tests/unit/test_factcache.py
@@ -2,7 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch, MagicMock, call
 from jnpr.junos.exception import FactLoopError
 
@@ -15,7 +15,7 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFactCache(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/test_junos.py
+++ b/tests/unit/test_junos.py
@@ -3,14 +3,14 @@
 import unittest
 import sys
 
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 
 __author__ = "Nitin Kumar"
 __credits__ = "Jeremy Schulman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestJunosInit(unittest.TestCase):
     def test_warning(self):
         with patch.object(sys.modules["sys"], "version_info", (2, 6, 3)) as mock_sys:

--- a/tests/unit/test_jxml.py
+++ b/tests/unit/test_jxml.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from io import StringIO
-from nose.plugins.attrib import attr
+import pytest
 from mock import patch
 from jnpr.junos.jxml import (
     NAME,
@@ -17,7 +17,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class Test_JXML(unittest.TestCase):
     def test_name(self):
         op = NAME("test")

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import re
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos.device import Device
 from jnpr.junos.rpcmeta import _RpcMetaExec
@@ -17,7 +17,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class Test_RpcMetaExec(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/transport/test_serial.py
+++ b/tests/unit/transport/test_serial.py
@@ -2,7 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 import sys
 import six
@@ -15,7 +15,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSerial(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_serial.serial.Serial.open")
     @patch("jnpr.junos.transport.tty_serial.serial.Serial.write")
@@ -77,7 +77,7 @@ class TestSerial(unittest.TestCase):
         self.assertEqual(self.dev._tty.read_prompt()[0], None)
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSerialWin(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_serial.serial.Serial.open")
     @patch("jnpr.junos.transport.tty_serial.serial.Serial.read")

--- a/tests/unit/transport/test_tty.py
+++ b/tests/unit/transport/test_tty.py
@@ -5,14 +5,14 @@ try:
 except ImportError:
     import unittest
 
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 
 from jnpr.junos.transport.tty import Terminal
 from jnpr.junos import exception as EzErrors
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestTTY(unittest.TestCase):
     def setUp(self):
         logging.getLogger("jnpr.junos.tty")

--- a/tests/unit/transport/test_tty_netconf.py
+++ b/tests/unit/transport/test_tty_netconf.py
@@ -2,7 +2,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 from jnpr.junos.transport.tty_netconf import tty_netconf
 import six
@@ -12,7 +12,7 @@ import socket
 from ncclient.operations import RPCError
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestTTYNetconf(unittest.TestCase):
     def setUp(self):
         self.tty_net = tty_netconf(MagicMock())

--- a/tests/unit/transport/test_tty_ssh.py
+++ b/tests/unit/transport/test_tty_ssh.py
@@ -5,12 +5,12 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 from jnpr.junos.transport.tty_ssh import SSH
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestTTYSSH(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_ssh.paramiko")
     def setUp(self, mock_paramiko):

--- a/tests/unit/transport/test_tty_telnet.py
+++ b/tests/unit/transport/test_tty_telnet.py
@@ -4,13 +4,13 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from mock import MagicMock, patch
 from jnpr.junos.transport.tty_telnet import Telnet
 import six
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestTTYTelnet(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_telnet.telnetlib.Telnet")
     def setUp(self, mpock_telnet):

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.utils.config import Config
@@ -32,7 +32,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestConfig(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 import os
 
 from ncclient.manager import Manager, make_device_handler
@@ -16,7 +16,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestFS(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 import ftplib
 import sys
 import os
@@ -15,7 +15,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 @unittest.skipIf(sys.platform == "win32", "will work for windows in coming days")
 class TestFtp(unittest.TestCase):
     @patch("ftplib.FTP.connect")

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -95,7 +95,10 @@ class TestFtp(unittest.TestCase):
     @patch("ftplib.FTP.login")
     @patch("ftplib.FTP.retrbinary")
     def test_ftp_dnload_file_get_rf_filename_cb(
-        self, mock_ftp_connect, mock_ftp_login, mock_ftp_retrbinary,
+        self,
+        mock_ftp_connect,
+        mock_ftp_login,
+        mock_ftp_retrbinary,
     ):
         def callback():
             pass

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -3,7 +3,7 @@ from six import StringIO
 from contextlib import contextmanager
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.utils.scp import SCP
@@ -19,7 +19,7 @@ else:
     builtin_string = "builtins"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestScp(unittest.TestCase):
     def setUp(self):
         self.dev = Device(host="1.1.1.1")

--- a/tests/unit/utils/test_start_shell.py
+++ b/tests/unit/utils/test_start_shell.py
@@ -1,5 +1,5 @@
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.utils.start_shell import StartShell
@@ -10,7 +10,7 @@ __author__ = "Rick Sherman"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestStartShell(unittest.TestCase):
     @patch("paramiko.SSHClient")
     def setUp(self, mock_connect):

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -7,7 +7,7 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
-from nose.plugins.attrib import attr
+import pytest
 from contextlib import contextmanager
 from jnpr.junos import Device
 from jnpr.junos.exception import RpcError, SwRollbackError, RpcTimeoutError
@@ -59,7 +59,7 @@ facts = {
 }
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestSW(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/utils/test_util.py
+++ b/tests/unit/utils/test_util.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from nose.plugins.attrib import attr
+import pytest
 
 from jnpr.junos import Device
 from jnpr.junos.utils.util import Util
@@ -10,7 +10,7 @@ from jnpr.junos.utils.util import Util
 from mock import patch
 
 
-@attr("unit")
+@pytest.mark.unit
 class TestUtil(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):


### PR DESCRIPTION
Both nose and yamlordereddictloader are not maintained anymore and dependency on the should be avoided.