### PR TITLE
Fix for EthernetSwitchingTable issue #1228

### DIFF
--- a/lib/jnpr/junos/op/ethernetswitchingtable.yml
+++ b/lib/jnpr/junos/op/ethernetswitchingtable.yml
@@ -3,6 +3,7 @@ EthernetSwitchingTable:
     rpc: get-ethernet-switching-table-information
     args:
         detail: True
+    key: mac-table-count
     item: ethernet-switching-table
     view: EthernetSwitchingView
 


### PR DESCRIPTION
Added the missing key and verified the fix.
fix for issue #1228 
```
(venv) root@masterhost:~/pyez_release_test1# python issue_1228.py 
{'1': {'count': '1',
       'entries': {'vlan100': {'action': 'Forward',
                               'age': None,
                               'interface': 'Router',
                               'interface-list': {'Router': {'interfaces': 'Router'}},
                               'learned_time': None,
                               'mac_address': '2c:6b:f5:89:7f:81',
                               'next_hop': '0',
                               'type': 'Static',
                               'vlan': 'vlan100',
                               'vlan_tag': '100'}},
       'learned': '0',
       'persistent': '0'}}



show ethernet-switching table 
Ethernet-switching table: 1 entries, 0 learned, 0 persistent entries
  VLAN              MAC address       Type         Age Interfaces
  vlan100           2c:6b:f5:89:7f:81 Static         - Router

{master:0}
```