### PR TITLE
Fixed the version check

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -868,10 +868,9 @@ class _Connection(object):
             "JSON",
         ]:
             ver_info = self.facts.get("version_info")
-            if (
-                ver_info
-                and (ver_info.major[0] >= 15
-                or (ver_info.major[0] == 14 and ver_info.major[1] >= 2))
+            if ver_info and (
+                ver_info.major[0] >= 15
+                or (ver_info.major[0] == 14 and ver_info.major[1] >= 2)
             ):
                 try:
                     return json.loads(rpc_rsp_e.text, strict=False)

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -870,8 +870,8 @@ class _Connection(object):
             ver_info = self.facts.get("version_info")
             if (
                 ver_info
-                and ver_info.major[0] >= 15
-                or (ver_info.major[0] == 14 and ver_info.major[1] >= 2)
+                and (ver_info.major[0] >= 15
+                or (ver_info.major[0] == 14 and ver_info.major[1] >= 2))
             ):
                 try:
                     return json.loads(rpc_rsp_e.text, strict=False)


### PR DESCRIPTION
Fixed the valid version check.

## Testcase
```
op = dev.rpc.get_interface_information({'format': 'json'}, interface_name='lo0')
print(op["interface-information"][0]["physical-interface"][0]["name"])
```

## O/p:

(pyez_vir) example % python3 simple.py
[{'data': 'lo0'}]
