### PR TITLE
Revise SECURITY.md for clarity on updates and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable version of py-junos-eznc receives security updates. Make sure you are running the most recent release.
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security problems. Instead, use GitHub's "Report a vulnerability" feature in the Security tab of this repository. We will review and respond as soon as possible.
+
+## Security Updates
+
+If we fix a vulnerability, we will announce it in the release notes. Keep your installation up to date to receive the latest fixes.


### PR DESCRIPTION
Updated the security policy to clarify supported versions and reporting vulnerabilities. By the way, could you please enable GitHub's "Report a vulnerability" feature in the "Security" tab of this repository? This would allow me to submit the full report and a PoC privately.