### PR TITLE
Pull request for pyez release 2.6.4

### DIFF
--- a/INSTALL-RHEL.md
+++ b/INSTALL-RHEL.md
@@ -1,0 +1,41 @@
+### Installation on RHEL
+
+The following are instructions for setting up a system starting from a stock system images.
+
+These instructions were tested on a 64-bit systems from https://github.com/opscode/bento, and using the _Junos PyEZ_ library version 2.6.3.
+
+Operating Systems
+---------------
+- Red hat Enterprise Linux 8.1 (Ootpa)
+
+#### Step 1: Install Python and PIP
+
+##### For Python 3.x:
+###### For RHEL:
+
+#### Step 1: Install Junos PyEZ
+
+##### For Python 3.x:
+        sudo pip3 install junos-eznc
+
+#### Step 2: Verify 
+
+Once you've completed the above step, you should be able to create a `Device` instance, connect to a Junos system, and display the "facts", as illustrated in the README.md file.
+
+Enjoy!
+
+
+#### Installing from GitHub
+
+Development code can be installed directly from GitHub based on any branch, commit, or tag.
+
+***Steps 1 -2 are still required.***
+#### Alternate Step 4: Install Junos PyEZ from GitHub
+
+#### Step 4a: Install Git from OS packages
+    pip install git
+
+#### Step 4b: Install Junos PyEZ from GitHub
+
+##### For Python 3.x:
+	    pip install git+https://github.com/Juniper/py-junos-eznc.git

--- a/INSTALL-RHEL.md
+++ b/INSTALL-RHEL.md
@@ -2,7 +2,7 @@
 
 The following are instructions for setting up a system starting from a stock system images.
 
-These instructions were tested on a 64-bit systems from https://github.com/opscode/bento, and using the _Junos PyEZ_ library version 2.6.3.
+These instructions were tested on a 64-bit systems from https://github.com/opscode/bento, and using the _Junos PyEZ_ library version 2.6.4.
 
 Operating Systems
 ---------------
@@ -11,7 +11,7 @@ Operating Systems
 #### Step 1: Install Python and PIP
 
 ##### For Python 3.x:
-###### For RHEL:
+       dnf install python3-pip python3-wheel
 
 #### Step 2: Install Junos PyEZ
 
@@ -33,9 +33,9 @@ Development code can be installed directly from GitHub based on any branch, comm
 #### Alternate Step 4: Install Junos PyEZ from GitHub
 
 #### Step 4a: Install Git from OS packages
-    pip install git
+        pip3 install git
 
 #### Step 4b: Install Junos PyEZ from GitHub
 
 ##### For Python 3.x:
-	    pip install git+https://github.com/Juniper/py-junos-eznc.git
+	    pip3 install git+https://github.com/Juniper/py-junos-eznc.git

--- a/INSTALL-RHEL.md
+++ b/INSTALL-RHEL.md
@@ -29,13 +29,13 @@ Enjoy!
 
 Development code can be installed directly from GitHub based on any branch, commit, or tag.
 
-***Step 1  still required.***
-#### Alternate Step 3: Install Junos PyEZ from GitHub
+***Step 1 and 3 still required.***
+#### Alternate Step 4: Install Junos PyEZ from GitHub
 
-#### Step 3a: Install Git from OS packages
+#### Step 4a: Install Git from OS packages
     pip install git
 
-#### Step 3b: Install Junos PyEZ from GitHub
+#### Step 4b: Install Junos PyEZ from GitHub
 
 ##### For Python 3.x:
 	    pip install git+https://github.com/Juniper/py-junos-eznc.git

--- a/INSTALL-RHEL.md
+++ b/INSTALL-RHEL.md
@@ -24,7 +24,6 @@ Once you've completed the above step, you should be able to create a `Device` in
 
 Enjoy!
 
-
 #### Installing from GitHub
 
 Development code can be installed directly from GitHub based on any branch, commit, or tag.

--- a/INSTALL-RHEL.md
+++ b/INSTALL-RHEL.md
@@ -13,12 +13,12 @@ Operating Systems
 ##### For Python 3.x:
 ###### For RHEL:
 
-#### Step 1: Install Junos PyEZ
+#### Step 2: Install Junos PyEZ
 
 ##### For Python 3.x:
         sudo pip3 install junos-eznc
 
-#### Step 2: Verify 
+#### Step 3: Verify 
 
 Once you've completed the above step, you should be able to create a `Device` instance, connect to a Junos system, and display the "facts", as illustrated in the README.md file.
 
@@ -29,13 +29,13 @@ Enjoy!
 
 Development code can be installed directly from GitHub based on any branch, commit, or tag.
 
-***Steps 1 -2 are still required.***
-#### Alternate Step 4: Install Junos PyEZ from GitHub
+***Step 1  still required.***
+#### Alternate Step 3: Install Junos PyEZ from GitHub
 
-#### Step 4a: Install Git from OS packages
+#### Step 3a: Install Git from OS packages
     pip install git
 
-#### Step 4b: Install Junos PyEZ from GitHub
+#### Step 3b: Install Junos PyEZ from GitHub
 
 ##### For Python 3.x:
 	    pip install git+https://github.com/Juniper/py-junos-eznc.git

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,7 +2,6 @@
 ### Features Added
 - Supported start_shell options to choose the shell types (sh or csh) #995
 - Supported for python 3.9
-
 ### Bugs fixed:
 - Fixed Device facts current_re returns the SRX cluster  node0 and node1 details with cluster ID 16 #1135
 - Fixed upgrade ncclient version 0.6.13, updated requirements.txt to install ncclient==0.6.13 #1153

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,7 +1,7 @@
 ## Release 2.6.4 - 9 JUNE 2022
 ### Features Added
 - Supported start_shell options to choose the shell types (sh or csh) #995
-- Support for python 3.9
+- Supported for python 3.9
 
 ### Bugs fixed:
 - Fixed Device facts current_re returns the SRX cluster  node0 and node1 details with cluster ID 16 #1135

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,13 @@
+## Release 2.6.4 - 9 JUNE 2022
+### Features Added
+- Supported start_shell options to choose the shell types (sh or csh) #995
+
+### Bugs fixed:
+- Fixed Device facts current_re returns the SRX cluster  node0 and node1 details with cluster ID 16 #1135
+- Fixed upgrade ncclient version 0.6.13, updated requirements.txt to install ncclient==0.6.13 #1153
+- Fixed deprecation warning due to invalid escape sequences #1034
+- Fixed Unit tests test_sw_put_ftp failure #1165
+
 ## Release 2.4.2.dev0 - 29 APRIL 2020
 ## Features Added
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,7 @@
 - Fixed upgrade ncclient version 0.6.13, updated requirements.txt to install ncclient==0.6.13 #1153
 - Fixed deprecation warning due to invalid escape sequences #1034
 - Fixed Unit tests test_sw_put_ftp failure #1165
+- Support for python 3.9
 
 ## Release 2.4.2.dev0 - 29 APRIL 2020
 ## Features Added

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,6 @@
 - Fixed deprecation warning due to invalid escape sequences #1034
 - Fixed Unit tests test_sw_put_ftp failure #1165
 
-
 ## Release 2.4.2.dev0 - 29 APRIL 2020
 ## Features Added
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,13 +1,14 @@
 ## Release 2.6.4 - 9 JUNE 2022
 ### Features Added
 - Supported start_shell options to choose the shell types (sh or csh) #995
+- Support for python 3.9
 
 ### Bugs fixed:
 - Fixed Device facts current_re returns the SRX cluster  node0 and node1 details with cluster ID 16 #1135
 - Fixed upgrade ncclient version 0.6.13, updated requirements.txt to install ncclient==0.6.13 #1153
 - Fixed deprecation warning due to invalid escape sequences #1034
 - Fixed Unit tests test_sw_put_ftp failure #1165
-- Support for python 3.9
+
 
 ## Release 2.4.2.dev0 - 29 APRIL 2020
 ## Features Added

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -84,7 +84,7 @@ class Serial(Terminal):
             line = self._ser.readline()
             if not line:
                 continue
-            rxb += b"line"
+            rxb += line
             found = _PROMPT.search(rxb)
             if found is not None:
                 break  # done reading

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -84,7 +84,7 @@ class Serial(Terminal):
             line = self._ser.readline()
             if not line:
                 continue
-            rxb += line
+            rxb += b'line'
             found = _PROMPT.search(rxb)
             if found is not None:
                 break  # done reading

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -84,7 +84,7 @@ class Serial(Terminal):
             line = self._ser.readline()
             if not line:
                 continue
-            rxb += b'line'
+            rxb += b"line"
             found = _PROMPT.search(rxb)
             if found is not None:
                 break  # done reading

--- a/lib/jnpr/junos/version.py
+++ b/lib/jnpr/junos/version.py
@@ -1,5 +1,5 @@
-VERSION = "2.5.0"
-DATE = "2020-Jun-15"
+VERSION = "2.6.4"
+DATE = "2022-Jun-9"
 
 # Augment with the internal version if present
 try:

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
What does this PR do?

Pull request for pyez release 2.6.4

What issues does this PR fix or reference?
Release 2.6.4
Enhancements done
Supported start_shell options to choose the shell types (sh or csh) #995
Bugs Fixed
Fixed Device facts current_re returns the SRX cluster  node0 and node1 details with cluster ID 16 #1135
Fixed upgrade ncclient version 0.6.13, updated requirements.txt to install ncclient==0.6.13 #1153
Fixed deprecation warning due to invalid escape sequences #1034
Fixed Unit tests test_sw_put_ftp failure #1165

Tests written?

Yes/No