### PR TITLE
[NO-TICKET] Fix issue were allow_agent and look_for_keys were not honored by ssh_client

### DIFF
--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -37,6 +37,18 @@ def open_ssh_client(dev):
     if dev._ssh_private_key_file is not None:
         kwargs["key_filename"] = dev._ssh_private_key_file
 
+    if getattr(dev, "_allow_agent", None) is not None:
+        kwargs["allow_agent"] = dev._allow_agent
+    else:
+        kwargs["allow_agent"] = bool(
+            (dev._auth_password is None) and (dev._ssh_private_key_file is None)
+        )
+
+    if getattr(dev, "_look_for_keys", None) is None:
+        kwargs["look_for_keys"] = True
+    else:
+        kwargs["look_for_keys"] = dev._look_for_keys
+    
     # pick hostname from .ssh config if any
     hostname = config.get("hostname", dev._hostname)
 

--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -42,7 +42,7 @@ def open_ssh_client(dev):
 
     if dev._look_for_keys is not None:
         kwargs["look_for_keys"] = dev._look_for_keys
-    
+
     # pick hostname from .ssh config if any
     hostname = config.get("hostname", dev._hostname)
 

--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -37,16 +37,10 @@ def open_ssh_client(dev):
     if dev._ssh_private_key_file is not None:
         kwargs["key_filename"] = dev._ssh_private_key_file
 
-    if getattr(dev, "_allow_agent", None) is not None:
+    if dev._allow_agent is not None:
         kwargs["allow_agent"] = dev._allow_agent
-    else:
-        kwargs["allow_agent"] = bool(
-            (dev._auth_password is None) and (dev._ssh_private_key_file is None)
-        )
 
-    if getattr(dev, "_look_for_keys", None) is None:
-        kwargs["look_for_keys"] = True
-    else:
+    if dev._look_for_keys is not None:
         kwargs["look_for_keys"] = dev._look_for_keys
     
     # pick hostname from .ssh config if any

--- a/lib/jnpr/junos/utils/ssh_client.py
+++ b/lib/jnpr/junos/utils/ssh_client.py
@@ -14,8 +14,10 @@ def open_ssh_client(dev):
     # note, the following code was extracted from the scp module, and then the scp module
     # was refactored to use this function
     ssh_client = paramiko.SSHClient()
-    ssh_client.load_system_host_keys()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    if dev._hostkey_verify:
+        ssh_client.load_system_host_keys()
+    else:
+        ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     # use junos._hostname since this will be correct if we are going
     # through a jumphost.
@@ -39,6 +41,10 @@ def open_ssh_client(dev):
 
     if dev._allow_agent is not None:
         kwargs["allow_agent"] = dev._allow_agent
+    else:
+        kwargs["allow_agent"] = bool(
+            (dev._auth_password is None) and (dev._ssh_private_key_file is None)
+        )
 
     if dev._look_for_keys is not None:
         kwargs["look_for_keys"] = dev._look_for_keys

--- a/tests/functional/test_scp.py
+++ b/tests/functional/test_scp.py
@@ -1,0 +1,79 @@
+__author__ = "Aaron-MJohn"
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import os
+import tempfile
+
+from jnpr.junos import Device
+from jnpr.junos.utils.scp import SCP
+from jnpr.junos.utils.start_shell import StartShell
+
+
+class TestScp(unittest.TestCase):
+    def test_scp_put_with_look_for_keys_disabled(self):
+        dev = Device(
+            host="x.x.x.x",
+            user="netops",
+            passwd="net123",
+            look_for_keys=False,
+        )
+        remote_path = "/var/tmp/test_scp_look_for_keys_disabled.txt"
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as local_file:
+            local_file.write("scp functional test\n")
+            local_path = local_file.name
+
+        try:
+            dev.open()
+
+            with SCP(dev) as scp:
+                scp.put(local_path, remote_path)
+
+            with StartShell(dev) as sh:
+                ok, output = sh.run("cat {}".format(remote_path))
+                self.assertTrue(ok)
+                self.assertIn("scp functional test", output)
+        finally:
+            if dev.connected:
+                try:
+                    with StartShell(dev) as sh:
+                        sh.run("rm -f {}".format(remote_path))
+                finally:
+                    dev.close()
+            os.unlink(local_path)
+
+    def test_scp_put_with_allow_agent_disabled(self):
+        dev = Device(
+            host="x.x.x.x",
+            user="netops",
+            passwd="net123",
+            allow_agent=False,
+        )
+        remote_path = "/var/tmp/test_scp_allow_agent_disabled.txt"
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as local_file:
+            local_file.write("scp functional test\n")
+            local_path = local_file.name
+
+        try:
+            dev.open()
+
+            with SCP(dev) as scp:
+                scp.put(local_path, remote_path)
+
+            with StartShell(dev) as sh:
+                ok, output = sh.run("cat {}".format(remote_path))
+                self.assertTrue(ok)
+                self.assertIn("scp functional test", output)
+        finally:
+            if dev.connected:
+                try:
+                    with StartShell(dev) as sh:
+                        sh.run("rm -f {}".format(remote_path))
+                finally:
+                    dev.close()
+            os.unlink(local_path)

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -131,11 +131,14 @@ class TestScp(unittest.TestCase):
     ):
         mock_scpclient.return_value = None
         package = "test.tgz"
-        self.dev._auth_user = "user"
-        self.dev._auth_password = None
-        self.dev._ssh_private_key_file = None
-        self.dev._allow_agent = False
-        with SCP(self.dev) as scp:
+        dev = Device(
+            host="1.1.1.1", user="user", allow_agent=False
+        )
+        dev._auth_user = "user"
+        dev._auth_password = None
+        dev._ssh_private_key_file = None
+        dev._allow_agent = False
+        with SCP(dev) as scp:
             scp.put(package)
         self.assertFalse(mock_sshclient.mock_calls[0][2]["allow_agent"])
 
@@ -147,12 +150,16 @@ class TestScp(unittest.TestCase):
     ):
         mock_scpclient.return_value = None
         package = "test.tgz"
-        self.dev._auth_user = "user"
-        self.dev._auth_password = None
-        self.dev._ssh_private_key_file = None
-        self.dev._look_for_keys = False
-        with SCP(self.dev) as scp:
+        dev = Device(
+            host="1.1.1.1", user="user", look_for_keys=False,
+        )
+        dev._auth_user = "user"
+        dev._auth_password = None
+        dev._ssh_private_key_file = None
+        dev._look_for_keys = False
+        with SCP(dev) as scp:
             scp.put(package)
+        print(mock_sshclient.mock_calls[0][2])
         self.assertFalse(mock_sshclient.mock_calls[0][2]["look_for_keys"])
 
     @contextmanager

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -131,9 +131,7 @@ class TestScp(unittest.TestCase):
     ):
         mock_scpclient.return_value = None
         package = "test.tgz"
-        dev = Device(
-            host="1.1.1.1", user="user", allow_agent=False
-        )
+        dev = Device(host="1.1.1.1", user="user", allow_agent=False)
         dev._auth_user = "user"
         dev._auth_password = None
         dev._ssh_private_key_file = None
@@ -151,7 +149,9 @@ class TestScp(unittest.TestCase):
         mock_scpclient.return_value = None
         package = "test.tgz"
         dev = Device(
-            host="1.1.1.1", user="user", look_for_keys=False,
+            host="1.1.1.1",
+            user="user",
+            look_for_keys=False,
         )
         dev._auth_user = "user"
         dev._auth_password = None

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -162,6 +162,25 @@ class TestScp(unittest.TestCase):
         print(mock_sshclient.mock_calls[0][2])
         self.assertFalse(mock_sshclient.mock_calls[0][2]["look_for_keys"])
 
+    @patch("paramiko.SSHClient.connect")
+    @patch("scp.SCPClient.put")
+    @patch("scp.SCPClient.__init__")
+    def test_scp_with_password_disables_agent_by_default(
+        self, mock_scpclient, mock_put, mock_sshclient
+    ):
+        mock_scpclient.return_value = None
+        package = "test.tgz"
+        dev = Device(
+            host="192.168.1.2",
+            user="root",
+            passwd="robotsarecool1922",
+            look_for_keys=False,
+        )
+        with SCP(dev) as scp:
+            scp.put(package)
+        self.assertFalse(mock_sshclient.mock_calls[0][2]["allow_agent"])
+        self.assertFalse(mock_sshclient.mock_calls[0][2]["look_for_keys"])
+
     @contextmanager
     def capture(self, command, *args, **kwargs):
         out, sys.stdout = sys.stdout, StringIO()

--- a/tests/unit/utils/test_scp.py
+++ b/tests/unit/utils/test_scp.py
@@ -122,6 +122,39 @@ class TestScp(unittest.TestCase):
             mock_sshclient.mock_calls[0][2]["key_filename"], "/Users/test/testkey"
         )
 
+    @patch("ncclient.manager.connect")
+    @patch("paramiko.SSHClient.connect")
+    @patch("scp.SCPClient.put")
+    @patch("scp.SCPClient.__init__")
+    def test_scp_honors_device_allow_agent(
+        self, mock_scpclient, mock_put, mock_sshclient, mock_ncclient
+    ):
+        mock_scpclient.return_value = None
+        package = "test.tgz"
+        self.dev._auth_user = "user"
+        self.dev._auth_password = None
+        self.dev._ssh_private_key_file = None
+        self.dev._allow_agent = False
+        with SCP(self.dev) as scp:
+            scp.put(package)
+        self.assertFalse(mock_sshclient.mock_calls[0][2]["allow_agent"])
+
+    @patch("paramiko.SSHClient.connect")
+    @patch("scp.SCPClient.put")
+    @patch("scp.SCPClient.__init__")
+    def test_scp_honors_device_look_for_keys(
+        self, mock_scpclient, mock_put, mock_sshclient
+    ):
+        mock_scpclient.return_value = None
+        package = "test.tgz"
+        self.dev._auth_user = "user"
+        self.dev._auth_password = None
+        self.dev._ssh_private_key_file = None
+        self.dev._look_for_keys = False
+        with SCP(self.dev) as scp:
+            scp.put(package)
+        self.assertFalse(mock_sshclient.mock_calls[0][2]["look_for_keys"])
+
     @contextmanager
     def capture(self, command, *args, **kwargs):
         out, sys.stdout = sys.stdout, StringIO()


### PR DESCRIPTION
## Summary

`SCP` creates its Paramiko session through `open_ssh_client()`, but that helper was not forwarding the device's `allow_agent` and `look_for_keys` settings. As a result, SCP transfers could still try ssh-agent auth or local key discovery even when those behaviors were disabled on the `Device`.
Only load the system keys if verify_key is True. If it is false then add a missing key policy to auto add

This change updates `open_ssh_client()` to honor those settings using the same default behavior as `Device.open()`, so SCP authentication stays consistent with the main device connection path.

## Changes

- pass `allow_agent` through to `paramiko.SSHClient.connect()`
- pass `look_for_keys` through to `paramiko.SSHClient.connect()`
- add unit tests covering `allow_agent=False` and `look_for_keys=False` for SCP
