### PR TITLE
Don't require six

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1,6 +1,5 @@
 # stdlib
 import os
-import six
 import types
 import platform
 import warnings
@@ -659,7 +658,7 @@ class _Connection(object):
         command = command.strip()
         # Get the equivalent RPC
         rpc = self.display_xml_rpc(command)
-        if isinstance(rpc, six.string_types):
+        if isinstance(rpc, str):
             # No RPC is available.
             return None
         rpc_string = "rpc.%s(" % (rpc.tag.replace("-", "_"))

--- a/lib/jnpr/junos/jxml.py
+++ b/lib/jnpr/junos/jxml.py
@@ -1,7 +1,6 @@
 from ncclient import manager
 from ncclient.xml_ import NCElement
 from lxml import etree
-import six
 
 """
   These are Junos XML 'helper' definitions use for generic XML processing
@@ -226,8 +225,7 @@ def cscript_conf(reply):
 
 
 # xslt to remove prefix like junos:ns
-strip_namespaces_prefix = six.b(
-    """<?xml version="1.0" encoding="UTF-8" ?>
+strip_namespaces_prefix = b"""<?xml version="1.0" encoding="UTF-8" ?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" indent="no" omit-xml-declaration="no" />
 
@@ -249,4 +247,3 @@ strip_namespaces_prefix = six.b(
         </xsl:attribute>
     </xsl:template>
 </xsl:stylesheet>"""
-)

--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -11,23 +11,22 @@ from lxml.etree import XMLSyntaxError
 from datetime import datetime, timedelta
 from ncclient.operations.rpc import RPCReply, RPCError
 from ncclient.xml_ import to_ele
-import six
 from ncclient.transport.session import HelloHandler
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    STARTS_WITH = six.b("<!--")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    STARTS_WITH = b"<!--"
 
 
 __all__ = ["xmlmode_netconf"]
 
-_NETCONF_EOM = six.b("]]>]]>")
-_xmlns = re.compile(six.b("xmlns=[^>]+"))
+_NETCONF_EOM = b"]]>]]>"
+_xmlns = re.compile(b"xmlns=[^>]+")
 _xmlns_strip = lambda text: _xmlns.sub(PY6.EMPTY_STR, text)
-_junosns = re.compile(six.b("junos:"))
+_junosns = re.compile(b"junos:")
 _junosns_strip = lambda text: _junosns.sub(PY6.EMPTY_STR, text)
 
 logger = logging.getLogger("jnpr.junos.tty_netconf")
@@ -116,7 +115,7 @@ class tty_netconf(object):
         """
         if not cmd.startswith("<"):
             cmd = "<{}/>".format(cmd)
-        rpc = six.b("<rpc>{}</rpc>".format(cmd))
+        rpc = "<rpc>{}</rpc>".format(cmd).encode('utf-8')
         logger.info("Calling rpc: %s" % rpc)
         self._tty.rawwrite(rpc)
 

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -1,6 +1,5 @@
 import serial
 import re
-import six
 from time import sleep
 from datetime import datetime, timedelta
 
@@ -10,7 +9,7 @@ from jnpr.junos.transport.tty import Terminal
 # Terminal connection over SERIAL CONSOLE
 # -------------------------------------------------------------------------
 
-_PROMPT = re.compile(six.b("|").join([six.b(i) for i in Terminal._RE_PAT]))
+_PROMPT = re.compile(b"|".join([i.encode('utf-8') for i in Terminal._RE_PAT]))
 
 
 class Serial(Terminal):
@@ -56,7 +55,7 @@ class Serial(Terminal):
 
     def write(self, content):
         """write content + <RETURN>"""
-        self._ser.write(six.b(content + "\n"))
+        self._ser.write(bytes(content + "\n", 'utf-8'))
         self._ser.flush()
 
     def rawwrite(self, content):
@@ -75,7 +74,7 @@ class Serial(Terminal):
         regular-expression group. If a timeout occurs, then return
         the tuple(None,None).
         """
-        rxb = six.b("")
+        rxb = b""
         mark_start = datetime.now()
         mark_end = mark_start + timedelta(seconds=self.EXPECT_TIMEOUT)
 

--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -6,7 +6,6 @@ import sys
 from time import sleep, time
 
 import paramiko
-import six
 
 from jnpr.junos.transport.tty import Terminal
 
@@ -15,14 +14,14 @@ logger = logging.getLogger("jnpr.junos.tty_ssh")
 # -------------------------------------------------------------------------
 # Terminal connection over SSH CONSOLE
 # -------------------------------------------------------------------------
-_PROMPT = re.compile(six.b("|").join([six.b(i) for i in Terminal._RE_PAT]))
+_PROMPT = re.compile(b"|".join([i.encode('utf-8') for i in Terminal._RE_PAT]))
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    IN_USE = six.b("in use")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    IN_USE = b"in use"
 
 
 class SSH(Terminal):
@@ -136,7 +135,7 @@ class SSH(Terminal):
     def write(self, content):
         """write content + <ENTER>"""
         logger.debug("Write: %s" % content)
-        self._ssh.sendall(six.b((content + "\n")))
+        self._ssh.sendall(bytes(content + "\n", 'utf-8'))
 
     def rawwrite(self, content):
         """write content as-is"""
@@ -152,13 +151,13 @@ class SSH(Terminal):
         if sys.version >= "3":
             content = content.decode("utf-8")
         for char in content:
-            self._ssh.sendall(six.b(char))
+            self._ssh.sendall(bchar)
             wtime = 10 / float(self.baud)
             sleep(wtime)  # do not remove
 
     def read(self):
         """read a single line"""
-        rxb = six.b("")
+        rxb = b""
         while True:
             data = self._ssh.recv(self.RECVSZ)
             if data is None or len(data) <= 0:
@@ -180,7 +179,7 @@ class SSH(Terminal):
         regular-expression group. If a timeout occurs, then return
         the tuple(None,None).
         """
-        rxb = six.b("")
+        rxb = b""
         timeout = time() + self.READ_PROMPT_DELAY
 
         while time() < timeout:
@@ -199,7 +198,7 @@ class SSH(Terminal):
         return rxb, found.lastgroup
 
     def _read_until(self, match, timeout=None):
-        rxb = six.b("")
+        rxb = b""
         timeout = time() + self.READ_PROMPT_DELAY
 
         while time() < timeout:

--- a/lib/jnpr/junos/transport/tty_telnet.py
+++ b/lib/jnpr/junos/transport/tty_telnet.py
@@ -2,7 +2,6 @@ from time import sleep
 import telnetlib
 import logging
 import sys
-import six
 
 from jnpr.junos.transport.tty import Terminal
 
@@ -14,10 +13,10 @@ logger = logging.getLogger("jnpr.junos.tty_telnet")
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    IN_USE = six.b("in use")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    IN_USE = b"in use"
 
 
 class Telnet(Terminal):
@@ -81,7 +80,7 @@ class Telnet(Terminal):
     def write(self, content):
         """write content + <ENTER>"""
         logger.debug("Write: %s" % content)
-        self._tn.write(six.b((content + "\n")))
+        self._tn.write(bytes(content + "\n", 'utf-8'))
 
     def rawwrite(self, content):
         """write content as-is"""
@@ -97,7 +96,7 @@ class Telnet(Terminal):
         if sys.version >= "3":
             content = content.decode("utf-8")
         for char in content:
-            self._tn.write(six.b(char))
+            self._tn.write(char.encode("utf-8"))
             wtime = 10 / float(self.baud)
             sleep(wtime)  # do not remove
 
@@ -106,7 +105,7 @@ class Telnet(Terminal):
         return self._tn.read_until(PY6.NEW_LINE, self.EXPECT_TIMEOUT)
 
     def read_prompt(self):
-        _RE_PAT = [six.b(i) for i in Terminal._RE_PAT]
+        _RE_PAT = [i.encode('utf-8') for i in Terminal._RE_PAT]
         got = self._tn.expect(_RE_PAT, self.EXPECT_TIMEOUT)
         if PY6.IN_USE in got[2]:
             raise RuntimeError("open_fail: port already in use")

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -3,7 +3,6 @@ import re
 import datetime
 from jnpr.junos.utils.ssh_client import open_ssh_client
 import subprocess
-import six
 from threading import Thread
 import time
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ ncclient>=0.6.15
 scp>=0.7.0
 jinja2>=2.7.1
 PyYAML>=5.1
-six
 pyserial
 yamlordereddictloader
 pyparsing

--- a/tests/unit/facts/test_swver.py
+++ b/tests/unit/facts/test_swver.py
@@ -1,8 +1,6 @@
 __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
-import six
-
 try:
     import unittest2 as unittest
 except:
@@ -13,9 +11,6 @@ from jnpr.junos.facts.swver import version_info, get_facts
 
 
 class TestVersionInfo(unittest.TestCase):
-    if six.PY2:
-        assertCountEqual = unittest.TestCase.assertItemsEqual
-
     def test_version_info_after_type_len_else(self):
         self.assertEqual(version_info("12.1X46-D10").build, None)
 

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -9,7 +9,6 @@ import re
 import sys
 import os
 from lxml import etree
-import six
 import socket
 
 from jnpr.junos.console import Console
@@ -40,16 +39,16 @@ class TestConsole(unittest.TestCase):
     def setUp(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search("(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search("(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search("(?P<shell>%|#\s*$)", "junos % "),
-                six.b("\r\r\nroot@device:~ # "),
+                b"\r\r\nroot@device:~ # ",
             ),
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="Telnet")
@@ -87,16 +86,16 @@ class TestConsole(unittest.TestCase):
     def test_login_bad_password(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search("(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search("(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search("(?P<badpasswd>ogin incorrect)", "login incorrect"),
-                six.b("\r\r\nlogin incorrect"),
+                b"\r\r\nlogin incorrect",
             ),
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="Telnet")
@@ -110,16 +109,16 @@ class TestConsole(unittest.TestCase):
         tty_netconf.open = MagicMock()
 
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search("(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search("(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search("(?P<shell>%|#\s*$)", "junos % "),
-                six.b("\r\r\nroot@device:~ # "),
+                b"\r\r\nroot@device:~ # ",
             ),
         ]
         with Console(
@@ -175,9 +174,9 @@ class TestConsole(unittest.TestCase):
     def test_console_serial(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            six.b("\r\r\n Login:"),
-            six.b("\r\r\n password:"),
-            six.b("\r\r\nroot@device:~ # "),
+            b"\r\r\n Login:",
+            b"\r\r\n password:",
+            b"\r\r\nroot@device:~ # ",
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="serial")
         self.dev.open()
@@ -258,15 +257,13 @@ class TestConsole(unittest.TestCase):
                 </policy-statement>
                 </policy-options>"""
 
-        mock_read_until.return_value = six.b(
-            """
+        mock_read_until.return_value = b"""
         <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/15.2I0/junos">
             <load-configuration-results>
             <ok/>
             </load-configuration-results>
             </rpc-reply>
             ]]>]]>"""
-        )
         cu = Config(self.dev)
         op = cu.load(xml, format="xml")
         cu.commit()

--- a/tests/unit/transport/test_serial.py
+++ b/tests/unit/transport/test_serial.py
@@ -5,7 +5,6 @@ except ImportError:
 import nose2
 from mock import MagicMock, patch
 import sys
-import six
 
 from jnpr.junos.console import Console
 
@@ -90,12 +89,9 @@ class TestSerialWin(unittest.TestCase):
             ("shell", "shell"),
         ]
         mock_serial_read.side_effect = [
-            six.b(
-                "<!-- No zombies were killed during the creation of this user interface -->"
-            ),
-            six.b(""),
-            six.b(
-                """<!-- user root, class super-user -->
+            b"<!-- No zombies were killed during the creation of this user interface -->",
+            b"",
+            b"""<!-- user root, class super-user -->
 <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
   <capabilities>
     <capability>urn:ietf:params:netconf:base:1.0</capability>
@@ -114,9 +110,8 @@ class TestSerialWin(unittest.TestCase):
   </capabilities>
   <session-id>7478</session-id>
 </hello>
-]]>]]>"""
-            ),
-            six.b(""),
+]]>]]>""",
+            b"",
         ]
         self.dev.open()
 
@@ -144,7 +139,7 @@ class TestSerialWin(unittest.TestCase):
         self.dev._tty.read = MagicMock()
         self.dev._tty.rawwrite = MagicMock()
         self.dev._tty.read.side_effect = [
-            six.b(
+            bytes(
                 '<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"'
                 ' xmlns:junos="http://xml.juniper.net/junos/15.1X49/junos">'
                 '<route-engine-information xmlns="http://xml.juniper.net/ju'
@@ -170,7 +165,8 @@ class TestSerialWin(unittest.TestCase):
                 "-reason><load-average-one>0.12</load-average-one><load-ave"
                 "rage-five>0.08</load-average-five><load-average-fifteen>0."
                 "06</load-average-fifteen></route-engine></route-engine-inf"
-                "ormation></rpc-reply>]]>]]>"
+                "ormation></rpc-reply>]]>]]>",
+                'utf-8'
             )
         ]
         res = self.dev.rpc.get_route_engine_information()

--- a/tests/unit/transport/test_tty_netconf.py
+++ b/tests/unit/transport/test_tty_netconf.py
@@ -7,7 +7,6 @@ from mock import MagicMock, patch
 
 from jnpr.junos.transport.tty_netconf import tty_netconf
 
-import six
 import os
 import select
 import socket
@@ -43,7 +42,7 @@ class TestTTYNetconf(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_netconf.timedelta")
     def test_open_RuntimeError(self, mock_delta, mock_rcv):
         mock_rcv.return_value = "]]>]]>"
-        self.tty_net._tty.read.return_value = six.b("testing")
+        self.tty_net._tty.read.return_value = b"testing"
         from datetime import timedelta
 
         mock_delta.return_value = timedelta(seconds=0.5)
@@ -56,7 +55,7 @@ class TestTTYNetconf(unittest.TestCase):
         mock_rcv.return_value = "]]>]]>"
         self.tty_net.rpc("get-interface-information")
         self.tty_net._tty.rawwrite.assert_called_with(
-            six.b("<rpc><get-interface-information/></rpc>")
+            b"<rpc><get-interface-information/></rpc>"
         )
 
     @patch("jnpr.junos.transport.tty_netconf.tty_netconf._receive")
@@ -103,7 +102,7 @@ class TestTTYNetconf(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_empty_line(self, mock_select):
         rx = MagicMock()
-        rx.read_until.side_effect = iter([six.b(""), six.b("]]>]]>")])
+        rx.read_until.side_effect = iter([b"", b"]]>]]>"])
         mock_select.return_value = ([rx], [], [])
         self.assertEqual(self.tty_net._receive().tag, "error-in-receive")
 
@@ -117,7 +116,7 @@ class TestTTYNetconf(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_splited_eom(self, mock_select):
         rx = MagicMock()
-        rx.read_until.side_effect = iter([six.b(i) for i in ["testing]", "]>", "]]>"]])
+        rx.read_until.side_effect = iter([i.encode('utf-8') for i in ["testing]", "]>", "]]>"]])
         mock_select.return_value = ([rx], [], [])
         self.assertEqual(self.tty_net._receive().tag, "error-in-receive")
 
@@ -126,30 +125,30 @@ class TestTTYNetconf(unittest.TestCase):
         rx = MagicMock()
 
         rx.read_until.side_effect = iter(
-            [six.b("<rpc-reply>ok<dummy></rpc-reply>"), six.b("\n]]>]]>")]
+            [b"<rpc-reply>ok<dummy></rpc-reply>", b"\n]]>]]>"]
         )
         mock_select.return_value = ([rx], [], [])
         self.assertEqual(
-            self.tty_net._receive(), six.b("<rpc-reply>ok<dummy/></rpc-reply>")
+            self.tty_net._receive(), b"<rpc-reply>ok<dummy/></rpc-reply>"
         )
 
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_XMLSyntaxError_eom_in_center(self, mock_select):
         rx = MagicMock()
         rx.read_until.side_effect = iter(
-            [six.b("<rpc-reply>ok</rpc-reply>"), six.b("]]>]]>\ndummy")]
+            [b"<rpc-reply>ok</rpc-reply>", b"]]>]]>\ndummy"]
         )
         mock_select.return_value = ([rx], [], [])
-        self.assertEqual(self.tty_net._receive(), six.b("<rpc-reply>ok</rpc-reply>"))
+        self.assertEqual(self.tty_net._receive(), b"<rpc-reply>ok</rpc-reply>")
 
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_xmn_error(self, mock_select):
         rx = MagicMock()
         rx.read_until.side_effect = iter(
             [
-                six.b("<message>ok</message>"),
-                six.b("\n</xnm:error>\n"),
-                six.b("]]>]]>\ndummy"),
+                b"<message>ok</message>",
+                b"\n</xnm:error>\n",
+                b"]]>]]>\ndummy",
             ]
         )
         mock_select.return_value = ([rx], [], [])

--- a/tests/unit/transport/test_tty_telnet.py
+++ b/tests/unit/transport/test_tty_telnet.py
@@ -7,7 +7,6 @@ except ImportError:
 import nose2
 from mock import MagicMock, patch
 from jnpr.junos.transport.tty_telnet import Telnet
-import six
 
 
 class TestTTYTelnet(unittest.TestCase):
@@ -62,7 +61,7 @@ class TestTTYTelnet(unittest.TestCase):
         self.tel_conn._tn.expect.return_value = (
             None,
             None,
-            six.b("port already in use"),
+            b"port already in use",
         )
         self.assertRaises(RuntimeError, self.tel_conn._login_state_machine)
 

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -1,5 +1,5 @@
 import sys
-from six import StringIO
+from io import StringIO
 from contextlib import contextmanager
 
 import unittest

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os
 import sys
-from six import StringIO
+from io import StringIO
 
 try:
     import unittest2 as unittest


### PR DESCRIPTION
As this library is python3-only, it shouldn't need six.

If there are any mistakes in the patch, please let me know. It was partially done by far-from-perfect sed script.