### PR TITLE
Fix for issue #1093

### DIFF
--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -268,7 +268,7 @@ class Config(Util):
                 "diff shouldn't return boolean as a rpc-reply",
                 RuntimeWarning,
             )
-            return None
+            return None 
                 
         diff_txt = rsp.find("configuration-output").text
         return None if diff_txt == "\n" else diff_txt

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -268,8 +268,8 @@ class Config(Util):
                 "diff shouldn't return boolean as a rpc-reply",
                 RuntimeWarning,
             )
-            return None 
-                
+            return None
+
         diff_txt = rsp.find("configuration-output").text
         return None if diff_txt == "\n" else diff_txt
 

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -260,6 +260,11 @@ class Config(Util):
             else:
                 raise
 
+        # Fix for Issue #1093, Newer Junos versions return a bool for config 
+        # diff if there are no changes
+        if isinstance(rsp, bool) and rsp:
+            return None
+                
         diff_txt = rsp.find("configuration-output").text
         return None if diff_txt == "\n" else diff_txt
 

--- a/lib/jnpr/junos/utils/config.py
+++ b/lib/jnpr/junos/utils/config.py
@@ -260,9 +260,14 @@ class Config(Util):
             else:
                 raise
 
-        # Fix for Issue #1093, Newer Junos versions return a bool for config 
-        # diff if there are no changes
-        if isinstance(rsp, bool) and rsp:
+        # The output is expected to be an etree, it may have empty <configuration-output> tags
+        # Adding a preventive check and displaying warning in case the value is bool.
+        # This check is added for PR 1564189 (juniper internal) which has issue for certain junos releases.
+        if isinstance(rsp, bool):
+            warnings.warn(
+                "diff shouldn't return boolean as a rpc-reply",
+                RuntimeWarning,
+            )
             return None
                 
         diff_txt = rsp.find("configuration-output").text


### PR DESCRIPTION
Added check for rsp variable in method diff to check for variable being a bool and then checking that the value is True before returning None which means no changes in the configuration for certain Junos releases.