### PR TITLE
Fix for issue #1354

### DIFF
--- a/lib/jnpr/junos/factory/optable.py
+++ b/lib/jnpr/junos/factory/optable.py
@@ -70,6 +70,7 @@ class OpTable(Table):
                 logger.debug("Not able to create SAX parser input due to " "'%s'" % ex)
             self.D.transform = lambda: remove_namespaces_and_spaces
 
+        self.D.transform = lambda: remove_namespaces_and_spaces
         rpc_args.update(self.GET_ARGS)  # copy default args
         # saltstack get_table pass args as named keyword
         if "args" in kvargs and isinstance(kvargs["args"], dict):


### PR DESCRIPTION
line was deleted as part fix  https://github.com/Juniper/py-junos-eznc/pull/1335, reverted the changes.

```
from napalm.junos import JunOSDriver
from pprint import pprint

test_host = JunOSDriver(hostname="xx.xx.xx.xx", username="xyz", password="xyz")
test_host.open()
pprint(test_host.get_interfaces())
test_host.close()


python3 get_interfaces_napalm.py 
{'cbp0': {'description': '',
          'is_enabled': True,
          'is_up': True,
          'last_flapped': -1.0,
          'mac_address': 'x.x.x.x',
          'mtu': 9192,
          'speed': -1.0},
 'demux0': {'description': '',
            'is_enabled': True,
            'is_up': True,
            'last_flapped': -1.0,
            'mac_address': 'None',
            'mtu': 9192,
            'speed': -1.0},
```