### PR TITLE
Fix for issue #1244

### DIFF
--- a/lib/jnpr/junos/op/systemstorage.yml
+++ b/lib/jnpr/junos/op/systemstorage.yml
@@ -1,12 +1,23 @@
----
+  ---
 SystemStorageTable:
   rpc: get-system-storage
-  key: filesystem-name
-  item: filesystem
+  key: re-name | Null
+  item: //multi-routing-engine-item | //rpc-reply/system-storage-information
   view: SystemStorageView
 
 SystemStorageView:
   fields:
+    re-name: re-name
+    filesystems: _FsTable
+
+_FsTable:
+  item: system-storage-information/filesystem | //rpc-reply/system-storage-information/filesystem
+  key: filesystem-name
+  view: _FsView
+
+_FsView:
+  fields:
+    name: filesystem-name
     total_blocks: total-blocks
     used_blocks: used-blocks
     available_blocks: available-blocks


### PR DESCRIPTION
Fix for issue #1244 

[systemstorage.yml](https://github.com/Juniper/py-junos-eznc/tree/master/lib/jnpr/junos/op/systemstorage.yml) changes handles  multiple routing-engine  file system storage information.

```
(venv) root@masterhost:~/pyez_release_test1# python issue_1244.py 
{'fpc0': {'filesystems': {'/dev/gpt/junos': {'available_blocks': '1004408',
                                             'mounted_on': '/.mount',
                                             'name': '/dev/gpt/junos',
                                             'total_blocks': '2943456',
                                             'used_blocks': '1703576',
                                             'used_percent': '63'},
                          'tmpfs': {'available_blocks': '663392',
                                    'mounted_on': '/.mount/mfs',
                                    'name': 'tmpfs',
                                    'total_blocks': '664456',
                                    'used_blocks': '1064',
                                    'used_percent': '0'}},
          're-name': 'fpc0'},
 'fpc1': {'filesystems': {'/dev/gpt/junos': {'available_blocks': '1006936',
                                             'mounted_on': '/.mount',
                                             'name': '/dev/gpt/junos',
                                             'total_blocks': '2943456',
                                             'used_blocks': '1701048',
                                             'used_percent': '63'},
                          'tmpfs': {'available_blocks': '663664',
                                    'mounted_on': '/.mount/mfs',
                                    'name': 'tmpfs',
                                    'total_blocks': '664456',
                                    'used_blocks': '792',
                                    'used_percent': '0'}},
          're-name': 'fpc1'},
 'fpc2': {'filesystems': {'/dev/gpt/junos': {'available_blocks': '954616',
                                             'mounted_on': '/.mount',
                                             'name': '/dev/gpt/junos',
                                             'total_blocks': '2943456',
                                             'used_blocks': '1753368',
                                             'used_percent': '65'},
                          'tmpfs': {'available_blocks': '663808',
                                    'mounted_on': '/.mount/mfs',
                                    'name': 'tmpfs',
                                    'total_blocks': '664456',
                                    'used_blocks': '648',
                                    'used_percent': '0'}},
          're-name': 'fpc2'},
 'fpc3': {'filesystems': {'/dev/gpt/junos': {'available_blocks': '1024040',
                                             'mounted_on': '/.mount',
                                             'name': '/dev/gpt/junos',
                                             'total_blocks': '2943456',
                                             'used_blocks': '1683944',
                                             'used_percent': '62'},
                          'tmpfs': {'available_blocks': '663808',
                                    'mounted_on': '/.mount/mfs',
                                    'name': 'tmpfs',
                                    'total_blocks': '664456',
                                    'used_blocks': '648',
                                    'used_percent': '0'}},
          're-name': 'fpc3'}}
```

```
(venv) root@masterhost:~/pyez_release_test1# python issue_1244.py 
{'filesystems': {'/dev/gpt/junos': {'available_blocks': '29118242',
                                    'mounted_on': '/.mount',
                                    'name': '/dev/gpt/junos',
                                    'total_blocks': '41803892',
                                    'used_blocks': '9341340',
                                    'used_percent': '24'},
                 '/var/jails/rest-api': {'available_blocks': '29118242',
                                         'mounted_on': '/.mount/packages/mnt/junos-runtime/web-api/var',
                                         'name': '/var/jails/rest-api',
                                         'total_blocks': '41803892',
                                         'used_blocks': '9341340',
                                         'used_percent': '24'},
                 'tmpfs': {'available_blocks': '1367720',
                           'mounted_on': '/.mount/mfs',
                           'name': 'tmpfs',
                           'total_blocks': '1369592',
                           'used_blocks': '1872',
                           'used_percent': '0'}},
 're-name': None}
```