### PR TITLE
chore: use ne for comparison against non literal

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -906,7 +906,7 @@ class _Connection(object):
             #    protocol: operation-failed
             #    error: device asdf not found
             # </rpc-reply>
-            if rpc_rsp_e.text is not None and rpc_rsp_e.text.strip() is not "":
+            if rpc_rsp_e.text is not None and rpc_rsp_e.text.strip() != "":
                 return rpc_rsp_e
             # no children, so assume it means we are OK
             return True
@@ -1342,7 +1342,7 @@ class Device(_Connection):
         """
 
         auto_probe = kvargs.get("auto_probe", self._auto_probe)
-        if auto_probe is not 0:
+        if auto_probe != 0:
             if not self.probe(auto_probe):
                 raise EzErrors.ProbeError(self)
 

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -154,7 +154,7 @@ class _RpcMetaExec(object):
             self._junos.transform = transform
         # in case of model provided top level should be data
         # return response
-        if model and filter_xml is None and options.get("format") is not "json":
+        if model and filter_xml is None and options.get("format") != "json":
             response = response.getparent()
             response.tag = "data"
         return response

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -171,7 +171,7 @@ class StartShell(object):
             got = "".join(self.wait_for(this, timeout, sleep=sleep))
             self.last_ok = False
             if this is None:
-                self.last_ok = got is not ""
+                self.last_ok = got != ""
             elif this != _SHELL_PROMPT:
                 self.last_ok = re.search(r"{}\s?$".format(this), got) is not None
             elif re.search(r"{}\s?$".format(_SHELL_PROMPT), got) is not None:


### PR DESCRIPTION
Use `!=` for comparison against non-literal, since Python >= 3.8 emits a warning about it.

```
.../.venv/lib/python3.9/site-packages/jnpr/junos/device.py:909: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if rpc_rsp_e.text is not None and rpc_rsp_e.text.strip() is not "":
.../.venv/lib/python3.9/site-packages/jnpr/junos/device.py:1330: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if auto_probe is not 0:
.../.venv/lib/python3.9/site-packages/jnpr/junos/rpcmeta.py:157: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if model and filter_xml is None and options.get("format") is not "json":
.../.venv/lib/python3.9/site-packages/jnpr/junos/utils/start_shell.py:147: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  self.last_ok = got is not ""
```

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>