### PR TITLE
support for proxy_command parameter

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1411,7 +1411,7 @@ class Device(_Connection):
 
             # build sock from proxy_command if provided
             sock = None
-            if self._proxy_command is not None:
+            if self._proxy_command:
                 proxy_cmd = self._proxy_command.replace("%h", self._hostname).replace(
                     "%p", str(self._port)
                 )

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1284,7 +1284,9 @@ class Device(_Connection):
             if hostname is None and self._sock_fd is None:
                 raise ValueError("You must provide either 'host' or 'sock_fd' value")
             if self._proxy_command is not None and self._sock_fd is not None:
-                raise ValueError("'proxy_command' and 'sock_fd' cannot be used together")
+                raise ValueError(
+                    "'proxy_command' and 'sock_fd' cannot be used together"
+                )
             self._hostname = hostname
             # user will default to $USER
             self._auth_user = os.getenv("USER")
@@ -1410,10 +1412,8 @@ class Device(_Connection):
             # build sock from proxy_command if provided
             sock = None
             if self._proxy_command is not None:
-                proxy_cmd = (
-                self._proxy_command
-                    .replace("%h", self._hostname)
-                    .replace("%p", str(self._port))
+                proxy_cmd = self._proxy_command.replace("%h", self._hostname).replace(
+                    "%p", str(self._port)
                 )
                 sock = paramiko.proxy.ProxyCommand(proxy_cmd)
 

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1230,6 +1230,13 @@ class Device(_Connection):
             *OPTIONAL* To enable ssh_known hostkey verify
             default is ``False``.
 
+        :param str proxy_command:
+            *OPTIONAL* The SSH ProxyCommand string to use when connecting
+            through a bastion/jump host, e.g.
+            ``"ssh -W %h:%p bastion.example.com"``.
+            Wraps :class:`paramiko.proxy.ProxyCommand` and is passed as the
+            ``sock`` argument to the underlying ncclient transport.
+            Cannot be combined with ``sock_fd``.
         """
 
         # ----------------------------------------
@@ -1251,6 +1258,8 @@ class Device(_Connection):
         self._allow_agent = kvargs.get("allow_agent", None)
         self._bind_addr = kvargs.get("bind_addr", None)
         self._hostkey_verify = kvargs.get("hostkey_verify", False)
+        if self._sock_fd is None:
+            self._proxy_command = kvargs.get("proxy_command", None)
         if self._fact_style != "new":
             warnings.warn(
                 "fact-style %s will be removed in a future "
@@ -1397,11 +1406,22 @@ class Device(_Connection):
             else:
                 hostkey_verify = self._hostkey_verify
 
+            # build sock from proxy_command if provided
+            sock = None
+            if self._proxy_command is not None:
+                proxy_cmd = (
+                self._proxy_command
+                    .replace("%h", self._hostname)
+                    .replace("%p", str(self._port))
+                )
+                sock = paramiko.proxy.ProxyCommand(proxy_cmd)
+
             # open connection using ncclient transport
             self._conn = netconf_ssh.connect(
                 host=self._hostname,
                 port=self._port,
                 sock_fd=self._sock_fd,
+                sock=sock,  # support for ProxyCommand parameter
                 username=self._auth_user,
                 password=self._auth_password,
                 hostkey_verify=hostkey_verify,

--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -1258,8 +1258,7 @@ class Device(_Connection):
         self._allow_agent = kvargs.get("allow_agent", None)
         self._bind_addr = kvargs.get("bind_addr", None)
         self._hostkey_verify = kvargs.get("hostkey_verify", False)
-        if self._sock_fd is None:
-            self._proxy_command = kvargs.get("proxy_command", None)
+        self._proxy_command = kvargs.get("proxy_command", None)
         if self._fact_style != "new":
             warnings.warn(
                 "fact-style %s will be removed in a future "
@@ -1284,6 +1283,8 @@ class Device(_Connection):
             # --------------------------
             if hostname is None and self._sock_fd is None:
                 raise ValueError("You must provide either 'host' or 'sock_fd' value")
+            if self._proxy_command is not None and self._sock_fd is not None:
+                raise ValueError("'proxy_command' and 'sock_fd' cannot be used together")
             self._hostname = hostname
             # user will default to $USER
             self._auth_user = os.getenv("USER")

--- a/tests/functional/test_device_ssh.py
+++ b/tests/functional/test_device_ssh.py
@@ -10,7 +10,8 @@ except ImportError:
 
 class TestDeviceSsh(unittest.TestCase):
     def tearDown(self):
-        self.dev.close()
+        if hasattr(self, "dev") and self.dev.connected:
+            self.dev.close()
 
     def test_device_open_key_pass(self):
         self.dev = Device(
@@ -54,58 +55,101 @@ class TestDeviceSsh(unittest.TestCase):
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
-    def test_device_open_key_file(self):
+    # ------------------------------------------------------------------
+    # proxy_command tests
+    # ------------------------------------------------------------------
+
+    def test_device_open_no_proxy_ssh_config_devnull(self):
+        """Direct connection (no proxy_command) with ssh_config suppressed
+        via /dev/null to ensure no host-level ProxyCommand is picked up."""
         self.dev = Device(
             host="x.x.x.x",
             user="netops",
+            port=22,
             ssh_private_key_file="~/.ssh/id_rsa",
+            ssh_config="/dev/null",
         )
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
     def test_device_open_proxy(self):
+        """proxy_command using ssh -W %h:%p through a jump host, combined
+        with an explicit SSH private key file and port=22."""
         self.dev = Device(
-            host="x.x.x.x", user="netops", proxy_command="ssh -J netops@y.y.y.y"
+            host="x.x.x.x",
+            user="netops",
+            port=22,
+            ssh_private_key_file="~/.ssh/id_rsa",
+            proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
         )
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
-    def test_device_open_ssh_agent_proxy(self):
+    def test_device_open_proxy_with_ssh_agent(self):
+        """proxy_command with ssh-agent forwarding enabled."""
         self.dev = Device(
             host="x.x.x.x",
             user="netops",
-            proxy_command="ssh -J netops@y.y.y.y",
+            port=22,
+            proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
             allow_agent=True,
         )
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
-    def test_device_open_key_file_proxy(self):
+    def test_device_open_proxy_allow_agent_false(self):
+        """proxy_command with ssh-agent forwarding explicitly disabled."""
         self.dev = Device(
             host="x.x.x.x",
             user="netops",
-            proxy_command="ssh -J netops@y.y.y.y",
+            port=22,
             ssh_private_key_file="~/.ssh/id_rsa",
+            proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
+            allow_agent=False,
         )
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
-    def test_device_open_ssh_agent_proxy(self):
+    def test_device_open_proxy_default_port(self):
+        """proxy_command without an explicit port; %p expands to the
+        default NETCONF port (830)."""
         self.dev = Device(
             host="x.x.x.x",
             user="netops",
-            proxy_command="ssh -J netops@y.y.y.y",
-            allow_agent=True,
+            ssh_private_key_file="~/.ssh/id_rsa",
+            proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
         )
         self.dev.open()
         self.assertEqual(self.dev.connected, True)
 
-    def test_device_open_key_file_proxy(self):
+    def test_device_proxy_command_stored_on_instance(self):
+        """The proxy_command string is preserved on the Device instance."""
         self.dev = Device(
             host="x.x.x.x",
             user="netops",
-            proxy_command="ssh -J netops@y.y.y.y",
+            port=22,
             ssh_private_key_file="~/.ssh/id_rsa",
+            proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
         )
-        self.dev.open()
-        self.assertEqual(self.dev.connected, True)
+        self.assertEqual(
+            self.dev._proxy_command, "ssh -W %h:%p -q netops@y.y.y.y"
+        )
+
+    def test_device_proxy_empty_string_not_used(self):
+        """An empty proxy_command string should not activate proxy routing."""
+        self.dev = Device(
+            host="x.x.x.x",
+            user="netops",
+            proxy_command="",
+        )
+        self.assertFalse(self.dev._proxy_command)
+
+    def test_device_proxy_and_sock_fd_raises(self):
+        """Combining proxy_command with sock_fd must raise ValueError."""
+        with self.assertRaises(ValueError):
+            Device(
+                host="x.x.x.x",
+                user="netops",
+                proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
+                sock_fd=5,
+            )

--- a/tests/functional/test_device_ssh.py
+++ b/tests/functional/test_device_ssh.py
@@ -131,9 +131,7 @@ class TestDeviceSsh(unittest.TestCase):
             ssh_private_key_file="~/.ssh/id_rsa",
             proxy_command="ssh -W %h:%p -q netops@y.y.y.y",
         )
-        self.assertEqual(
-            self.dev._proxy_command, "ssh -W %h:%p -q netops@y.y.y.y"
-        )
+        self.assertEqual(self.dev._proxy_command, "ssh -W %h:%p -q netops@y.y.y.y")
 
     def test_device_proxy_empty_string_not_used(self):
         """An empty proxy_command string should not activate proxy routing."""

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -553,6 +553,48 @@ class TestDevice(unittest.TestCase):
 
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
+    def test_device_open_with_proxy_command(self, mock_connect, mock_execute):
+        with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat, patch(
+            "paramiko.proxy.ProxyCommand"
+        ) as mock_proxy:
+            mock_cat.return_value = "\n    domain jls.net\n"
+            mock_connect.side_effect = self._mock_manager
+            mock_execute.side_effect = self._mock_manager
+            mock_sock = MagicMock()
+            mock_proxy.return_value = mock_sock
+            self.dev2 = Device(
+                host="2.2.2.2",
+                user="test",
+                password="password123",
+                proxy_command="ssh -W %h:%p jump-host",
+            )
+            self.dev2.open()
+            mock_proxy.assert_called_once_with("ssh -W 2.2.2.2:830 jump-host")
+            _, connect_kwargs = mock_execute.call_args
+            self.assertEqual(connect_kwargs["sock"], mock_sock)
+
+    @patch("ncclient.manager.connect")
+    @patch("jnpr.junos.Device.execute")
+    def test_device_open_with_proxy_command_empty_string(self, mock_connect, mock_execute):
+        with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat, patch(
+            "paramiko.proxy.ProxyCommand"
+        ) as mock_proxy:
+            mock_cat.return_value = "\n    domain jls.net\n"
+            mock_connect.side_effect = self._mock_manager
+            mock_execute.side_effect = self._mock_manager
+            self.dev2 = Device(
+                host="2.2.2.2",
+                user="test",
+                password="password123",
+                proxy_command="",
+            )
+            self.dev2.open()
+            mock_proxy.assert_not_called()
+            _, connect_kwargs = mock_execute.call_args
+            self.assertIsNone(connect_kwargs["sock"])
+
+    @patch("ncclient.manager.connect")
+    @patch("jnpr.junos.Device.execute")
     def test_device_outbound(self, mock_connect, mock_execute):
         with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat:
             mock_cat.return_value = """

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -554,9 +554,10 @@ class TestDevice(unittest.TestCase):
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
     def test_device_open_with_proxy_command(self, mock_connect, mock_execute):
-        with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat, patch(
-            "paramiko.proxy.ProxyCommand"
-        ) as mock_proxy:
+        with (
+            patch("jnpr.junos.utils.fs.FS.cat") as mock_cat,
+            patch("paramiko.proxy.ProxyCommand") as mock_proxy,
+        ):
             mock_cat.return_value = "\n    domain jls.net\n"
             mock_connect.side_effect = self._mock_manager
             mock_execute.side_effect = self._mock_manager
@@ -575,10 +576,13 @@ class TestDevice(unittest.TestCase):
 
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
-    def test_device_open_with_proxy_command_empty_string(self, mock_connect, mock_execute):
-        with patch("jnpr.junos.utils.fs.FS.cat") as mock_cat, patch(
-            "paramiko.proxy.ProxyCommand"
-        ) as mock_proxy:
+    def test_device_open_with_proxy_command_empty_string(
+        self, mock_connect, mock_execute
+    ):
+        with (
+            patch("jnpr.junos.utils.fs.FS.cat") as mock_cat,
+            patch("paramiko.proxy.ProxyCommand") as mock_proxy,
+        ):
             mock_cat.return_value = "\n    domain jls.net\n"
             mock_connect.side_effect = self._mock_manager
             mock_execute.side_effect = self._mock_manager


### PR DESCRIPTION
prox_command parameter support 
```
regress@masterhost:~/junos_eznc_proxy$ cat test.py 
from jnpr.junos import Device

dev = Device(
    host="xx.xx.xx.xx",
    user="user1",
    port=22,
    ssh_private_key_file="~/.ssh/id_rsa",
    proxy_command="ssh -W %h:%p -q user1@xx.xx.xx.xx",
)
dev.open()
print(dev.facts)
dev.close()
```
