### PR TITLE
Newer junos versions return a bool for config diff if there are no changes

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -260,6 +260,10 @@ class Config(Util):
             else:
                 raise
 
+        # Check return type is an etree Element, if not return None for no changes
+        if not type(rsp) == etree._Element:
+            return None
+
         diff_txt = rsp.find("configuration-output").text
         return None if diff_txt == "\n" else diff_txt
 


### PR DESCRIPTION
Check return type is an etree Element, if not return None for no changes. Fixes #1082