### PR TITLE
Fix for issue #1273 for X100-202310100600.0-EVO

### DIFF
--- a/lib/jnpr/junos/facts/swver.py
+++ b/lib/jnpr/junos/facts/swver.py
@@ -19,7 +19,12 @@ class version_info(object):
                 if len(after_type) < 2:
                     self.build = None
                 else:
-                    self.build = int(after_type[1])
+                    try:
+                        # handling case for EVO format X100-202310100600.0-EVO
+                        self.build = int(after_type[1])
+                    except:
+                        self.build = None
+
             # X type not hyphen format, perhaps "11.4X12.1", just extract
             # build rev or set None
             else:


### PR DESCRIPTION
Fix for EVO version format X100-202310100600.0-EVO
```
~/pyez_release_268_test1/py-junos-eznc/tests/functional# python test_get_facts_qfx.py 
> /root/pyez_release_268_test1/venv/lib/python3.9/site-packages/junos_eznc-2.6.8+0.g0745dd0e.dirty-py3.9.egg/jnpr/junos/facts/swver.py(15)__init__()
-> if "X" == self.type:
(Pdb) c
> /root/pyez_release_268_test1/venv/lib/python3.9/site-packages/junos_eznc-2.6.8+0.g0745dd0e.dirty-py3.9.egg/jnpr/junos/facts/swver.py(15)__init__()
-> if "X" == self.type:
(Pdb) c
{'2RE': False,
 'HOME': '/home/root',
 'RE0': {'last_reboot_reason': 'software reboot',
         'mastership_state': 'Master',
         'model': 'RE-QFXxyz',
         'status': 'OK',
         'up_time': '1 hour, 47 minutes, 48 seconds'},
 'RE1': None,
 'RE_hw_mi': False,
 'current_re': ['re0'],
 'domain': 'xyz',
 'fqdn': 'xyz',
 'hostname': 'zyz',
 'hostname_info': {'re0': 'xyz'},
 'ifd_style': 'SWITCH',
 'junos_info': {'re0': {'object': junos.version_info(major=(xx, x), type=X, minor=(100, '2', 2310100600), build=None),
                        'text': 'xx.xxX100-202310100600.0-EVO'}},
 'master': 'RE0',
 'model': 'QFXxyz',
 'model_info': {'re0': 'QFXxyz-64CD'},
 'personality': 'SWITCH',
 're_info': {'default': {'0': {'last_reboot_reason': 'software reboot',
                               'mastership_state': 'Master',
                               'model': 'RE-QFXxyz',
                               'status': 'OK'},
                         'default': {'last_reboot_reason': 'software reboot',
                                     'mastership_state': 'Master',
                                     'model': 'RE-QFXxyz',
                                     'status': 'OK'}}},
 're_master': {'default': '0'},
 'serialnumber': 'FU1923AN0012',
 'srx_cluster': None,
 'srx_cluster_id': None,
 'srx_cluster_redundancy_group': None,
 'switch_style': 'VLAN_L2NG',
 'vc_capable': False,
 'vc_fabric': None,
 'vc_master': None,
 'vc_mode': None,
 'version': 'xx.xX100-202310100600.0-EVO',
 'version_RE0': 'xx.xX100-202310100600.0-EVO',
 'version_RE1': None,
 'version_info': junos.version_info(major=(xx, x), type=X, minor=(100, '2', 2310100600), build=None),
 'virtual': False}

```