### PR TITLE
Fix for 1243

### DIFF
--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -207,6 +207,7 @@ class Terminal(object):
             self.write("\n")
             self._badpasswd += 1
             if self._badpasswd == 2:
+                self._tty_close()
                 # raise RuntimeError("Bad username/password")
                 raise EzErrors.ConnectAuthError(self, "Bad username/password")
             # return through and try again ... could have been

--- a/tests/unit/transport/test_tty.py
+++ b/tests/unit/transport/test_tty.py
@@ -29,6 +29,7 @@ class TestTTY(unittest.TestCase):
         self.terminal.read_prompt = MagicMock()
         self.terminal.read_prompt.return_value = (None, "badpasswd")
         self.terminal.write = MagicMock()
+        self.terminal._tty_close = MagicMock()
         self.assertRaises(EzErrors.ConnectAuthError, self.terminal._login_state_machine)
 
     @patch("jnpr.junos.transport.tty.sleep")


### PR DESCRIPTION
Fix for [1243](https://github.com/Juniper/py-junos-eznc/issues/1243).  

Previously if a bad password is given for serial connection, there is EzErrors.ConnectAuthError(self, "Bad username/password")  raised. But this doesn't disconnect the serial port, till the script is killed.  I have added a disconnect call before the raise to account for this. 

 