### PR TITLE
Fixed unit test test_textfsm_table_mutli_key failing because of invalid key error

### DIFF
--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -2214,10 +2214,7 @@ FPCThreadView:
                 "L2ALM Manager": {"cpu": "0", "state": "asleep"},
                 "L2PD": {"cpu": "0", "state": "asleep"},
                 "L2TP-SF KA Transmit": {"cpu": "0", "state": "asleep"},
-                "LKUP ASIC UCODE Rebalance Service": {
-                    "cpu": "1",
-                    "state": "asleep",
-                },
+                "LKUP ASIC UCODE Rebalance Service": {"cpu": "1", "state": "asleep",},
                 "LKUP ASIC Wedge poll thread": {"cpu": "0", "state": "asleep"},
                 "LU Background Service": {"cpu": "4", "state": "asleep"},
                 "LU-CNTR Reader": {"cpu": "0", "state": "asleep"},
@@ -2379,7 +2376,7 @@ ARPtable:
 
 ARPview:
     fields:
-        mac: MAC
+        mac: MAC_ADDRESS
         ip: IP_ADDRESS
         interface: INTERFACE
         flag: FLAGS


### PR DESCRIPTION
The template has "MAC_ADDRESS" as key but the reference field has only MAC which cause a invalid key and fails the unit test