### PR TITLE
Fix for sw reboot when member_id is not set

### DIFF
--- a/lib/jnpr/junos/ofacts/session.py
+++ b/lib/jnpr/junos/ofacts/session.py
@@ -1,5 +1,5 @@
 """
-  facts['HOME'] = login home directory
+facts['HOME'] = login home directory
 """
 
 from lxml.builder import E

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1215,7 +1215,9 @@ class SW(Util):
             * reboot message (string) if command successful
         """
 
-        if (self._multi_VC_nsync is True or self._multi_VC is True) and member_id is not None:
+        if (
+            self._multi_VC_nsync is True or self._multi_VC is True
+        ) and member_id is not None:
             vc_members = [
                 re.search(r"(\d+)", x).group(1)
                 for x in self._RE_list

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1215,7 +1215,7 @@ class SW(Util):
             * reboot message (string) if command successful
         """
 
-        if self._multi_VC_nsync is True or self._multi_VC is True:
+        if (self._multi_VC_nsync is True or self._multi_VC is True) and member_id is not None:
             vc_members = [
                 re.search(r"(\d+)", x).group(1)
                 for x in self._RE_list


### PR DESCRIPTION
Fix to handle when member_id is not set.
Fix for issue #1351 