### PR TITLE
Added bind_addr parameter in Device() API

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1217,6 +1217,10 @@ class Device(_Connection):
             *OPTIONAL* To disable public key authentication.
             default is ``None``.
 
+        :param str bind_addr:
+            *OPTIONAL* To use (local) source IP address.
+            default is ``None``.
+
         :param bool hostkey_verify:
             *OPTIONAL* To enable ssh_known hostkey verify
             default is ``False``.

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1239,6 +1239,7 @@ class Device(_Connection):
         self._huge_tree = kvargs.get("huge_tree", False)
         self._conn_open_timeout = kvargs.get("conn_open_timeout", 30)
         self._look_for_keys = kvargs.get("look_for_keys", None)
+        self._bind_addr = kvargs.get("bind_addr", None)
         self._hostkey_verify = kvargs.get("hostkey_verify", False)
         if self._fact_style != "new":
             warnings.warn(
@@ -1393,6 +1394,7 @@ class Device(_Connection):
                 allow_agent=allow_agent,
                 look_for_keys=look_for_keys,
                 ssh_config=self._sshconf_lkup(),
+                bind_addr=self._bind_addr,
                 timeout=self._conn_open_timeout,
                 device_params={
                     "name": "junos",

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -465,6 +465,23 @@ class TestDevice(unittest.TestCase):
 
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
+    def test_device_open_with_bind_addr(self, mock_connect, mock_execute):
+        with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat:
+            mock_cat.return_value = """
+
+    domain jls.net
+
+            """
+            mock_connect.side_effect = self._mock_manager
+            mock_execute.side_effect = self._mock_manager
+            self.dev2 = Device(
+                host="2.2.2.2", user="test", password="password123", bind_addr="1.1.1.1"
+            )
+            self.dev2.open()
+            self.assertEqual(self.dev2.connected, True)
+
+    @patch("ncclient.manager.connect")
+    @patch("jnpr.junos.Device.execute")
     def test_device_open_with_look_for_keys_False(self, mock_connect, mock_execute):
         with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat:
             mock_cat.return_value = """
@@ -496,6 +513,7 @@ class TestDevice(unittest.TestCase):
             )
             self.dev2.open()
             self.assertEqual(self.dev2.connected, True)
+
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
     def test_device_open_with_hostkey_verify_True(self, mock_connect, mock_execute):
@@ -525,7 +543,10 @@ class TestDevice(unittest.TestCase):
             mock_connect.side_effect = self._mock_manager
             mock_execute.side_effect = self._mock_manager
             self.dev2 = Device(
-                host="2.2.2.2", user="test", password="password123", hostkey_verify=False
+                host="2.2.2.2",
+                user="test",
+                password="password123",
+                hostkey_verify=False,
             )
             self.dev2.open()
             self.assertEqual(self.dev2.connected, True)


### PR DESCRIPTION
*bind_addr* is a (local) source IP address to use, must be reachable from the remote device.

```
(envname) root@masterhost:~# ping -I 1.1.1.4 x.x.x.x
PING x.x.x.x (x.x.x.x) from 1.1.1.4 : 56(84) bytes of data.
64 bytes from x.x.x.x: icmp_seq=1 ttl=64 time=27.3 ms
64 bytes from x.x.x.x: icmp_seq=2 ttl=64 time=1.20 ms
64 bytes from x.x.x.x: icmp_seq=3 ttl=64 time=1.33 ms
```

####  Testcase1:  No Bind address configured 
 
```
(envname) root@masterhost:~# cat sample.py 
from jnpr.junos import Device
from pprint import pprint
dev = Device(host=‘ng1r,’ user='xyz', password='xyz')
dev.open()
pprint (dev.facts['hostname'])
```

##### O/P: 
(envname) root@masterhost:~# python3 sample.py 
'ng1r'
 
##### Netstat o/p: 
root@masterhost:~# netstat -a | grep 830
tcp        0      0 ng1h.englab.junip:53886 ng1r-fxp0.englab.ju:830 ESTABLISHED 

#### Testcase2: When bind address configured as None

```
(envname) root@masterhost:~# cat sample.py 
from jnpr.junos import Device
from pprint import pprint
dev = Device(host=’ng1r’, bind_addr= None, user='xyz', password='xyz')
dev.open()
pprint (dev.facts['hostname'])

```

##### O/p:
(envname) root@masterhost:~# python3 sample.py 
'ng1r'

##### Netstat o/p:
root@masterhost:~# netstat -a | grep 830
tcp        0      0 ng1h.englab.junip:45758 ng1r-fxp0.englab.ju:830 ESTABLISHED


#### Testcase3: When bind_address configured

```
(envname) root@masterhost:~# cat sample.py 
from jnpr.junos import Device
from pprint import pprint
dev = Device(host=‘ngn1r’, bind_addr= "1.1.1.4", user='xyz', password='xyz')
dev.open()
pprint (dev.facts['hostname'])
```

##### O/p:
(envname) root@masterhost:~# python3 sample.py 
'ng1r'

##### Netstat o/p:
root@masterhost:~# netstat -a | grep 830
tcp        0      0 1.1.1.4:55351           ng1r-fxp0.englab.ju:830 ESTABLISHED


#### Unit-test  
```
(envname) root@masterhost:~/dinesh/py-junos-eznc# nose2  tests.unit.test_device
............................................................................................................
----------------------------------------------------------------------
Ran 108 tests in 0.227s

OK
```