### PR TITLE
Populate the component

### DIFF
--- a/lib/jnpr/junos/dcs.py
+++ b/lib/jnpr/junos/dcs.py
@@ -142,7 +142,7 @@ class DCS(_Connection):
             if isinstance(rpc_cmd_e, etree._Element)
             else rpc_cmd_e
         )
-        di = self._grpc_types_pb2.DeviceInfo(UUID=self._dev_uuid)
+        di = self._grpc_types_pb2.DeviceInfo(UUID=self._dev_uuid, component="JUNOS")
         exec = self._grpc_dcs_pb2.GetRequest(command=[rpc_cmd], device_info=di)
         res = self._grpc_conn_stub.Get(request=exec, metadata=self._grpc_meta_data)
         if res.error_code != self._grpc_types_pb2.NoError:


### PR DESCRIPTION
The DeviceInfo needs to be populated with the component along with the UUID so that the DCS  Service will use the device initiated connection. Currently it uses the connecton established from the application to the device

Configuration on the device side 

```bash
regress@vmx105# show system services
netconf {
    ssh;
    rfc-compliant;
}
outbound-ssh {
    client EMS-10.54.146.223 {
        device-id 910833ae-0943-40ac-9b9c-f639344c04cd.JUNOS;
        secret "$9$pd7-OBEleWL7-KvZUji.mcyreX7JZUDk.Y2ZjkqQzBIRElK8LNY2acy-Vw2aJ36/CBIcyl8X7vM87Vwg49AtOEcylKWX7vMX-ws4oz3n9Cu"; ## SECRET-DATA
        keep-alive;
        services netconf;
        10.54.146.223 port 7804;
    }
}

```