### PR TITLE
trim usage of six.b(), not needed since Python 2.6

### DIFF
--- a/lib/jnpr/junos/transport/tty_netconf.py
+++ b/lib/jnpr/junos/transport/tty_netconf.py
@@ -16,18 +16,18 @@ from ncclient.xml_ import to_ele
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    STARTS_WITH = six.b("<!--")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    STARTS_WITH = b"<!--"
 
 
 __all__ = ["xmlmode_netconf"]
 
-_NETCONF_EOM = six.b("]]>]]>")
-_xmlns = re.compile(six.b("xmlns=[^>]+"))
+_NETCONF_EOM = b"]]>]]>"
+_xmlns = re.compile(b"xmlns=[^>]+")
 _xmlns_strip = lambda text: _xmlns.sub(PY6.EMPTY_STR, text)
-_junosns = re.compile(six.b("junos:"))
+_junosns = re.compile(b"junos:")
 _junosns_strip = lambda text: _junosns.sub(PY6.EMPTY_STR, text)
 
 logger = logging.getLogger("jnpr.junos.tty_netconf")

--- a/lib/jnpr/junos/transport/tty_serial.py
+++ b/lib/jnpr/junos/transport/tty_serial.py
@@ -10,7 +10,7 @@ from jnpr.junos.transport.tty import Terminal
 # Terminal connection over SERIAL CONSOLE
 # -------------------------------------------------------------------------
 
-_PROMPT = re.compile(six.b("|").join([six.b(i) for i in Terminal._RE_PAT]))
+_PROMPT = re.compile(b"|".join([six.b(i) for i in Terminal._RE_PAT]))
 
 
 class Serial(Terminal):
@@ -75,7 +75,7 @@ class Serial(Terminal):
         regular-expression group. If a timeout occurs, then return
         the tuple(None,None).
         """
-        rxb = six.b("")
+        rxb = b""
         mark_start = datetime.now()
         mark_end = mark_start + timedelta(seconds=self.EXPECT_TIMEOUT)
 

--- a/lib/jnpr/junos/transport/tty_ssh.py
+++ b/lib/jnpr/junos/transport/tty_ssh.py
@@ -18,10 +18,10 @@ _PROMPT = re.compile(six.b("|").join([six.b(i) for i in Terminal._RE_PAT]))
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    IN_USE = six.b("in use")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    IN_USE = b"in use"
 
 
 class SSH(Terminal):
@@ -157,7 +157,7 @@ class SSH(Terminal):
 
     def read(self):
         """read a single line"""
-        rxb = six.b("")
+        rxb = b""
         while True:
             data = self._ssh.recv(self.RECVSZ)
             if data is None or len(data) <= 0:
@@ -179,7 +179,7 @@ class SSH(Terminal):
         regular-expression group. If a timeout occurs, then return
         the tuple(None,None).
         """
-        rxb = six.b("")
+        rxb = b""
         timeout = time() + self.READ_PROMPT_DELAY
 
         while time() < timeout:
@@ -198,7 +198,7 @@ class SSH(Terminal):
         return rxb, found.lastgroup
 
     def _read_until(self, match, timeout=None):
-        rxb = six.b("")
+        rxb = b""
         timeout = time() + self.READ_PROMPT_DELAY
 
         while time() < timeout:

--- a/lib/jnpr/junos/transport/tty_telnet.py
+++ b/lib/jnpr/junos/transport/tty_telnet.py
@@ -14,10 +14,10 @@ logger = logging.getLogger("jnpr.junos.tty_telnet")
 
 
 class PY6:
-    NEW_LINE = six.b("\n")
-    EMPTY_STR = six.b("")
-    NETCONF_EOM = six.b("]]>]]>")
-    IN_USE = six.b("in use")
+    NEW_LINE = b"\n"
+    EMPTY_STR = b""
+    NETCONF_EOM = b"]]>]]>"
+    IN_USE = b"in use"
 
 
 class Telnet(Terminal):

--- a/lib/jnpr/junos/utils/start_shell.py
+++ b/lib/jnpr/junos/utils/start_shell.py
@@ -5,7 +5,6 @@ import time
 from select import select
 from threading import Thread
 
-import six
 from jnpr.junos.utils.ssh_client import open_ssh_client
 
 _JUNOS_PROMPT = "> "

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -40,16 +40,16 @@ class TestConsole(unittest.TestCase):
     def setUp(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search(r"(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search(r"(?P<shell>%|#\s*$)", "junos % "),
-                six.b("\r\r\nroot@device:~ # "),
+                b"\r\r\nroot@device:~ # ",
             ),
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="Telnet")
@@ -87,16 +87,16 @@ class TestConsole(unittest.TestCase):
     def test_login_bad_password(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search(r"(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search("(?P<badpasswd>ogin incorrect)", "login incorrect"),
-                six.b("\r\r\nlogin incorrect"),
+                b"\r\r\nlogin incorrect",
             ),
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="Telnet")
@@ -110,16 +110,16 @@ class TestConsole(unittest.TestCase):
         tty_netconf.open = MagicMock()
 
         mock_expect.side_effect = [
-            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), six.b("\r\r\n ogin:")),
+            (1, re.search(r"(?P<login>ogin:\s*$)", "login: "), b"\r\r\n ogin:"),
             (
                 2,
                 re.search(r"(?P<passwd>assword:\s*$)", "password: "),
-                six.b("\r\r\n password:"),
+                b"\r\r\n password:",
             ),
             (
                 3,
                 re.search(r"(?P<shell>%|#\s*$)", "junos % "),
-                six.b("\r\r\nroot@device:~ # "),
+                b"\r\r\nroot@device:~ # ",
             ),
         ]
         with Console(
@@ -175,9 +175,9 @@ class TestConsole(unittest.TestCase):
     def test_console_serial(self, mock_write, mock_expect, mock_open):
         tty_netconf.open = MagicMock()
         mock_expect.side_effect = [
-            six.b("\r\r\n Login:"),
-            six.b("\r\r\n password:"),
-            six.b("\r\r\nroot@device:~ # "),
+            b"\r\r\n Login:",
+            b"\r\r\n password:",
+            b"\r\r\nroot@device:~ # ",
         ]
         self.dev = Console(host="1.1.1.1", user="lab", password="lab123", mode="serial")
         self.dev.open()

--- a/tests/unit/transport/test_serial.py
+++ b/tests/unit/transport/test_serial.py
@@ -94,7 +94,7 @@ class TestSerialWin(unittest.TestCase):
             six.b(
                 "<!-- No zombies were killed during the creation of this user interface -->"
             ),
-            six.b(""),
+            b"",
             six.b(
                 """<!-- user root, class super-user -->
 <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">

--- a/tests/unit/transport/test_tty_netconf.py
+++ b/tests/unit/transport/test_tty_netconf.py
@@ -43,7 +43,7 @@ class TestTTYNetconf(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_netconf.timedelta")
     def test_open_RuntimeError(self, mock_delta, mock_rcv):
         mock_rcv.return_value = "]]>]]>"
-        self.tty_net._tty.read.return_value = six.b("testing")
+        self.tty_net._tty.read.return_value = b"testing"
         from datetime import timedelta
 
         mock_delta.return_value = timedelta(seconds=0.5)
@@ -56,7 +56,7 @@ class TestTTYNetconf(unittest.TestCase):
         mock_rcv.return_value = "]]>]]>"
         self.tty_net.rpc("get-interface-information")
         self.tty_net._tty.rawwrite.assert_called_with(
-            six.b("<rpc><get-interface-information/></rpc>")
+            b"<rpc><get-interface-information/></rpc>"
         )
 
     @patch("jnpr.junos.transport.tty_netconf.tty_netconf._receive")
@@ -103,7 +103,7 @@ class TestTTYNetconf(unittest.TestCase):
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_empty_line(self, mock_select):
         rx = MagicMock()
-        rx.read_until.side_effect = iter([six.b(""), six.b("]]>]]>")])
+        rx.read_until.side_effect = iter([b"", b"]]>]]>"])
         mock_select.return_value = ([rx], [], [])
         self.assertEqual(self.tty_net._receive().tag, "error-in-receive")
 
@@ -126,30 +126,30 @@ class TestTTYNetconf(unittest.TestCase):
         rx = MagicMock()
 
         rx.read_until.side_effect = iter(
-            [six.b("<rpc-reply>ok<dummy></rpc-reply>"), six.b("\n]]>]]>")]
+            [b"<rpc-reply>ok<dummy></rpc-reply>", b"\n]]>]]>"]
         )
         mock_select.return_value = ([rx], [], [])
         self.assertEqual(
-            self.tty_net._receive(), six.b("<rpc-reply>ok<dummy/></rpc-reply>")
+            self.tty_net._receive(), b"<rpc-reply>ok<dummy/></rpc-reply>"
         )
 
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_XMLSyntaxError_eom_in_center(self, mock_select):
         rx = MagicMock()
         rx.read_until.side_effect = iter(
-            [six.b("<rpc-reply>ok</rpc-reply>"), six.b("]]>]]>\ndummy")]
+            [b"<rpc-reply>ok</rpc-reply>", b"]]>]]>\ndummy"]
         )
         mock_select.return_value = ([rx], [], [])
-        self.assertEqual(self.tty_net._receive(), six.b("<rpc-reply>ok</rpc-reply>"))
+        self.assertEqual(self.tty_net._receive(), b"<rpc-reply>ok</rpc-reply>")
 
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_xmn_error(self, mock_select):
         rx = MagicMock()
         rx.read_until.side_effect = iter(
             [
-                six.b("<message>ok</message>"),
-                six.b("\n</xnm:error>\n"),
-                six.b("]]>]]>\ndummy"),
+                b"<message>ok</message>",
+                b"\n</xnm:error>\n",
+                b"]]>]]>\ndummy",
             ]
         )
         mock_select.return_value = ([rx], [], [])

--- a/tests/unit/transport/test_tty_netconf.py
+++ b/tests/unit/transport/test_tty_netconf.py
@@ -129,9 +129,7 @@ class TestTTYNetconf(unittest.TestCase):
             [b"<rpc-reply>ok<dummy></rpc-reply>", b"\n]]>]]>"]
         )
         mock_select.return_value = ([rx], [], [])
-        self.assertEqual(
-            self.tty_net._receive(), b"<rpc-reply>ok<dummy/></rpc-reply>"
-        )
+        self.assertEqual(self.tty_net._receive(), b"<rpc-reply>ok<dummy/></rpc-reply>")
 
     @patch("jnpr.junos.transport.tty_netconf.select.select")
     def test_tty_netconf_receive_XMLSyntaxError_eom_in_center(self, mock_select):

--- a/tests/unit/transport/test_tty_telnet.py
+++ b/tests/unit/transport/test_tty_telnet.py
@@ -8,7 +8,6 @@ except ImportError:
 from unittest.mock import MagicMock, patch
 
 import nose2
-import six
 from jnpr.junos.transport.tty_telnet import Telnet
 
 
@@ -64,7 +63,7 @@ class TestTTYTelnet(unittest.TestCase):
         self.tel_conn._tn.expect.return_value = (
             None,
             None,
-            six.b("port already in use"),
+            b"port already in use",
         )
         self.assertRaises(RuntimeError, self.tel_conn._login_state_machine)
 


### PR DESCRIPTION
Python 2.7 & Python 3.3+ handle this just fine with the native built-in syntax