### PR TITLE
Updated latest paramiko that supports aes128-gcm and aes256-gcm cipher

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -6,4 +6,4 @@ pep8	     # https://github.com/jcrocholl/pep8
 pyflakes	 # https://launchpad.net/pyflakes
 coveralls	 # https://coveralls.io/
 ntc_templates # user needs to explicitly install this
-cryptography==3.2
+cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ncclient==0.6.15
 scp>=0.7.0
 jinja2>=2.7.1
 PyYAML>=5.1
+paramiko>=3.5.0
 six
 pyserial
 yamlordereddictloader

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup, find_packages
 import versioneer
 import os
 
-# Install customer paramiko
-os.system("pip install git+https://github.com/Juniper/paramiko.git@v3.4.0-JNPR")
 # parse requirements
 req_lines = [line.strip() for line in open("requirements.txt").readlines()]
 install_reqs = list(filter(None, req_lines))


### PR DESCRIPTION
* Updated latest paramiko version which supports aes128-gcm and aes256-gcm cipher

### Testcase


#### Configuration

```
{master}[edit]
xxxx@jnpr# show system services    
ssh {
    ciphers [ "aes128-gcm@openssh.com" "aes256-gcm@openssh.com" ];
}

```

#### Snippet

```
(pyez_vir)  % cat simple.py 
from jnpr.junos import Device
from lxml import etree
import json

dev = Device(host='x.x.x.', user='xxxx', password= 'yyyyy', port=22, gather_facts=False)
dev.open()
print(dev.facts['hostname'])
dev.close()
```

#### Output

(pyez_vir)  % python3 simple.py 
jnpr

