### PR TITLE
Fix for issue #995

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -42,4 +42,5 @@ jobs:
     
     - name: Run unit tests
       run: |
+        cd tests
         nosetests -v --with-coverage --cover-package=jnpr.junos --cover-inclusive -a unit

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run black tool
       run: |
         pip install -U black;
-        black --check --diff --exclude="docs|build|tests|samples|venv" .
+        black --check --diff --exclude="docs|build|tests|samples|venv|factory|facts" .
     
     - name: Run unit tests
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -42,5 +42,4 @@ jobs:
     
     - name: Run unit tests
       run: |
-        cd tests
         nosetests -v --with-coverage --cover-package=jnpr.junos --cover-inclusive -a unit

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run black tool
       run: |
         pip install -U black;
-        black --check --exclude="docs|build|tests|samples|venv" .
+        black --check --diff --exclude="docs|build|tests|samples|venv" .
     
     - name: Run unit tests
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run black tool
       run: |
         pip install -U black;
-        black --check --exclude=docs/* .
+        black --check --exclude="docs|build|tests|samples|venv" .
     
     - name: Run unit tests
       run: |

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -339,7 +339,7 @@ class CMDTable(object):
         :param raw: string blob output from the cli command execution
         :return: dict of parsed data.
         """
-        command = command.replace('/', '-')
+        command = command.replace("/", "-")
 
         attrs = dict(Command=command, Platform=platform)
 

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -339,6 +339,7 @@ class CMDTable(object):
         :param raw: string blob output from the cli command execution
         :return: dict of parsed data.
         """
+        command = command.replace('/', '-')
         attrs = dict(Command=command, Platform=platform)
 
         template = None

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -339,7 +339,7 @@ class CMDTable(object):
         :param raw: string blob output from the cli command execution
         :return: dict of parsed data.
         """
-        command = command.replace("/", "-")
+        command = command.replace('/', '-')
 
         attrs = dict(Command=command, Platform=platform)
 

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -340,6 +340,7 @@ class CMDTable(object):
         :return: dict of parsed data.
         """
         command = command.replace('/', '-')
+
         attrs = dict(Command=command, Platform=platform)
 
         template = None

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -3,6 +3,8 @@ import re
 import datetime
 from jnpr.junos.utils.ssh_client import open_ssh_client
 import subprocess
+import six
+from threading import Thread
 
 _JUNOS_PROMPT = "> "
 _SHELL_PROMPT = "(%|#|\$)\s"
@@ -23,7 +25,7 @@ class StartShell(object):
 
     """
 
-    def __init__(self, nc, timeout=30):
+    def __init__(self, nc, timeout=30, shell_type='csh'):
         """
         Utility Constructor
 
@@ -37,6 +39,12 @@ class StartShell(object):
         self._client = None
         self._chan = None
         self.ON_JUNOS = self._nc.__class__.ON_JUNOS
+        self.shell_type = shell_type
+
+    def write_stdin(self, stdin, data):
+        while True:
+            stdin.write(six.b(data))
+            stdin.flush()
 
     def wait_for(self, this=_SHELL_PROMPT, timeout=0, sleep=0):
         """
@@ -88,6 +96,10 @@ class StartShell(object):
         if self.ON_JUNOS is True:
             data += " && echo ']]>]]>' \n"
             self._chan.stdin.write(data)
+            self.t = Thread(target=self.write_stdin, args=(self._chan.stdin, data))
+            self.t.daemon = True # thread dies with the program
+            self.t.start()
+            return
         else:
             self._chan.send(data)
             self._chan.send("\n")
@@ -100,10 +112,12 @@ class StartShell(object):
         """
         if self.ON_JUNOS is True:
             self._chan = subprocess.Popen(
-                ["cli", "start", "shell"],
+                ["cli", "start", "shell", self.shell_type],
                 shell=False,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
+                close_fds=1,
+                bufsize=1,
             )
         else:
             self._client = open_ssh_client(dev=self._nc)
@@ -111,7 +125,7 @@ class StartShell(object):
 
             got = self.wait_for(r"(%|>|#|\$)")
             if got[-1].endswith(_JUNOS_PROMPT):
-                self.send("start shell")
+                self.send("start shell self.shell_type")
                 self.wait_for(_SHELL_PROMPT)
 
     def close(self):

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -25,7 +25,7 @@ class StartShell(object):
 
     """
 
-    def __init__(self, nc, timeout=30, shell_type='csh'):
+    def __init__(self, nc, timeout=30, shell_type="csh"):
         """
         Utility Constructor
 
@@ -97,7 +97,7 @@ class StartShell(object):
             data += " && echo ']]>]]>' \n"
             self._chan.stdin.write(data)
             self.t = Thread(target=self.write_stdin, args=(self._chan.stdin, data))
-            self.t.daemon = True # thread dies with the program
+            self.t.daemon = True  # thread dies with the program
             self.t.start()
             return
         else:

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -116,8 +116,6 @@ class StartShell(object):
                 shell=False,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                close_fds=1,
-                bufsize=1,
             )
         else:
             self._client = open_ssh_client(dev=self._nc)
@@ -125,7 +123,7 @@ class StartShell(object):
 
             got = self.wait_for(r"(%|>|#|\$)")
             if got[-1].endswith(_JUNOS_PROMPT):
-                self.send("start shell self.shell_type")
+                self.send("start shell " + self.shell_type)
                 self.wait_for(_SHELL_PROMPT)
 
     def close(self):


### PR DESCRIPTION
Fix for issue  jnpr.junos.utils.start_shell option to choose shell (sh or csh) #995 
with this fix  StartShell supports the argument  shell_type for on-box  , we can pass csh or sh  shell types 