### PR TITLE
add 'member' to reboot RPC only when it's not None

### DIFF
--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1131,10 +1131,8 @@ class SW(Util):
             elif self._mixed_VC is True:
                 cmd.append(E("all-members"))
         elif (
-            (self._multi_VC_nsync is True
-            or self._multi_VC is True)
-            and member_id is not None
-        ):
+            self._multi_VC_nsync is True or self._multi_VC is True
+        ) and member_id is not None:
             cmd.append(E("member", str(member_id)))
         if in_min >= 0 and at is None:
             cmd.append(E("in", str(in_min)))

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1131,8 +1131,8 @@ class SW(Util):
             elif self._mixed_VC is True:
                 cmd.append(E("all-members"))
         elif (
-            self._multi_VC_nsync is True
-            or self._multi_VC is True
+            (self._multi_VC_nsync is True
+            or self._multi_VC is True)
             and member_id is not None
         ):
             cmd.append(E("member", str(member_id)))


### PR DESCRIPTION
The current logic adds the 'member' attribute to the request-reboot RPC, even if the member attribute is 'None' (default) while the target device is running on a single-node virtual chassis.

This causes the RPC call to fail.

-> parentheses were missing to reflect the right logic