### PR TITLE
Get full RPC response in cli function

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -735,6 +735,8 @@ class _Connection(object):
             if rsp is True:
                 return ""
             if rsp.tag in ["output", "rpc-reply"]:
+                if rsp.tag == "output" and rsp.getparent():
+                    rsp = rsp.getparent()
                 encode = None if sys.version < "3" else "unicode"
                 return etree.tostring(
                     rsp, method="text", with_tail=False, encoding=encode

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -735,7 +735,7 @@ class _Connection(object):
             if rsp is True:
                 return ""
             if rsp.tag in ["output", "rpc-reply"]:
-                if rsp.tag == "output" and rsp.getparent():
+                if rsp.tag == "output" and rsp.getparent() is not None:
                     rsp = rsp.getparent()
                 encode = None if sys.version < "3" else "unicode"
                 return etree.tostring(


### PR DESCRIPTION
`junos-eznc`'s `execute` function only returns the first child element, described in https://github.com/Juniper/py-junos-eznc/blob/a64698b280fb717730dddf75a2d4d8cacb2e4775/lib/jnpr/junos/device.py#L896-L901
Normally this isn't an issue, since commands return the full payload in one `<output>` as part of a `<rpc-reply>` i.e.
```
<rpc-reply message-id="xxx"><output>
Slot 0   Online       xxx
  PIC 0  Online       xxx
  PIC 1  Online       xxx
Slot 1   Online       xxx
  PIC 0  Online       xxx
  PIC 1  Online       xxx
</output></rpc-reply>
```
However, for some commands, like `show system core-dumps`, the `<rpc-reply>` contains multiple `<output>`s.
```
<rpc-reply message-id="urn:uuid:xxx"><output>
/var/crash/*core*: No such file or directory
</output><output>
/var/tmp/*core*: No such file or directory
</output><output>
/var/tmp/pics/*core*: No such file or directory
</output><output>
/var/crash/kernel.*: No such file or directory
</output><output>
/var/jails/rest-api/tmp/*core*: No such file or directory
</output><output>
/tftpboot/corefiles/*core*: No such file or directory
</output></rpc-reply>
```
In these cases, only selecting the first element means that we only select 
```
<output>
/var/crash/*core*: No such file or directory
</output>
```
and `cli` returns just 
```
/var/crash/*core*: No such file or directory
```
instead of the full output.

To fix this I'm proposing to get the parent of output message (if one exists) so that the full output of the command is returned.