### PR TITLE
fix for issue #756

### DIFF
--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -90,7 +90,7 @@ class _RpcMetaExec(object):
                  options={'database':'committed','inherit':'inherit'})
 
         :param str model: Can provide yang model openconfig/custom/ietf. When
-                model is True and filter_xml is None, xml is enclosed under
+                model is non None and filter_xml is None, xml is enclosed under
                 <data> so that we get junos as well as other model
                 configurations
 

--- a/lib/jnpr/junos/rpcmeta.py
+++ b/lib/jnpr/junos/rpcmeta.py
@@ -90,7 +90,7 @@ class _RpcMetaExec(object):
                  options={'database':'committed','inherit':'inherit'})
 
         :param str model: Can provide yang model openconfig/custom/ietf. When
-                model is non None and filter_xml is None, xml is enclosed under
+                model is True (filter_xml option is not supported), xml is enclosed under
                 <data> so that we get junos as well as other model
                 configurations
 


### PR DESCRIPTION
statement When model is True and filter_xml is None, xml is enclosed under <data> so that we get junos as well as other model configurations 
updated to 

When model is True ( filter_xml is not supported ), xml is enclosed under <data> so that we get junos as well as other model configurations

it is already metiond in the PyEZ documentation

 - https://www.juniper.net/documentation/us/en/software/junos-pyez/junos-pyez-developer/topics/topic-map/junos-pyez-program-configuration-retrieving.html