### PR TITLE
Fix Python 3.12: `SyntaxWarning: invalid escape sequence '\s'` (closes #1312)

### DIFF
--- a/lib/jnpr/junos/transport/tty.py
+++ b/lib/jnpr/junos/transport/tty.py
@@ -52,7 +52,7 @@ class Terminal(object):
         "(?P<badpasswd>ogin incorrect)",
         r"(?P<netconf_closed><!-- session end at .*-->\s*)",
         r"(?P<shell>%|#|(~\$)\s*$)",
-        '(?P<cli>[^\\-"]>\s*$)',
+        r'(?P<cli>[^\-"]>\s*$)',
         r"(?P<option>Enter your option:\s*$)",
         "(?P<hotkey>connection: <CTRL>Z)",
     ]

--- a/tests/unit/factory/test_cmdtable.py
+++ b/tests/unit/factory/test_cmdtable.py
@@ -351,7 +351,7 @@ FPCLinkStatTable:
     @patch("jnpr.junos.Device.execute")
     def test_title_in_view(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 ShowLuchipTable:
   command: show luchip {{ lu_instance }}
@@ -498,7 +498,7 @@ FPCLinkStatTable:
     @patch("jnpr.junos.Device.execute")
     def test_field_eval(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 XMChipStatsTable:
   command: show xmchip {{ instance }} pt stats
@@ -675,7 +675,7 @@ FPCTTPReceiveStatsView:
     @patch("jnpr.junos.Device.execute")
     def test_unstructured_mtip_cge_regex(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 MtipCgeSummaryTable:
   command: show mtip-cge summary
@@ -877,7 +877,7 @@ _ICMPRateView:
     @patch("jnpr.junos.Device.execute")
     def test_unstructured_ithrottle_key_args(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 IthrottleIDTable:
   command: show ithrottle id {{ id }}
   args:
@@ -921,7 +921,7 @@ _ThrottleStatsTable:
     @patch("jnpr.junos.Device.execute")
     def test_pci_errs_multi_key_regex(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 ShowPciErrorsTable:
   command: show pci errors {{ pci_controller_number }}
@@ -1024,7 +1024,7 @@ FPCMemoryView:
     @patch("jnpr.junos.Device.execute")
     def test_item_regex_pq3_pci(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 PQ3PCITable:
   command: show pq3 pci
@@ -1147,7 +1147,7 @@ PQ3PCI:
     @patch("jnpr.junos.Device.execute")
     def test_regex_with_fields(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 SchedulerTable:
   command: show sched
@@ -1252,7 +1252,7 @@ HostlbStatusSummaryView:
     @patch("jnpr.junos.Device.execute")
     def test_table_with_item_regex(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 DevicesLocalTable:
   command: show devices local
@@ -1354,7 +1354,7 @@ _TransmitPerQueueView:
     @patch("jnpr.junos.Device.execute")
     def test_table_item_group_key_mismatch(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 DevicesLocalTable:
   command: show devices local
@@ -1390,7 +1390,7 @@ _ReceiveView:
     @patch("jnpr.junos.Device.execute")
     def test_table_with_item_without_view(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 EthernetSwitchStatisticsIterTable:
   command: show chassis ethernet-switch statistics
@@ -1629,7 +1629,7 @@ _EthSwitchStatsFpc5Table:
     @patch("jnpr.junos.Device.execute")
     def test_valueerror_with_no_target(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 ShowToePfePacketStatsTable:
   command: show toe pfe {{ pfe_instance }} {{ asic_type }} {{ asic_instance }} toe-inst {{ toe_instance }} packet-stats
@@ -1697,7 +1697,7 @@ _ShowToePfePacketStatsStream_rx_errors:
     @patch("jnpr.junos.Device.execute")
     def test_item_with_fields_delimiter(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 ShowToePfePacketStatsTable:
   command: show toe pfe {{ pfe_instance }} {{ asic_type }} {{ asic_instance }} toe-inst {{ toe_instance }} packet-stats
@@ -2300,7 +2300,7 @@ FPCThreadView:
     @patch("jnpr.junos.Device.execute")
     def test_new_line_in_data(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
-        yaml_data = """
+        yaml_data = r"""
 ---
 CChipLoStatsTable:
   command: show xmchip {{ chip_instance }} lo stats 0

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -40,15 +40,15 @@ class TestConsole(unittest.TestCase):
     def setUp(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
             (
                 2,
-                re.search("(?P<passwd>assword:\s*$)", "password: "),
+                re.search(r"(?P<passwd>assword:\s*$)", "password: "),
                 six.b("\r\r\n password:"),
             ),
             (
                 3,
-                re.search("(?P<shell>%|#\s*$)", "junos % "),
+                re.search(r"(?P<shell>%|#\s*$)", "junos % "),
                 six.b("\r\r\nroot@device:~ # "),
             ),
         ]
@@ -87,10 +87,10 @@ class TestConsole(unittest.TestCase):
     def test_login_bad_password(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
             (
                 2,
-                re.search("(?P<passwd>assword:\s*$)", "password: "),
+                re.search(r"(?P<passwd>assword:\s*$)", "password: "),
                 six.b("\r\r\n password:"),
             ),
             (
@@ -110,15 +110,15 @@ class TestConsole(unittest.TestCase):
         tty_netconf.open = MagicMock()
 
         mock_expect.side_effect = [
-            (1, re.search("(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
             (
                 2,
-                re.search("(?P<passwd>assword:\s*$)", "password: "),
+                re.search(r"(?P<passwd>assword:\s*$)", "password: "),
                 six.b("\r\r\n password:"),
             ),
             (
                 3,
-                re.search("(?P<shell>%|#\s*$)", "junos % "),
+                re.search(r"(?P<shell>%|#\s*$)", "junos % "),
                 six.b("\r\r\nroot@device:~ # "),
             ),
         ]

--- a/tests/unit/test_rpcmeta.py
+++ b/tests/unit/test_rpcmeta.py
@@ -214,7 +214,7 @@ class Test_RpcMetaExec(unittest.TestCase):
         except JSONLoadError as ex:
             self.assertTrue(
                 re.search(
-                    "Expecting '?,'? delimiter: line 17 column 39 \(char 516\)",
+                    r"Expecting '?,'? delimiter: line 17 column 39 \(char 516\)",
                     ex.ex_msg,
                 )
                 is not None

--- a/tests/unit/utils/test_start_shell.py
+++ b/tests/unit/utils/test_start_shell.py
@@ -69,7 +69,7 @@ class TestStartShell(unittest.TestCase):
         ---(more)---
         """
         self.assertTrue(
-            str(self.shell.wait_for("---\(more\s?\d*%?\)---\n\s*|%")[0])
+            str(self.shell.wait_for(r"---\(more\s?\d*%?\)---\n\s*|%")[0])
             in self.shell._chan.recv.return_value
         )
 
@@ -92,7 +92,7 @@ class TestStartShell(unittest.TestCase):
         """
         ]
         self.assertTrue(
-            self.shell.run("show version", "---\(more\s?\d*%?\)---\n\s*|%")[0]
+            self.shell.run("show version", r"---\(more\s?\d*%?\)---\n\s*|%")[0]
         )
 
     @patch("jnpr.junos.utils.start_shell.StartShell.wait_for")


### PR DESCRIPTION
This fixes #1312 (Python 3.12: `SyntaxWarning: invalid escape sequence '\s'` (tty.py:55)) by using the Python raw string syntax where `\` are not evaluated.