### PR TITLE
fixed issue #1135

### DIFF
--- a/lib/jnpr/junos/facts/current_re.py
+++ b/lib/jnpr/junos/facts/current_re.py
@@ -68,6 +68,10 @@ def get_facts(device):
                                 cluster_id_octet = str(
                                     (int(device.facts["srx_cluster_id"]) & 0x000F) << 4
                                 )
+                                if cluster_id_octet == "0":
+                                    cluster_id_octet = str(
+                                        device.facts["srx_cluster_id"]
+                                    )
                                 # node0 will have an IP of
                                 #     129.<cluster_id_octet>.0.1
                                 # node1 will have an IP of


### PR DESCRIPTION
is srx_cluster_id is  16 or multiples of 16 , then cluster_id_octet is set to '0' ,  added following lines to  initialize the cluster_id_octet value to srx_cluster_id  , cluster_id_octet is set to '0'

                                if cluster_id_octet == "0":
                                    cluster_id_octet = str(
                                        device.facts["srx_cluster_id"]
                                    )