### PR TITLE
Updated mock to built-in unittest.mock

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 
 coverage     # http://nedbatchelder.com/code/coverage/
-mock         # http://www.voidspace.org.uk/python/mock/
 nose2        # https://docs.nose2.io/en/latest/
 pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 
 import nose2
-from mock import patch
+from unittest.mock import patch
 
 __author__ = "Nitin Kumar"
 __credits__ = "Jeremy Schulman"

--- a/tests/unit/factory/test_cfgtable.py
+++ b/tests/unit/factory/test_cfgtable.py
@@ -13,7 +13,7 @@ from jnpr.junos import Device
 from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 from lxml import etree
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from jnpr.junos.factory import loadyaml
 from jnpr.junos.factory.factory_loader import FactoryLoader

--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -10,7 +10,7 @@ from jnpr.junos.exception import RpcError
 
 from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import yamlordereddictloader
 from jnpr.junos.factory.factory_loader import FactoryLoader
 import yaml

--- a/tests/unit/factory/test_factory_loader.py
+++ b/tests/unit/factory/test_factory_loader.py
@@ -4,7 +4,7 @@ __credits__ = "Jeremy Schulman"
 import unittest
 import nose2
 from jnpr.junos.factory import FactoryLoader
-from mock import patch
+from unittest.mock import patch
 
 
 class TestFactoryLoader(unittest.TestCase):

--- a/tests/unit/factory/test_optable.py
+++ b/tests/unit/factory/test_optable.py
@@ -19,7 +19,7 @@ from ncclient.operations.rpc import RPCReply
 
 from lxml import etree
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestFactoryOpTable(unittest.TestCase):

--- a/tests/unit/factory/test_table.py
+++ b/tests/unit/factory/test_table.py
@@ -8,7 +8,7 @@ import os
 from jnpr.junos import Device
 from jnpr.junos.factory.table import Table
 
-from mock import patch
+from unittest.mock import patch
 from lxml import etree
 from jnpr.junos.op.phyport import PhyPortTable
 

--- a/tests/unit/factory/test_to_json.py
+++ b/tests/unit/factory/test_to_json.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import patch
+from unittest.mock import patch
 import os
 import json
 

--- a/tests/unit/factory/test_view.py
+++ b/tests/unit/factory/test_view.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from jnpr.junos import Device
 from jnpr.junos.factory.view import View
 from jnpr.junos.op.phyport import PhyPortStatsTable, PhyPortStatsView

--- a/tests/unit/facts/test_current_re.py
+++ b/tests/unit/facts/test_current_re.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_domain.py
+++ b/tests/unit/facts/test_domain.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_ethernet_mac_table.py
+++ b/tests/unit/facts/test_ethernet_mac_table.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_file_list.py
+++ b/tests/unit/facts/test_file_list.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/facts/test_get_chassis_cluster_status.py
+++ b/tests/unit/facts/test_get_chassis_cluster_status.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_get_chassis_inventory.py
+++ b/tests/unit/facts/test_get_chassis_inventory.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/facts/test_get_route_engine_information.py
+++ b/tests/unit/facts/test_get_route_engine_information.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_get_software_information.py
+++ b/tests/unit/facts/test_get_software_information.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_get_virtual_chassis_information.py
+++ b/tests/unit/facts/test_get_virtual_chassis_information.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 import sys
 from lxml import etree

--- a/tests/unit/facts/test_ifd_style.py
+++ b/tests/unit/facts/test_ifd_style.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from lxml import etree
 

--- a/tests/unit/facts/test_iri_mapping.py
+++ b/tests/unit/facts/test_iri_mapping.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/facts/test_personality.py
+++ b/tests/unit/facts/test_personality.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 from jnpr.junos.exception import RpcError
 

--- a/tests/unit/ofacts/test_chassis.py
+++ b/tests/unit/ofacts/test_chassis.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from lxml import etree
 import os
 

--- a/tests/unit/ofacts/test_domain.py
+++ b/tests/unit/ofacts/test_domain.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from lxml import etree
 
 from jnpr.junos.ofacts.domain import facts_domain

--- a/tests/unit/ofacts/test_ifd_style.py
+++ b/tests/unit/ofacts/test_ifd_style.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from mock import patch
+from unittest.mock import patch
 import nose2
 
 from jnpr.junos import Device

--- a/tests/unit/ofacts/test_personality.py
+++ b/tests/unit/ofacts/test_personality.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from mock import patch
+from unittest.mock import patch
 import nose2
 
 from jnpr.junos import Device

--- a/tests/unit/ofacts/test_routing_engines.py
+++ b/tests/unit/ofacts/test_routing_engines.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 import sys
 

--- a/tests/unit/ofacts/test_srx_cluster.py
+++ b/tests/unit/ofacts/test_srx_cluster.py
@@ -3,7 +3,7 @@ __credits__ = "Jeremy Schulman"
 
 import unittest
 import nose2
-from mock import patch
+from unittest.mock import patch
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/ofacts/test_switch_style.py
+++ b/tests/unit/ofacts/test_switch_style.py
@@ -2,7 +2,7 @@ __author__ = "Nitin Kumar, Rick Sherman"
 __credits__ = "Jeremy Schulman"
 
 import unittest
-from mock import patch
+from unittest.mock import patch
 import nose2
 
 from jnpr.junos import Device

--- a/tests/unit/ofacts/test_swver.py
+++ b/tests/unit/ofacts/test_swver.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -4,7 +4,7 @@ except ImportError:
     import unittest
 from jnpr.junos.utils.config import Config
 import nose2
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 import re
 import sys
 import os

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -12,7 +12,7 @@ from jnpr.junos.exception import RpcError, ConfigLoadError
 from jnpr.junos.decorators import timeoutDecorator, normalizeDecorator
 from jnpr.junos.decorators import ignoreWarnDecorator
 
-from mock import patch, MagicMock, PropertyMock, call
+from unittest.mock import patch, MagicMock, PropertyMock, call
 
 from ncclient.operations.rpc import RPCError
 from ncclient.manager import Manager, make_device_handler

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import MagicMock, patch, mock_open, call
+from unittest.mock import MagicMock, patch, mock_open, call
 import os
 from lxml import etree
 import sys

--- a/tests/unit/test_factcache.py
+++ b/tests/unit/test_factcache.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 from jnpr.junos.exception import FactLoopError
 
 from jnpr.junos import Device

--- a/tests/unit/test_junos.py
+++ b/tests/unit/test_junos.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 
 import nose2
-from mock import patch
+from unittest.mock import patch
 
 __author__ = "Nitin Kumar"
 __credits__ = "Jeremy Schulman"

--- a/tests/unit/test_jxml.py
+++ b/tests/unit/test_jxml.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from io import StringIO
 import nose2
-from mock import patch
+from unittest.mock import patch
 from jnpr.junos.jxml import (
     NAME,
     INSERT,

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -10,7 +10,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 from jnpr.junos.exception import JSONLoadError
 
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 from lxml import etree
 
 __author__ = "Nitin Kumar, Rick Sherman"

--- a/tests/unit/transport/test_serial.py
+++ b/tests/unit/transport/test_serial.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 import sys
 import six
 

--- a/tests/unit/transport/test_tty.py
+++ b/tests/unit/transport/test_tty.py
@@ -6,7 +6,7 @@ except ImportError:
     import unittest
 
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from jnpr.junos.transport.tty import Terminal
 from jnpr.junos import exception as EzErrors

--- a/tests/unit/transport/test_tty_netconf.py
+++ b/tests/unit/transport/test_tty_netconf.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from jnpr.junos.transport.tty_netconf import tty_netconf
 

--- a/tests/unit/transport/test_tty_ssh.py
+++ b/tests/unit/transport/test_tty_ssh.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from jnpr.junos.transport.tty_ssh import SSH
 
 

--- a/tests/unit/transport/test_tty_telnet.py
+++ b/tests/unit/transport/test_tty_telnet.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import unittest
 import nose2
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from jnpr.junos.transport.tty_telnet import Telnet
 import six
 

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -19,7 +19,7 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 from ncclient.operations import RPCError, RPCReply
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from lxml import etree
 import os
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -9,7 +9,7 @@ from jnpr.junos import Device
 from jnpr.junos.utils.fs import FS
 from jnpr.junos.exception import RpcError
 
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 from lxml import etree
 
 __author__ = "Nitin Kumar, Rick Sherman"

--- a/tests/unit/utils/test_ftp.py
+++ b/tests/unit/utils/test_ftp.py
@@ -7,7 +7,7 @@ import os
 from jnpr.junos import Device
 import jnpr.junos.utils.ftp
 
-from mock import patch
+from unittest.mock import patch
 
 if sys.version < "3":
     builtin_string = "__builtin__"

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -8,7 +8,7 @@ import nose2
 from jnpr.junos import Device
 from jnpr.junos.utils.scp import SCP
 
-from mock import patch
+from unittest.mock import patch
 
 __author__ = "Rick Sherman, Nitin Kumar"
 __credits__ = "Jeremy Schulman"

--- a/tests/unit/utils/test_start_shell.py
+++ b/tests/unit/utils/test_start_shell.py
@@ -4,7 +4,7 @@ import nose2
 from jnpr.junos import Device
 from jnpr.junos.utils.start_shell import StartShell
 
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 
 __author__ = "Rick Sherman"
 __credits__ = "Jeremy Schulman, Nitin Kumar"

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -16,7 +16,7 @@ from jnpr.junos.facts.swver import version_info
 from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 from lxml import etree
-from mock import patch, MagicMock, call, mock_open
+from unittest.mock import patch, MagicMock, call, mock_open
 
 if sys.version < "3":
     builtin_string = "__builtin__"

--- a/tests/unit/utils/test_util.py
+++ b/tests/unit/utils/test_util.py
@@ -7,7 +7,7 @@ import nose2
 from jnpr.junos import Device
 from jnpr.junos.utils.util import Util
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestUtil(unittest.TestCase):


### PR DESCRIPTION
Removed a `mock` dependency in the PyEZ module.
`mock` was a third-party package for Python 2.7 first, then became part of the standard library in Python 3, available as unittest.mock.  So, updated unit testcases to use unittest.mock module.