### PR TITLE
Remove Unused Dependency: Netaddr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ paramiko>=1.15.2
 scp>=0.7.0
 jinja2>=2.7.1
 PyYAML>=5.1
-netaddr
 six
 pyserial
 yamlordereddictloader


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `netaddr` from the `requirements.txt` configuration file. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale
The `netaddr`  library was first integrated into the project as per 0b69f3953,  to support its usage in `lib/jnpr/junos/cfg/srx/ab_finder.py`. However, as of 8f4c131, the `ab_finder.py` file has been removed from the project, rendering the associated dependency redundant. Despite its removal from the source code, `netaddr` remained listed as a requirement in the project's configuration file. Removing this unused dependency reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the `netaddr` dependency from `requirements.txt`.

## Impact

- **Reduced Package Size**: Omitting this unused dependency will reduce the overall size of the installed packages.
- **Simplified Dependency Tree**: Reducing dependencies simplifies maintenance and can expedite installation.


