### PR TITLE
Issue 1162 fix1

### DIFF
--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -339,6 +339,7 @@ class CMDTable(object):
         :param raw: string blob output from the cli command execution
         :return: dict of parsed data.
         """
+        command = command.replace('/', '-')
         attrs = dict(Command=command, Platform=platform)
 
         template = None

--- a/lib/jnpr/junos/factory/cmdtable.py
+++ b/lib/jnpr/junos/factory/cmdtable.py
@@ -340,6 +340,7 @@ class CMDTable(object):
         :return: dict of parsed data.
         """
         command = command.replace('/', '-')
+
         attrs = dict(Command=command, Platform=platform)
 
         template = None


### PR DESCRIPTION
Issue with converting commands with "/" to file names .
Linux was forbidden to use the “/” character in the filename because it considers a directory/file path separator
fix added to replace “/” with “-” to create the file.
