### PR TITLE
Fix lxml version

### DIFF
--- a/lib/jnpr/junos/factory/table.py
+++ b/lib/jnpr/junos/factory/table.py
@@ -245,7 +245,9 @@ class Table(object):
             fname += "_%s" % append
 
         path = fname + fext
-        return etree.ElementTree(self.xml).write(open(path, "wb"))
+        with open(path, "wb+") as f:
+            pass
+        return etree.ElementTree(self.xml).write(path)
 
     def to_json(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml>=3.2.4<=3.7.1
+lxml>=3.2.4
 # ncclient version 0.6.10 has issues with PyEZ(junos-eznc) and needs to be avoided
 ncclient==0.6.9
 paramiko>=1.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml>=3.2.4
+lxml>=3.2.4<=3.7.1
 # ncclient version 0.6.10 has issues with PyEZ(junos-eznc) and needs to be avoided
 ncclient==0.6.9
 paramiko>=1.15.2

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -139,9 +139,9 @@ class TestFactoryTable(unittest.TestCase):
     def test_table_savexml(self, mock_file, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.ppt.xml = etree.XML("<root><a>test</a></root>")
-        self.ppt.savexml("/vasr/tmssp/foo.xml", hostname=True, append="test")
-        mock_file.assert_called_once_with("/vasr/tmssp/foo_1.1.1.1_test.xml", "wb")
-        self.ppt.savexml("/vasr/tmssp/foo.xml", hostname=True, timestamp=True)
+        self.ppt.savexml("foo.xml", hostname=True, append="test")
+        mock_file.assert_called_once_with("foo_1.1.1.1_test.xml", "wb+")
+        self.ppt.savexml("foo.xml", hostname=True, timestamp=True)
         self.assertEqual(mock_file.call_count, 2)
 
     def _read_file(self, fname):


### PR DESCRIPTION
Fix the testcase post lxml version update

Related issue : https://github.com/Juniper/py-junos-eznc/issues/1157