### PR TITLE
Updated custom juniper paramiko

### DIFF
--- a/lib/jnpr/junos/cfg/phyport/base.py
+++ b/lib/jnpr/junos/cfg/phyport/base.py
@@ -6,7 +6,6 @@ from jnpr.junos.cfg.resource import Resource
 
 
 class PhyPortBase(Resource):
-
     """
     [edit interfaces <name>]
 

--- a/lib/jnpr/junos/cfg/user.py
+++ b/lib/jnpr/junos/cfg/user.py
@@ -8,7 +8,6 @@ from jnpr.junos.cfg.user_ssh_key import UserSSHKey
 
 
 class User(Resource):
-
     """
     [edit system login user <name>]
 

--- a/lib/jnpr/junos/cfg/user_ssh_key.py
+++ b/lib/jnpr/junos/cfg/user_ssh_key.py
@@ -7,7 +7,6 @@ from jnpr.junos import jxml as JXML
 
 
 class UserSSHKey(Resource):
-
     """
     [edit system login user <name> authentication <key-type> <key-value> ]
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -54,7 +54,6 @@ logger = logging.getLogger("jnpr.junos.device")
 
 
 class _MyTemplateLoader(jinja2.BaseLoader):
-
     """
     Create a jinja2 template loader class that can be used to
     load templates from all over the filesystem, but defaults
@@ -1023,7 +1022,6 @@ class _Connection(object):
 
 
 class DeviceSessionListener(SessionListener):
-
     """
     Listens to Session class of Netconf Transport
     and detects errors in the transport.
@@ -1045,7 +1043,6 @@ class DeviceSessionListener(SessionListener):
 
 
 class Device(_Connection):
-
     """
     Junos Device class.
 

--- a/lib/jnpr/junos/exception.py
+++ b/lib/jnpr/junos/exception.py
@@ -14,7 +14,6 @@ class FactLoopError(RuntimeError):
 
 
 class RpcError(Exception):
-
     """
     Parent class for all junos-pyez RPC Exceptions
     """
@@ -87,7 +86,6 @@ class RpcError(Exception):
 
 
 class CommitError(RpcError):
-
     """
     Generated in response to a commit-check or a commit action.
     """
@@ -107,7 +105,6 @@ class CommitError(RpcError):
 
 
 class ConfigLoadError(RpcError):
-
     """
     Generated in response to a failure when loading a configuration.
     """
@@ -127,7 +124,6 @@ class ConfigLoadError(RpcError):
 
 
 class LockError(RpcError):
-
     """
     Generated in response to attempting to take an exclusive
     lock on the configuration database.
@@ -138,7 +134,6 @@ class LockError(RpcError):
 
 
 class UnlockError(RpcError):
-
     """
     Generated in response to attempting to unlock the
     configuration database.
@@ -149,7 +144,6 @@ class UnlockError(RpcError):
 
 
 class PermissionError(RpcError):
-
     """
     Generated in response to invoking an RPC for which the
     auth user does not have user-class permissions.
@@ -164,7 +158,6 @@ class PermissionError(RpcError):
 
 
 class RpcTimeoutError(RpcError):
-
     """
     Generated in response to a RPC execution timeout.
     """
@@ -181,7 +174,6 @@ class RpcTimeoutError(RpcError):
 
 
 class SwRollbackError(RpcError):
-
     """
     Generated in response to a SW rollback error.
     """
@@ -208,7 +200,6 @@ class SwRollbackError(RpcError):
 
 
 class ConnectError(Exception):
-
     """
     Parent class for all connection related exceptions
     """
@@ -249,7 +240,6 @@ class ConnectError(Exception):
 
 
 class ProbeError(ConnectError):
-
     """
     Generated if auto_probe is enabled and the probe action fails
     """
@@ -258,7 +248,6 @@ class ProbeError(ConnectError):
 
 
 class ConnectAuthError(ConnectError):
-
     """
     Generated if the user-name, password is invalid
     """
@@ -267,7 +256,6 @@ class ConnectAuthError(ConnectError):
 
 
 class ConnectTimeoutError(ConnectError):
-
     """
     Generated if the NETCONF session fails to connect, could
     be due to the fact the device is not ip reachable; bad
@@ -278,7 +266,6 @@ class ConnectTimeoutError(ConnectError):
 
 
 class ConnectUnknownHostError(ConnectError):
-
     """
     Generated if the specific hostname does not DNS resolve
     """
@@ -287,7 +274,6 @@ class ConnectUnknownHostError(ConnectError):
 
 
 class ConnectRefusedError(ConnectError):
-
     """
     Generated if the specified host denies the NETCONF; could
     be that the services is not enabled, or the host has
@@ -298,7 +284,6 @@ class ConnectRefusedError(ConnectError):
 
 
 class ConnectNotMasterError(ConnectError):
-
     """
     Generated if the connection is made to a non-master
     routing-engine.  This could be a backup RE on an MX
@@ -309,7 +294,6 @@ class ConnectNotMasterError(ConnectError):
 
 
 class ConnectClosedError(ConnectError):
-
     """
     Generated if connection unexpectedly closed
     """
@@ -320,7 +304,6 @@ class ConnectClosedError(ConnectError):
 
 
 class JSONLoadError(Exception):
-
     """
     Generated if json content of rpc reply fails to load
     """

--- a/lib/jnpr/junos/factory/cmdview.py
+++ b/lib/jnpr/junos/factory/cmdview.py
@@ -1,5 +1,4 @@
 class CMDView(object):
-
     """
     View is the base-class that makes extracting values from XML
     data appear as objects with attributes.

--- a/lib/jnpr/junos/factory/factory_loader.py
+++ b/lib/jnpr/junos/factory/factory_loader.py
@@ -4,6 +4,7 @@ create Runstat Table and View objects from a <dict> of data.  The <dict> can
 originate from any kind of source: YAML, JSON, program.  For examples of YAML
 refer to the .yml files in this jnpr.junos.op directory.
 """
+
 # stdlib
 from copy import deepcopy
 import re
@@ -29,7 +30,6 @@ _CMDCHILDTBL = FactoryCMDChildTable
 
 
 class FactoryLoader(object):
-
     """
     Used to load a <dict> of data that contains Table and View definitions.
 

--- a/lib/jnpr/junos/factory/state_machine.py
+++ b/lib/jnpr/junos/factory/state_machine.py
@@ -810,9 +810,9 @@ class StateMachine(Machine):
                             val, result[list(self._view.REGEX.keys()).index(key)], re.I
                         )
                         if obj and len(obj.groups()) >= 1:
-                            result[
-                                list(self._view.REGEX.keys()).index(key)
-                            ] = obj.groups()[0]
+                            result[list(self._view.REGEX.keys()).index(key)] = (
+                                obj.groups()[0]
+                            )
                 items = convert_to_data_type(result)
                 tmp_dict = dict(zip(self._view.REGEX.keys(), items))
                 if len(tmp_dict) > 0:

--- a/lib/jnpr/junos/factory/view.py
+++ b/lib/jnpr/junos/factory/view.py
@@ -11,7 +11,6 @@ from jnpr.junos.factory.to_json import TableViewJSONEncoder
 
 
 class View(object):
-
     """
     View is the base-class that makes extracting values from XML
     data appear as objects with attributes.

--- a/lib/jnpr/junos/factory/viewfields.py
+++ b/lib/jnpr/junos/factory/viewfields.py
@@ -1,5 +1,4 @@
 class ViewFields(object):
-
     """
     Used to dynamically create a field dictionary used with the
     RunstatView class

--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -31,6 +31,7 @@ NOTE: The dictionary key for each available fact is guaranteed to exist. If
 The following dictionary keys represent the available facts and their meaning:
 
 """
+
 import sys
 
 import jnpr.junos.facts.current_re

--- a/lib/jnpr/junos/ofacts/session.py
+++ b/lib/jnpr/junos/ofacts/session.py
@@ -1,6 +1,7 @@
 """
   facts['HOME'] = login home directory
 """
+
 from lxml.builder import E
 
 

--- a/lib/jnpr/junos/resources/autosys.py
+++ b/lib/jnpr/junos/resources/autosys.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for AutoSys Table/View
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/resources/bgp.py
+++ b/lib/jnpr/junos/resources/bgp.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for BGP Table/View
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/resources/interface.py
+++ b/lib/jnpr/junos/resources/interface.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for interface table/view
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/resources/staticroutes.py
+++ b/lib/jnpr/junos/resources/staticroutes.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for Static route Table/View
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/resources/syslog.py
+++ b/lib/jnpr/junos/resources/syslog.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for Syslog Table/View
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/resources/user.py
+++ b/lib/jnpr/junos/resources/user.py
@@ -1,6 +1,7 @@
 """
 Pythonifier for User Table/View
 """
+
 from jnpr.junos.factory import loadyaml
 from os.path import splitext
 

--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -14,7 +14,6 @@ __all__ = ["Terminal"]
 
 
 class Terminal(object):
-
     """
     Terminal is used to bootstrap Junos New Out of the Box (NOOB) device
     over the CONSOLE port. The general use-case is to setup the minimal

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -38,7 +38,6 @@ logger = logging.getLogger("jnpr.junos.tty_netconf")
 
 
 class tty_netconf(object):
-
     """
     Basic Junos XML API for bootstraping through the TTY
     """

--- a/lib/jnpr/junos/utils/fs.py
+++ b/lib/jnpr/junos/utils/fs.py
@@ -7,7 +7,6 @@ from jnpr.junos.exception import RpcError
 
 
 class FS(Util):
-
     """
     Filesystem (FS) utilities:
 

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -14,7 +14,6 @@ _RECVSZ = 1024
 
 
 class StartShell(object):
-
     """
     Junos shell execution utility.  This utility is written to
     support the "context manager" design pattern.  For example::

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 lxml>=3.2.4
 # ncclient version 0.6.10 has issues with PyEZ(junos-eznc) and needs to be avoided
 ncclient>=0.6.15
-paramiko>=1.15.2
 scp>=0.7.0
 jinja2>=2.7.1
 PyYAML>=5.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import versioneer
 import os
 
 # Install customer paramiko
-os.system("pip install git+https://github.com/Juniper/paramiko.git")
+os.system("pip install git+https://github.com/Juniper/paramiko.git@v3.4.0-JNPR")
 # parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import versioneer
 import os
 
 # Install customer paramiko
-os.system('pip install git+https://github.com/Juniper/paramiko.git')
+os.system("pip install git+https://github.com/Juniper/paramiko.git")
 # parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 from setuptools import setup, find_packages
 import versioneer
+import pip
 
+def install(package):
+    if hasattr(pip, 'main'):
+        pip.main(['install', package])
+    else:
+        pip._internal.main(['install', package])
+
+# Install customer paramiko
+install("git+https://github.com/Juniper/paramiko.git")
 # parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,9 @@
 from setuptools import setup, find_packages
 import versioneer
-import pip
-
-def install(package):
-    if hasattr(pip, 'main'):
-        pip.main(['install', package])
-    else:
-        pip._internal.main(['install', package])
+import os
 
 # Install customer paramiko
-install("git+https://github.com/Juniper/paramiko.git")
+os.system('pip install git+https://github.com/Juniper/paramiko.git')
 # parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))


### PR DESCRIPTION
- Updated juniper paramiko which supported aes128 and aes257 cipher.
- Fixed Python code style format running black tools


show system services 
ssh {
    ciphers [ [aes128-gcm@openssh.com](mailto:aes128-gcm@openssh.com) [aes256-gcm@openssh.com](mailto:aes256-gcm@openssh.com) ];
}

```
>>> from jnpr.junos import Device
>>> dev = Device(host='x.x.x.x', user='xxxx', password='xxxx')
>>> dev.open()
Device(x.x.x.x)
>>> dev.facts
{'2RE': False,
 'HOME': '/root',
 'RE0': {'last_reboot_reason': '0x4000:VJUNOS reboot',
         'mastership_state': 'master',
         'model': 'RE-QFX5110-48S-4C',
         'status': 'OK',
         'up_time': '384 days, 7 hours, 3 minutes, 29 seconds'},
```