### PR TITLE
Added vmhost parameter in the facts template

### DIFF
--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -31,6 +31,7 @@ NOTE: The dictionary key for each available fact is guaranteed to exist. If
 The following dictionary keys represent the available facts and their meaning:
 
 """
+
 import sys
 
 import jnpr.junos.facts.current_re

--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -31,7 +31,6 @@ NOTE: The dictionary key for each available fact is guaranteed to exist. If
 The following dictionary keys represent the available facts and their meaning:
 
 """
-
 import sys
 
 import jnpr.junos.facts.current_re
@@ -48,6 +47,7 @@ import jnpr.junos.facts.iri_mapping
 import jnpr.junos.facts.personality
 import jnpr.junos.facts.swver
 import jnpr.junos.facts.is_linux
+import jnpr.junos.facts.vmhost
 
 
 def _build_fact_callbacks_and_doc_strings():

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -1,0 +1,40 @@
+from jnpr.junos.exception import RpcError
+import re
+from lxml import etree
+
+
+def provides_facts():
+    """
+    Returns a dictionary keyed on the facts provided by this module. The value
+    of each key is the doc string describing the fact.
+    """
+    return {
+        "vmhost": "A boolean indicating if the device is vmhost.",
+    }
+
+
+def get_facts(device):
+    """
+    Gathers facts from the sysctl command.
+    """
+    SYSCTL_VMHOST_MODE = "sysctl -n hw.re.vmhost_mode"
+    vmhost = None
+
+    if device.facts["_is_linux"]:
+        vmhost = None
+    else:
+        try:
+            rsp = device.rpc.request_shell_execute(command=SYSCTL_VMHOST_MODE)
+            if rsp.tag == "rpc-error":
+                raise RpcError()
+            result = re.sub("<[^<]+>", "", etree.tostring(rsp).decode())
+            if result.strip() == "1":
+                vmhost = True
+            else:
+                vmhost = False
+        except RpcError:
+            pass
+
+    return {
+        "vmhost": vmhost,
+    }

--- a/tests/unit/facts/rpc-reply/vmhost_error_request-shell-execute.xml
+++ b/tests/unit/facts/rpc-reply/vmhost_error_request-shell-execute.xml
@@ -1,0 +1,11 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1R1/junos">
+<rpc-error>
+<error-type>protocol</error-type>
+<error-tag>operation-failed</error-tag>
+<error-severity>error</error-severity>
+<error-message>permission denied</error-message>
+<error-info>
+<bad-element>system</bad-element>
+</error-info>
+</rpc-error>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/vmhost_false_request-shell-execute.xml
+++ b/tests/unit/facts/rpc-reply/vmhost_false_request-shell-execute.xml
@@ -1,0 +1,5 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1R1/junos">
+<output>
+0
+</output>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/vmhost_true_request-shell-execute.xml
+++ b/tests/unit/facts/rpc-reply/vmhost_true_request-shell-execute.xml
@@ -1,0 +1,5 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/16.1R1/junos">
+<output>
+1
+</output>
+</rpc-reply>

--- a/tests/unit/facts/test_vmhost.py
+++ b/tests/unit/facts/test_vmhost.py
@@ -1,0 +1,74 @@
+__author__ = "Stacy Smith"
+__credits__ = "Jeremy Schulman, Nitin Kumar"
+
+import unittest
+from nose.plugins.attrib import attr
+from mock import patch, MagicMock
+import os
+
+from jnpr.junos import Device
+
+from ncclient.manager import Manager, make_device_handler
+from ncclient.transport import SSHSession
+
+
+@attr("unit")
+class TestVmHost(unittest.TestCase):
+    @patch("ncclient.manager.connect")
+    def setUp(self, mock_connect):
+        mock_connect.side_effect = self._mock_manager_setup
+        self.dev = Device(
+            host="1.1.1.1", user="rick", password="password123", gather_facts=False
+        )
+        self.dev.open()
+
+    @patch("jnpr.junos.Device.execute")
+    def test_vmhost_true(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_vmhost_true
+        self.assertEqual(self.dev.facts["vmhost"], True)
+
+    @patch("jnpr.junos.Device.execute")
+    def test_vmhost_false(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_vmhost_false
+        self.assertEqual(self.dev.facts["vmhost"], False)
+
+    @patch("jnpr.junos.Device.execute")
+    def test_vmhost_none(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_vmhost_false
+        self.dev.facts._cache["_is_linux"] = True
+        self.assertEqual(self.dev.facts["vmhost"], None)
+
+    @patch("jnpr.junos.Device.execute")
+    def test_vmhost_error(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager_vmhost_error
+        self.assertEqual(self.dev.facts["vmhost"], None)
+
+    def _read_file(self, fname):
+        from ncclient.xml_ import NCElement
+
+        fpath = os.path.join(os.path.dirname(__file__), "rpc-reply", fname)
+        foo = open(fpath).read()
+
+        rpc_reply = NCElement(
+            foo, self.dev._conn._device_handler.transform_reply()
+        )._NCElement__doc[0]
+        return rpc_reply
+
+    def _mock_manager_setup(self, *args, **kwargs):
+        if kwargs:
+            device_params = kwargs["device_params"]
+            device_handler = make_device_handler(device_params)
+            session = SSHSession(device_handler)
+            return Manager(session, device_handler)
+
+    def _mock_manager_vmhost_true(self, *args, **kwargs):
+        if args:
+            return self._read_file("vmhost_true_" + args[0].tag + ".xml")
+
+    def _mock_manager_vmhost_false(self, *args, **kwargs):
+        if args:
+            return self._read_file("vmhost_false_" + args[0].tag + ".xml")
+
+    def _mock_manager_vmhost_error(self, *args, **kwargs):
+        if args:
+            return self._read_file("vmhost_error_" + args[0].tag + ".xml")

--- a/tests/unit/facts/test_vmhost.py
+++ b/tests/unit/facts/test_vmhost.py
@@ -12,7 +12,6 @@ from ncclient.manager import Manager, make_device_handler
 from ncclient.transport import SSHSession
 
 
-@attr("unit")
 class TestVmHost(unittest.TestCase):
     @patch("ncclient.manager.connect")
     def setUp(self, mock_connect):

--- a/tests/unit/facts/test_vmhost.py
+++ b/tests/unit/facts/test_vmhost.py
@@ -2,8 +2,8 @@ __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
 import unittest
-from nose.plugins.attrib import attr
-from mock import patch, MagicMock
+import nose2
+from unittest.mock import patch, MagicMock
 import os
 
 from jnpr.junos import Device

--- a/tests/unit/facts/test_vmhost.py
+++ b/tests/unit/facts/test_vmhost.py
@@ -1,7 +1,10 @@
 __author__ = "Stacy Smith"
 __credits__ = "Jeremy Schulman, Nitin Kumar"
 
-import unittest
+try:
+    import unittest2 as unittest
+except:
+    import unittest
 import nose2
 from unittest.mock import patch, MagicMock
 import os


### PR DESCRIPTION
Added vmhost parameter in the facts template to check running device is vmhost supported or not.  

If vmhost returns `True`, then the running device is Vmhost supported device.
If vmhost returns `False`, then the running device is non-Vmhost-supported device.
If Vmhost returns `None`,  then the running device is Juno’s evolved device or unable to get the vmhost data.


### Functional test cases:  

```
from jnpr.junos import Device
dev_vmhost = Device(host=‘x.x.x.x’, user='root', password=‘’xxxx)
dev_evolved = Device(host='x.x.x.x’', user='root', password=‘xxxx’)
dev_non_vmhost = Device(host='x.x.x.x’', user='root', password=‘xxxx’)

dev_vmhost.open()
dev_evolved.open()
dev_non_vmhost.open()

print("The output of facts['vmhost'] in vmhost supported device: " + str(dev_vmhost.facts['vmhost']))
dev_vmhost.facts_refresh()
print("The output of facts['vmhost'] in vmhost supported device after refresh: " + str(dev_vmhost.facts['vmhost']))

print("The output of facts['vmhost'] in junos evolved device:  " + str(dev_evolved.facts['vmhost']))
dev_evolved.facts_refresh()
print("The output of facts['vmhost'] in junos evolved device after refresh:  " + str(dev_evolved.facts['vmhost']))

print("The output of facts['vmhost'] in non vmhost supported device: " + str(dev_non_vmhost.facts['vmhost']))
dev_non_vmhost.facts_refresh()
print("The output of facts['vmhost'] in non vmhost supported device after refresh: " + str(dev_non_vmhost.facts['vmhost']))
```


##### O/p: 
The output of facts['vmhost'] in vmhost supported device: True
The output of facts['vmhost'] in vmhost supported device after refresh: True
The output of facts['vmhost'] in junos evolved device:  None
The output of facts['vmhost'] in junos evolved device after refresh:  None
The output of facts['vmhost'] in non vmhost supported device: False
The output of facts['vmhost'] in non vmhost supported device after refresh: False

###  Unit test cases:

```
(venv_pyez) py-junos-eznc % nose2 --with-coverage tests.unit.facts.test_vmhost                      
....
----------------------------------------------------------------------
Ran 4 tests in 0.012s  Name                                                       Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------------
lib/jnpr/junos/facts/vmhost.py                     21      0   100%
```
