### PR TITLE
Fix issue calling dev.rpc.get() on JunOS 12.3R12.4 (Ref. EX2200-24P-4G)

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -211,7 +211,9 @@ class _RpcMetaExec(object):
         filter_params = {"type": "xpath"}
         if filter_select is not None:
             filter_params["source"] = filter_select
-        rpc = E("get", E("filter", filter_params))
+            rpc = E("get", E("filter", filter_params))
+        else:
+            rpc = E("get")
         return self._junos.execute(rpc, ignore_warning=ignore_warning, **kwargs)
 
     # -----------------------------------------------------------------------


### PR DESCRIPTION
Without this change, the EX2200-24P-4G (running the last supported version for the hardware: 12.3R12.4) will return `ncclient.operations.rpc.RPCError: syntax error, expecting <filter> or </get>`