### PR TITLE
Add input/output bps/pps to phyport.yml

### DIFF
--- a/lib/jnpr/junos/op/phyport.yml
+++ b/lib/jnpr/junos/op/phyport.yml
@@ -42,8 +42,12 @@ PhyPortStatsView:
   fields_ts:
     rx_bytes: { input-bytes: int }
     rx_packets: { input-packets: int }
+    rx_bps: { input-bps: int }
+    rx_pps: { input-pps: int }
     tx_bytes: { output-bytes: int }
     tx_packets: { output-packets: int }
+    tx_bps: { output-bps: int }
+    tx_pps: { output-pps: int }
 
   fields_rxerrs:
     rx_err_input: { input-errors: int }


### PR DESCRIPTION
This change adds bps/pps counters to input/output in `jnpr.junos.op.phyport.PhyPortStatsTable`.

Example script:-

```
#!/usr/bin/python3

from json import loads, dumps
from jnpr.junos import Device
from jnpr.junos.op.phyport import PhyPortStatsTable

HOST = 'my-fancy-router'

def main():
    with Device(host=HOST, port=22) as dev:
        pst = PhyPortStatsTable(dev)
        pst.get('xe-0/1/0')
        print(dumps(loads(pst.to_json()), indent=2))

if __name__ == "__main__":
    main()
```

Example output:-
```
{
  "xe-0/1/0": {
    "rx_bytes": 3508146369,
    "rx_packets": 49692709,
    "rx_bps": 744,
    "rx_pps": 0,
    "tx_bytes": 3153720077,
    "tx_packets": 21855321,
    "tx_bps": 1040,
    "tx_pps": 1,
    "rx_err_input": 0,
    "rx_err_drops": 0
  }
}
```
