### PR TITLE
fix reboot failing on other RE

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1077,7 +1077,7 @@ class SW(Util):
         """
         if other_re is True:
             if self._dev.facts["2RE"]:
-                cmd = E("other-routing-engine")
+                cmd.append(E("other-routing-engine"))
         elif all_re is True:
             if self._multi_RE is True and vmhost is True:
                 cmd.append(E("routing-engine", "both"))


### PR DESCRIPTION
<request-reboot> tag is missing from Pyez. Appended the tag in order to reboot other RE successfully. 