### PR TITLE
Do not disable SSH agent

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1354,15 +1354,6 @@ class Device(_Connection):
         try:
             ts_start = datetime.datetime.now()
 
-            # we want to enable the ssh-agent if-and-only-if we are
-            # not given a password or an ssh key file.
-            # in this condition it means we want to query the agent
-            # for available ssh keys
-
-            allow_agent = bool(
-                (self._auth_password is None) and (self._ssh_private_key_file is None)
-            )
-
             # option to disable ncclient transport ssh authentication
             # using public keys look_for_keys=False
             if self._look_for_keys is None:
@@ -1379,7 +1370,6 @@ class Device(_Connection):
                 password=self._auth_password,
                 hostkey_verify=False,
                 key_filename=self._ssh_private_key_file,
-                allow_agent=allow_agent,
                 look_for_keys=look_for_keys,
                 ssh_config=self._sshconf_lkup(),
                 timeout=self._conn_open_timeout,

--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -72,14 +72,6 @@ class SSH(Terminal):
     def _tty_open(self):
         retry = self.RETRY_OPEN
 
-        # we want to enable the ssh-agent if-and-only-if we are
-        # not given a password or an ssh key file.
-        # in this condition it means we want to query the agent
-        # for available ssh keys
-        allow_agent = bool(
-            (self.cs_passwd is None) and (self.ssh_private_key_file is None)
-        )
-
         while retry > 0:
             try:
                 self._ssh_pre.connect(
@@ -88,7 +80,6 @@ class SSH(Terminal):
                     username=self.cs_user,
                     password=self.cs_passwd,
                     timeout=self.timeout,
-                    allow_agent=allow_agent,
                     look_for_keys=False,
                     key_filename=self.ssh_private_key_file,
                 )


### PR DESCRIPTION
The current logic around the SSH agent is flawed and tentatives to fix it to cover more cases only leads to more complexity.

As seen in #648, to this day, nobody really knows why we disable the agent. In the meantime, many valid use cases just don't work because of disabling the agent, including the good practice to use encrypted private key files. I think it is time to bite the bullet and just leave the agent always on: "ssh" from OpenSSH does not have an option to disable the agent and nobody complains about this.