### PR TITLE
Fix for issue #1355 to add vmhost partitions details to facts

### DIFF
--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -66,7 +66,7 @@ def get_facts(device):
         except RpcError:
             pass
 
-    if vmhost == True:
+    if vmhost:
         rsp = _get_vmhost_version_information(device)
         if rsp.tag == "output":
             pass

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -2,6 +2,32 @@ from jnpr.junos.exception import RpcError
 import re
 from lxml import etree
 
+def _get_vmhost_version_information(device):
+    multi_re = False
+    try:
+        rsp = device.rpc.get_route_engine_information(normalize=True)
+        re_list = rsp.findall(".//route-engine")
+        if len(re_list) > 1:
+            multi_re = True
+        else:
+            multi_re = False
+    except RpcError as err:
+        pass
+
+    if multi_re == True:
+        try:
+            return device.rpc.cli(
+                "show vmhost version invoke-on all-routing-engines", format="xml", normalize=True
+            )
+        except RpcError as err:
+            raise RpcError()
+    else:
+        try:
+            return device.rpc.cli(
+                "show vmhost version", format="xml", normalize=True
+            )
+        except RpcError as err:
+            raise RpcError()
 
 def provides_facts():
     """
@@ -19,6 +45,8 @@ def get_facts(device):
     """
     SYSCTL_VMHOST_MODE = "sysctl -n hw.re.vmhost_mode"
     vmhost = None
+    vmhost_info = {}
+    vm_ver_rsp = None
 
     if device.facts["_is_linux"]:
         vmhost = False
@@ -35,6 +63,30 @@ def get_facts(device):
         except RpcError:
             pass
 
+    if vmhost == True:
+        rsp = _get_vmhost_version_information(device)
+        if rsp.tag == "output":
+            pass
+        else:
+            if rsp.tag == "vmhost-version-information":
+                vm_ver_rsp = [rsp]
+            else:
+                vm_ver_rsp = rsp.findall(".//vmhost-version-information")
+            vmhost_info = {}
+
+            for re_vm_ver_info in vm_ver_rsp:
+                re_name = re_vm_ver_info.findtext("../re-name", "re0")
+                vmhost_current_root_set = re_vm_ver_info.findtext("./current-root-set")
+                vmhost_set_junos_version_set_p = re_vm_ver_info.findtext("./set-disk-info[set-disk-name = 'set p']/set-junos-version")
+                vmhost_set_junos_version_set_b = re_vm_ver_info.findtext("./set-disk-info[set-disk-name = 'set b']/set-junos-version")
+
+                vmhost_info[re_name] = {
+                    "vmhost_current_root_set": vmhost_current_root_set,
+                    "vmhost_version_set_p" : vmhost_set_junos_version_set_p,
+                    "vmhost_version_set_b": vmhost_set_junos_version_set_b,
+               }
+
     return {
         "vmhost": vmhost,
+        "vmhost_info": vmhost_info,
     }

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -72,7 +72,8 @@ def get_facts(device):
 
     if vmhost:
         rsp = _get_vmhost_version_information(device)
-        if device.facts["version"] >= "22.2R3":  # PR 1510446 for show vmhost version rpc supports form 22.2R3
+        # PR 1510446 fix for show vmhost version rpc supports form 22.2R3
+        if device.facts["version"] >= "22.2R3":
             if rsp.tag == "vmhost-version-information":
                 vm_ver_rsp = [rsp]
             else:

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -13,7 +13,7 @@ def _get_vmhost_version_information(device):
         else:
             multi_re = False
     except RpcError as err:
-        pass
+        raise RpcError()
 
     if multi_re == True:
         try:

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -87,6 +87,7 @@ def get_facts(device):
                     "./set-disk-info[set-disk-name = 'set b']/set-junos-version"
                 )
 
+
                 vmhost_info[re_name] = {
                     "vmhost_current_root_set": vmhost_current_root_set,
                     "vmhost_version_set_p": vmhost_set_junos_version_set_p,

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -50,6 +50,10 @@ def get_facts(device):
     vmhost = None
     vmhost_info = {}
     vm_ver_rsp = None
+    vmhost_current_root_set = None
+    vmhost_set_junos_version_set_p = None
+    vmhost_set_junos_version_set_b = None
+    re_name = None
 
     if device.facts["_is_linux"]:
         vmhost = False
@@ -68,14 +72,11 @@ def get_facts(device):
 
     if vmhost:
         rsp = _get_vmhost_version_information(device)
-        if rsp.tag == "output":
-            pass
-        else:
+        if device.facts["version"] >= "22.2R3":  # PR 1510446 for show vmhost version rpc supports form 22.2R3
             if rsp.tag == "vmhost-version-information":
                 vm_ver_rsp = [rsp]
             else:
                 vm_ver_rsp = rsp.findall(".//vmhost-version-information")
-            vmhost_info = {}
 
             for re_vm_ver_info in vm_ver_rsp:
                 re_name = re_vm_ver_info.findtext("../re-name", "re0")
@@ -92,6 +93,8 @@ def get_facts(device):
                     "vmhost_version_set_p": vmhost_set_junos_version_set_p,
                     "vmhost_version_set_b": vmhost_set_junos_version_set_b,
                 }
+        else:
+            pass
 
     return {
         "vmhost": vmhost,

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -20,7 +20,7 @@ def _get_vmhost_version_information(device):
             return device.rpc.cli(
                 "show vmhost version invoke-on all-routing-engines",
                 format="xml",
-                normalize=True
+                normalize=True,
             )
         except RpcError as err:
             raise RpcError()
@@ -86,7 +86,6 @@ def get_facts(device):
                 vmhost_set_junos_version_set_b = re_vm_ver_info.findtext(
                     "./set-disk-info[set-disk-name = 'set b']/set-junos-version"
                 )
-
 
                 vmhost_info[re_name] = {
                     "vmhost_current_root_set": vmhost_current_root_set,

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -2,6 +2,7 @@ from jnpr.junos.exception import RpcError
 import re
 from lxml import etree
 
+
 def _get_vmhost_version_information(device):
     multi_re = False
     try:
@@ -17,17 +18,18 @@ def _get_vmhost_version_information(device):
     if multi_re == True:
         try:
             return device.rpc.cli(
-                "show vmhost version invoke-on all-routing-engines", format="xml", normalize=True
+                "show vmhost version invoke-on all-routing-engines",
+                format="xml",
+                normalize=True
             )
         except RpcError as err:
             raise RpcError()
     else:
         try:
-            return device.rpc.cli(
-                "show vmhost version", format="xml", normalize=True
-            )
+            return device.rpc.cli("show vmhost version", format="xml", normalize=True)
         except RpcError as err:
             raise RpcError()
+
 
 def provides_facts():
     """
@@ -36,6 +38,7 @@ def provides_facts():
     """
     return {
         "vmhost": "A boolean indicating if the device is vmhost.",
+        "vmhost_info": "A dictionay indicating  vmhost RE partion JUNOS versions.",
     }
 
 
@@ -77,14 +80,18 @@ def get_facts(device):
             for re_vm_ver_info in vm_ver_rsp:
                 re_name = re_vm_ver_info.findtext("../re-name", "re0")
                 vmhost_current_root_set = re_vm_ver_info.findtext("./current-root-set")
-                vmhost_set_junos_version_set_p = re_vm_ver_info.findtext("./set-disk-info[set-disk-name = 'set p']/set-junos-version")
-                vmhost_set_junos_version_set_b = re_vm_ver_info.findtext("./set-disk-info[set-disk-name = 'set b']/set-junos-version")
+                vmhost_set_junos_version_set_p = re_vm_ver_info.findtext(
+                    "./set-disk-info[set-disk-name = 'set p']/set-junos-version"
+                )
+                vmhost_set_junos_version_set_b = re_vm_ver_info.findtext(
+                    "./set-disk-info[set-disk-name = 'set b']/set-junos-version"
+                )
 
                 vmhost_info[re_name] = {
                     "vmhost_current_root_set": vmhost_current_root_set,
-                    "vmhost_version_set_p" : vmhost_set_junos_version_set_p,
+                    "vmhost_version_set_p": vmhost_set_junos_version_set_p,
                     "vmhost_version_set_b": vmhost_set_junos_version_set_b,
-               }
+                }
 
     return {
         "vmhost": vmhost,

--- a/lib/jnpr/junos/facts/vmhost.py
+++ b/lib/jnpr/junos/facts/vmhost.py
@@ -38,7 +38,7 @@ def provides_facts():
     """
     return {
         "vmhost": "A boolean indicating if the device is vmhost.",
-        "vmhost_info": "A dictionay indicating  vmhost RE partion JUNOS versions.",
+        "vmhost_info": "A dictionary indicating  vmhost RE partition JUNOS versions.",
     }
 
 

--- a/lib/jnpr/junos/ofacts/session.py
+++ b/lib/jnpr/junos/ofacts/session.py
@@ -1,5 +1,5 @@
 """
-  facts['HOME'] = login home directory
+facts['HOME'] = login home directory
 """
 
 from lxml.builder import E

--- a/tests/unit/facts/rpc-reply/vmhost_true_command.xml
+++ b/tests/unit/facts/rpc-reply/vmhost_true_command.xml
@@ -1,0 +1,35 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.2R2.1/junos">
+    <vmhost-version-information>
+        <current-root>
+            <current-root-device>sda</current-root-device>
+            <current-root-label>jrootb_P</current-root-label>
+            <current-root-partition>sda4</current-root-partition>
+        </current-root>
+        <current-boot-disk>Primary</current-boot-disk>
+        <current-root-set>b</current-root-set>
+        <uefi-version>CBEP_P_VAL1_00.18.02</uefi-version>
+        <primary-disk-upgrade-time>Tue Jan 21 21:05:21 PST 2025
+        </primary-disk-upgrade-time>
+        <set-disk-info>
+            <set-disk-name>set p</set-disk-name>
+            <set-vmhost-version>7.2725</set-vmhost-version>
+            <set-vmhost-root>vmhost-x86_64-22.4R3-S2-20240326_1606_builder</set-vmhost-root>
+            <set-vmhost-core>vmhost-core-x86-64-22.4R3-S3.3</set-vmhost-core>
+            <set-vmhost-kernel-version>5.2.60-rt15-LTS19</set-vmhost-kernel-version>
+            <set-junos-version>junos-install-mx-x86-64-22.4R3-S3.3</set-junos-version>
+            <set-vmhost-diag-version></set-vmhost-diag-version>
+        </set-disk-info>
+        <set-disk-info>
+            <set-disk-name>set b</set-disk-name>
+            <set-vmhost-version>10.3103</set-vmhost-version>
+            <set-vmhost-root>vmhost-x86_64-24.2R2-20241112_0808_builder</set-vmhost-root>
+            <set-vmhost-core>vmhost-core-x86-64-24.2R2.1</set-vmhost-core>
+            <set-vmhost-kernel-version>5.15.136-rt61-LTS22</set-vmhost-kernel-version>
+            <set-junos-version>junos-install-mx-x86-64-24.2R2.1</set-junos-version>
+            <set-vmhost-diag-version></set-vmhost-diag-version>
+        </set-disk-info>
+    </vmhost-version-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/vmhost_true_get-route-engine-information.xml
+++ b/tests/unit/facts/rpc-reply/vmhost_true_get-route-engine-information.xml
@@ -1,0 +1,42 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/19.3R0/junos">
+    <route-engine-information xmlns="http://xml.juniper.net/junos/19.3R0/junos-chassis">
+        <route-engine>
+            <status>OK</status>
+            <temperature junos:celsius="43">43 degrees C / 109 degrees F</temperature>
+            <cpu-temperature junos:celsius="43">43 degrees C / 109 degrees F</cpu-temperature>
+            <memory-dram-size>16337 MB</memory-dram-size>
+            <memory-installed-size>(16384 MB installed)</memory-installed-size>
+            <memory-buffer-utilization>5</memory-buffer-utilization>
+            <cpu-user>0</cpu-user>
+            <cpu-background>0</cpu-background>
+            <cpu-system>0</cpu-system>
+            <cpu-interrupt>0</cpu-interrupt>
+            <cpu-idle>99</cpu-idle>
+            <cpu-user1>1</cpu-user1>
+            <cpu-background1>0</cpu-background1>
+            <cpu-system1>0</cpu-system1>
+            <cpu-interrupt1>0</cpu-interrupt1>
+            <cpu-idle1>99</cpu-idle1>
+            <cpu-user2>0</cpu-user2>
+            <cpu-background2>0</cpu-background2>
+            <cpu-system2>0</cpu-system2>
+            <cpu-interrupt2>0</cpu-interrupt2>
+            <cpu-idle2>99</cpu-idle2>
+            <cpu-user3>0</cpu-user3>
+            <cpu-background3>0</cpu-background3>
+            <cpu-system3>0</cpu-system3>
+            <cpu-interrupt3>0</cpu-interrupt3>
+            <cpu-idle3>99</cpu-idle3>
+            <model>RE-S-1600x8</model>
+            <start-time junos:seconds="1738724429">2025-02-05 08:30:29 IST</start-time>
+            <up-time junos:seconds="101832">1 day, 4 hours, 17 minutes, 12 seconds</up-time>
+            <last-reboot-reason>0x4000:VJUNOS reboot</last-reboot-reason>
+            <load-average-one>0.39</load-average-one>
+            <load-average-five>0.29</load-average-five>
+            <load-average-fifteen>0.25</load-average-fifteen>
+        </route-engine>
+    </route-engine-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>


### PR DESCRIPTION
Enhancement to add vmhost partitions details to facts 

```
 'vmhost_info': {'re0': {'vmhost_current_root_set': 'b',
                         'vmhost_version_set_b': 'junos-install-mx-x86-64-24.2R2.1',
                         'vmhost_version_set_p': 'junos-install-mx-x86-64-22.4R3-S3.3'},
                 're1': {'vmhost_current_root_set': 'p',
                         'vmhost_version_set_b': 'junos-install-mx-x86-64-22.4R3-S3.3',
                         'vmhost_version_set_p': 'junos-install-mx-x86-64-24.2R2.1'}}}
```