### PR TITLE
Fix import issue

### DIFF
--- a/lib/jnpr/junos/command/__init__.py
+++ b/lib/jnpr/junos/command/__init__.py
@@ -11,7 +11,7 @@ __all__ = []
 
 
 class MetaPathFinder(MetaPathFinder):
-    def find_module(self, fullname, path=None):
+    def find_spec(self, fullname, path=None, target=None):
         mod = fullname.split(".")[-1]
         if mod in [
             os.path.splitext(i)[0] for i in os.listdir(os.path.dirname(__file__))

--- a/lib/jnpr/junos/op/systemstorage.yml
+++ b/lib/jnpr/junos/op/systemstorage.yml
@@ -1,4 +1,4 @@
-  ---
+---
 SystemStorageTable:
   rpc: get-system-storage
   key: re-name | Null


### PR DESCRIPTION
The following import seems to fail.
I fixed this issue.
- jnpr.junos.op.systemstorage
- jnpr.junos.command.*

```
>>> from jnpr.junos.op.systemstorage import SystemStorageTable
Traceback (most recent call last):
  File "/Users/minefuto/py-junos-eznc/lib/jnpr/junos/op/__init__.py", line 36, in exec_module
    yaml.load(stream, Loader=yaml.FullLoader)
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/composer.py", line 58, in compose_document
    self.get_event()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/parser.py", line 118, in get_event
    self.current_event = self.state()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/parser.py", line 193, in parse_document_end
    token = self.peek_token()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/scanner.py", line 129, in peek_token
    self.fetch_more_tokens()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/scanner.py", line 223, in fetch_more_tokens
    return self.fetch_value()
  File "/Users/minefuto/py-junos-eznc/.venv/lib/python3.9/site-packages/yaml/scanner.py", line 577, in fetch_value
    raise ScannerError(None, None,
yaml.scanner.ScannerError: mapping values are not allowed here
  in "/Users/minefuto/py-junos-eznc/lib/jnpr/junos/op/systemstorage.yml", line 2, column 19

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/minefuto/py-junos-eznc/lib/jnpr/junos/op/__init__.py", line 39, in exec_module
    raise ImportError("%s is not loaded" % mod)
ImportError: systemstorage is not loaded
>>> from jnpr.junos.command.ospf_neighbor import OspfNeighborTable
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 627, in _load_backward_compatible
AttributeError: 'ModuleSpec' object has no attribute 'load_module'

```