### PR TITLE
Inorrect import from 'collections' will stop working in Python 3.9

### DIFF
--- a/lib/jnpr/junos/factcache.py
+++ b/lib/jnpr/junos/factcache.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import warnings
 from pprint import pformat
 
@@ -7,7 +7,7 @@ from jnpr.junos.facts import __doc__ as facts_doc
 import jnpr.junos.exception
 
 
-class _FactCache(collections.MutableMapping):
+class _FactCache(collections.abc.MutableMapping):
     """
     A dictionary-like object which performs on-demand fact gathering.
 


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
Solving #1089 