### PR TITLE
add set_parse_action

### DIFF
--- a/lib/jnpr/junos/factory/state_machine.py
+++ b/lib/jnpr/junos/factory/state_machine.py
@@ -29,12 +29,12 @@ class Identifiers:
     printables = pp.OneOrMore(pp.Word(pp.printables))
     numbers = (
         pp.Word(pp.nums) + pp.Optional(pp.Literal(".") + pp.Word(pp.nums))
-    ).setParseAction(lambda i: "".join(i))
+    ).set_parse_action(lambda i: "".join(i))
     hex_numbers = pp.OneOrMore(pp.Word(pp.nums, min=1)) & pp.OneOrMore(
         pp.Word("abcdefABCDEF", min=1)
     )
     word = pp.Word(pp.alphanums) | pp.Word(pp.alphas)
-    words = (pp.OneOrMore(word)).setParseAction(lambda i: " ".join(i))
+    words = (pp.OneOrMore(word)).set_parse_action(lambda i: " ".join(i))
     percentage = pp.Word(pp.nums) + pp.Literal("%")
     header_bar = (
         pp.OneOrMore(pp.Word("-")) | pp.OneOrMore(pp.Word("="))

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -1351,26 +1351,37 @@ class SW(Util):
         except Exception as err:
             raise err
 
-    def zeroize(self, all_re=False, media=None):
+    def zeroize(self, all_re=False, media=None, vmhost=False):
         """
         Restore the system (configuration, log files, etc.) to a
         factory default state. This is the equivalent of the
-        C(request system zeroize) CLI command.
+        C(request system zeroize) CLI command, or
+        C(request vmhost zeroize) for VMHost-based platforms
+        (e.g. SRX1600, SRX2300, SRX4300).
 
         :param bool all_re: In case of dual re or VC setup, function by default
             will halt all. If all is False will only halt connected device
 
         :param str media: Overwrite media when performing the zeroize operation.
 
+        :param bool vmhost:
+            (Optional) When ``True``, issue the ``request vmhost zeroize``
+            command instead of ``request system zeroize``.  Required for
+            VMHost-based SRX platforms (SRX1600, SRX2300, SRX4300).
+            The default is ``False``.
+
         :returns:
             * rpc response message (string) if command successful
         """
-        cmd = E("request-system-zeroize")
-        if all_re is False:
-            if self._dev.facts["2RE"]:
-                cmd = E("local")
-            if media is True:
-                cmd = E("media")
+        if vmhost is True:
+            cmd = E("request-vmhost-zeroize")
+        else:
+            cmd = E("request-system-zeroize")
+            if all_re is False:
+                if self._dev.facts["2RE"]:
+                    cmd = E("local")
+                if media is True:
+                    cmd = E("media")
 
         # initialize an empty output message
         output_msg = ""

--- a/tests/unit/factory/test_state_machine.py
+++ b/tests/unit/factory/test_state_machine.py
@@ -1,0 +1,108 @@
+import unittest
+import warnings
+
+import pyparsing as pp
+
+from jnpr.junos.factory.state_machine import Identifiers, convert_to_data_type, data_type
+
+
+class TestIdentifiersNumbers(unittest.TestCase):
+    """Tests for Identifiers.numbers (set_parse_action joining integer/float parts)."""
+
+    def test_numbers_parses_integer(self):
+        result = Identifiers.numbers.parseString("42", parseAll=True)
+        self.assertEqual(result[0], "42")
+
+    def test_numbers_parses_float(self):
+        result = Identifiers.numbers.parseString("3.14", parseAll=True)
+        self.assertEqual(result[0], "3.14")
+
+    def test_numbers_parse_action_joins_parts(self):
+        # "1.5" is tokenised as ["1", ".", "5"]; parse action must join to "1.5"
+        result = Identifiers.numbers.parseString("1.5", parseAll=True)
+        self.assertIsInstance(result[0], str)
+        self.assertEqual(result[0], "1.5")
+
+    def test_numbers_parse_action_single_token(self):
+        # Integer: only one token, join should be a no-op
+        result = Identifiers.numbers.parseString("0", parseAll=True)
+        self.assertEqual(result[0], "0")
+
+    def test_numbers_rejects_non_numeric(self):
+        with self.assertRaises(pp.ParseException):
+            Identifiers.numbers.parseString("abc", parseAll=True)
+
+    def test_numbers_no_deprecation_warning(self):
+        """Ensure no PyparsingDeprecationWarning is raised when using the identifier."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Identifiers.numbers.parseString("99", parseAll=True)
+        pyparsing_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+            and "setParseAction" in str(w.message)
+        ]
+        self.assertEqual(pyparsing_warnings, [])
+
+
+class TestIdentifiersWords(unittest.TestCase):
+    """Tests for Identifiers.words (set_parse_action joining tokens with spaces)."""
+
+    def test_words_parses_single_word(self):
+        result = Identifiers.words.parseString("hello", parseAll=True)
+        self.assertEqual(result[0], "hello")
+
+    def test_words_parses_multiple_words(self):
+        result = Identifiers.words.parseString("hello world", parseAll=True)
+        self.assertEqual(result[0], "hello world")
+
+    def test_words_parse_action_joins_with_space(self):
+        result = Identifiers.words.parseString("foo bar baz", parseAll=True)
+        self.assertIsInstance(result[0], str)
+        self.assertEqual(result[0], "foo bar baz")
+
+    def test_words_no_deprecation_warning(self):
+        """Ensure no PyparsingDeprecationWarning is raised when using the identifier."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Identifiers.words.parseString("test words", parseAll=True)
+        pyparsing_warnings = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+            and "setParseAction" in str(w.message)
+        ]
+        self.assertEqual(pyparsing_warnings, [])
+
+
+class TestDataType(unittest.TestCase):
+    """Tests for data_type() which relies on Identifiers.numbers internally."""
+
+    def test_data_type_integer(self):
+        self.assertEqual(data_type("42"), int)
+
+    def test_data_type_float(self):
+        self.assertEqual(data_type("3.14"), float)
+
+    def test_data_type_hex_string(self):
+        self.assertEqual(data_type("1a2b"), str)
+
+    def test_data_type_plain_string(self):
+        self.assertEqual(data_type("hello"), str)
+
+
+class TestConvertToDataType(unittest.TestCase):
+    """Tests for convert_to_data_type() which uses data_type() internally."""
+
+    def test_converts_integer_item(self):
+        result = convert_to_data_type(["5"])
+        self.assertEqual(result, [5])
+
+    def test_converts_mixed_items(self):
+        result = convert_to_data_type(["10", "host"])
+        self.assertEqual(result, [10, "host"])
+
+    def test_converts_string_items(self):
+        result = convert_to_data_type(["hello", "world"])
+        self.assertEqual(result, ["hello", "world"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/factory/test_state_machine.py
+++ b/tests/unit/factory/test_state_machine.py
@@ -3,7 +3,11 @@ import warnings
 
 import pyparsing as pp
 
-from jnpr.junos.factory.state_machine import Identifiers, convert_to_data_type, data_type
+from jnpr.junos.factory.state_machine import (
+    Identifiers,
+    convert_to_data_type,
+    data_type,
+)
 
 
 class TestIdentifiersNumbers(unittest.TestCase):
@@ -38,7 +42,9 @@ class TestIdentifiersNumbers(unittest.TestCase):
             warnings.simplefilter("always")
             Identifiers.numbers.parseString("99", parseAll=True)
         pyparsing_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
             and "setParseAction" in str(w.message)
         ]
         self.assertEqual(pyparsing_warnings, [])
@@ -66,7 +72,9 @@ class TestIdentifiersWords(unittest.TestCase):
             warnings.simplefilter("always")
             Identifiers.words.parseString("test words", parseAll=True)
         pyparsing_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
             and "setParseAction" in str(w.message)
         ]
         self.assertEqual(pyparsing_warnings, [])

--- a/tests/unit/utils/rpc-reply/request-vmhost-zeroize.xml
+++ b/tests/unit/utils/rpc-reply/request-vmhost-zeroize.xml
@@ -1,0 +1,13 @@
+<rpc-reply>
+<rpc-error>
+<error-severity>warning</error-severity>
+<error-message>
+zeroizing vmhost re0
+</error-message>
+</rpc-error>
+<warning xmlns="http://xml.juniper.net/xnm/1.1/xnm" xmlns:xnm="http://xml.juniper.net/xnm/1.1/xnm">
+<message>
+zeroizing vmhost re0
+</message>
+</warning>
+</rpc-reply>

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -1014,6 +1014,36 @@ class TestSW(unittest.TestCase):
         self.assertRaises(Exception, self.sw.zeroize)
 
     @patch("jnpr.junos.Device.execute")
+    def test_sw_zeroize_vmhost(self, mock_execute):
+        mock_execute.side_effect = self._mock_manager
+        self.assertTrue("zeroizing vmhost" in self.sw.zeroize(vmhost=True))
+
+    @patch("jnpr.junos.Device.execute")
+    def test_sw_zeroize_vmhost_uses_vmhost_rpc(self, mock_execute):
+        # Verify that the request-vmhost-zeroize RPC tag is used, not
+        # request-system-zeroize, for VMHost-based SRX platforms.
+        mock_execute.side_effect = self._mock_manager
+        self.sw.zeroize(vmhost=True)
+        rpc_call = mock_execute.call_args[0][0]
+        self.assertEqual(rpc_call.tag, "request-vmhost-zeroize")
+
+    @patch("jnpr.junos.Device.execute")
+    def test_sw_zeroize_non_vmhost_uses_system_rpc(self, mock_execute):
+        # Verify that non-vmhost path still uses request-system-zeroize (or
+        # its sub-element, e.g. 'local' when 2RE is True and all_re=False).
+        mock_execute.side_effect = self._mock_manager
+        self.sw.zeroize()
+        rpc_call = mock_execute.call_args[0][0]
+        self.assertIn(rpc_call.tag, ("request-system-zeroize", "local", "media"))
+
+    @patch("jnpr.junos.Device.execute")
+    def test_sw_zeroize_vmhost_exception(self, mock_execute):
+        # Exception path: non-warning RpcError on vmhost zeroize must propagate.
+        rsp = etree.XML("<rpc-reply><a>test</a></rpc-reply>")
+        mock_execute.side_effect = RpcError(rsp=rsp)
+        self.assertRaises(Exception, self.sw.zeroize, vmhost=True)
+
+    @patch("jnpr.junos.Device.execute")
     def test_sw_check_pending_install(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         package = "test.tgz"
@@ -1071,6 +1101,16 @@ class TestSW(unittest.TestCase):
                 if kwargs["path"] == "/packages":
                     return self._read_file("file-list_dir.xml")
             if args and self._testMethodName == "test_sw_zeroize":
+                return self._read_file("request-zeroize.xml")
+            if args and self._testMethodName in (
+                "test_sw_zeroize_vmhost",
+                "test_sw_zeroize_vmhost_uses_vmhost_rpc",
+            ):
+                return self._read_file("request-vmhost-zeroize.xml")
+            if (
+                args
+                and self._testMethodName == "test_sw_zeroize_non_vmhost_uses_system_rpc"
+            ):
                 return self._read_file("request-zeroize.xml")
             device_params = kwargs["device_params"]
             device_handler = make_device_handler(device_params)


### PR DESCRIPTION
1) Fix for issue #1399 - replaced setParseAction' with  'set_parse_action'
```
/opt/openl2m/venv/lib/python3.12/site-packages/jnpr/junos/factory/state_machine.py:32: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
).setParseAction(lambda i: "".join(i))

/opt/openl2m/venv/lib/python3.12/site-packages/jnpr/junos/factory/state_machine.py:37: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
words = (pp.OneOrMore(word)).setParseAction(lambda i: " ".join(i))
```

2) Fix for issue #1372 
support is required for "request vmhost zeroize" for the new platforms