### PR TITLE
docstring initialized with empty string

### DIFF
--- a/lib/jnpr/junos/factcache.py
+++ b/lib/jnpr/junos/factcache.py
@@ -296,7 +296,7 @@ class _FactCache(collections.MutableMapping):
 
     # In case optimization flag is enabled, it strips of docstring and __doc__ becomes None
     if __doc__ is None:
-        __doc__ = " "
+        __doc__ = ""
 
     # Precede the class's documentation with the documentation on the specific
     # facts from  the jnpr.junos.facts package.

--- a/lib/jnpr/junos/factcache.py
+++ b/lib/jnpr/junos/factcache.py
@@ -294,7 +294,10 @@ class _FactCache(collections.MutableMapping):
                 self._warnings_on_failure = False
                 self._should_warn = False
 
+    # In case optimization flag is enabled, it strips of docstring and __doc__ becomes None
+    if __doc__ is None:
+        __doc__ = " "
+
     # Precede the class's documentation with the documentation on the specific
     # facts from  the jnpr.junos.facts package.
-    print(__doc__)
     __doc__ = facts_doc + "Implementation details on the _FactCache class:" + __doc__

--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -86,6 +86,10 @@ def _build_fact_callbacks_and_doc_strings():
 # Import all of the fact modules and build the callbacks and doc strings
 (_callbacks, _doc_strings) = _build_fact_callbacks_and_doc_strings()
 
+# In case optimization flag is enabled, it strips of docstring and __doc__ becomes None
+if __doc__ is None:
+    __doc__ = " "
+
 # Append the doc string (__doc__) with the documentation for each fact.
 for key in sorted(_doc_strings, key=lambda s: s.lower()):
     __doc__ += ":%s:\n  %s\n" % (key, _doc_strings[key])

--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -88,7 +88,7 @@ def _build_fact_callbacks_and_doc_strings():
 
 # In case optimization flag is enabled, it strips of docstring and __doc__ becomes None
 if __doc__ is None:
-    __doc__ = " "
+    __doc__ = ""
 
 # Append the doc string (__doc__) with the documentation for each fact.
 for key in sorted(_doc_strings, key=lambda s: s.lower()):


### PR DESCRIPTION
During optimization if present , the docstring is removed and becomes None, so the code can fail where __doc__ is being used as a string. 