### PR TITLE
Fix for issue #1206

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -920,9 +920,10 @@ class SW(Util):
         ):
             pkg_set = [package]
         if isinstance(pkg_set, (list, tuple)) and len(pkg_set) > 0:
+            remote_urls = ("ftp", "scp", "http", "https", "tftp")
             for pkg in pkg_set:
                 parsed_url = urlparse(pkg)
-                if parsed_url.scheme == "":
+                if parsed_url.scheme not in remote_urls:
                     if no_copy is False:
                         # To disable cleanfs after 1st iteration
                         cleanfs = cleanfs and pkg_set.index(pkg) == 0


### PR DESCRIPTION
Fix for issue #1206 , 
sw.install fails due to urlparase of C:\Users*\Desktop*\network_switch_tool\ex2300-c\junos-arm-32-20.2R3-S3.6.tgz , considers it as remote url since it contains C: , ignores the no_copy=False and the pkg file is not copied to the device and directly tries to download from the remote-url and fails with error .

Added check for remote url and if it is windows path C: , then safe_copy will be invoked to copy the pkg to the device 