### PR TITLE
Bump ncclient to 0.6.15 to support Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lxml>=3.2.4
 # ncclient version 0.6.10 has issues with PyEZ(junos-eznc) and needs to be avoided
-ncclient==0.6.13
+ncclient==0.6.15
 paramiko>=1.15.2
 scp>=0.7.0
 jinja2>=2.7.1


### PR DESCRIPTION
Hi team,

ncclient 0.6.13 does not build successfully on Python 3.12, and as PyEz has this dependency pinned to this version it results in PyEz also failing to be installed successfully.

https://github.com/ncclient/ncclient/issues/572

Bumped the pinned version to 0.6.15 to resolve this issue, however in favour of updating to have the minimum version be set to 0.6.13 instead if this is preferable.

Let me know if you have any questions.

Kind regards,
Louis