### PR TITLE
support ncclient 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lxml>=3.2.4
 # ncclient version 0.6.10 and 0.6.16 has issues with PyEZ(junos-eznc) and needs to be avoided
-ncclient==0.6.15
+ncclient==0.7.0
 scp>=0.7.0
 jinja2>=2.7.1
 PyYAML>=5.1


### PR DESCRIPTION
support for ncclient 0.7.0
Fix for #1380 
```
(pyeztest2venv) root@masterhost:~/pyez_release_test2/py-junos-eznc# pip list
Package               Version
--------------------- ------------------------------
bcrypt                4.3.0
cffi                  2.0.0
coverage              7.10.7
cryptography          46.0.1
invoke                2.2.0
Jinja2                3.1.6
junos-eznc            0+untagged.2813.gb506a95.dirty
lxml                  6.0.2
MarkupSafe            3.0.2
ncclient              0.7.0
nose2                 0.15.1
ntc-templates         1.4.1
paramiko              4.0.0
pip                   23.2.1
pycparser             2.23
PyNaCl                1.6.0
pyparsing             3.2.5
pyserial              3.5
PyYAML                6.0.2
scp                   0.15.0
six                   1.17.0
terminal              0.4.0
textfsm               0.4.1
transitions           0.9.3
yamlordereddictloader 0.4.2
```