### PR TITLE
Fixed Console' object has no attribute '_use_filter' error when executed Table/View script

### DIFF
--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -114,6 +114,7 @@ class Console(_Connection):
         self._attempts = kvargs.get("attempts", 10)
         self._gather_facts = kvargs.get("gather_facts", False)
         self._fact_style = kvargs.get("fact_style", "new")
+        self._use_filter = False
         self._huge_tree = kvargs.get("huge_tree", False)
         if self._fact_style != "new":
             warnings.warn(

--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -68,8 +68,8 @@ class OpTable(Table):
                 rpc_args["filter_xml"] = filter_xml
             except Exception as ex:
                 logger.debug("Not able to create SAX parser input due to " "'%s'" % ex)
+            self.D.transform = lambda: remove_namespaces_and_spaces
 
-        self.D.transform = lambda: remove_namespaces_and_spaces
         rpc_args.update(self.GET_ARGS)  # copy default args
         # saltstack get_table pass args as named keyword
         if "args" in kvargs and isinstance(kvargs["args"], dict):


### PR DESCRIPTION
The `use_filter` parameter is supported only on SSH connection, not on telnet/serial connection.
Need enhancement to support  `use_filter` on telnet connection.

### Testcase

## Using telnet mode table/view script execution

```
% cat issue_1314.py 
from jnpr.junos import Device
from jnpr.junos.op.systemstorage import SystemStorageTable 
from jnpr.junos.factory.factory_loader import FactoryLoader
import yaml

with Device(host="x.x.x.x", user="xxx", passwd="xxx", mode = "telnet") as dev:
    ss = SystemStorageTable(dev).get()
    print(ss)
``` 

Output:

 % python3 issue_1314.py 
SystemStorageTable:x.x.x.x: 4 items


## Using ssh mode table/view script execution

```
% cat issue_1314.py 
from jnpr.junos import Device
from jnpr.junos.op.systemstorage import SystemStorageTable 
from jnpr.junos.factory.factory_loader import FactoryLoader
import yaml

with Device(host="x.x.x.x", user="xxx", passwd="xxx", port=22) as dev:
    ss = SystemStorageTable(dev).get()
    print(ss)
```

Output:

 % python3 issue_1314.py 
SystemStorageTable:x.x.x.x: 4 items


