### PR TITLE
proxy pr fix

### DIFF
--- a/lib/jnpr/junos/device.py
+++ b/lib/jnpr/junos/device.py
@@ -49,6 +49,15 @@ _MODULEPATH = os.path.dirname(__file__)
 
 logger = logging.getLogger("jnpr.junos.device")
 
+# Matches a plain hostname/IPv4 label sequence or a bracketed IPv6 literal.
+# Used to reject whitespace, leading hyphens, and shell metacharacters
+# before substituting the hostname into a proxy_command template.
+# The plain-hostname branch requires the value to start and end with an
+# alphanumeric character, which also blocks leading-hyphen argument injection.
+_HOSTNAME_RE = re.compile(
+    r"^(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?|\[[0-9a-fA-F:]+\])$"
+)
+
 
 class _MyTemplateLoader(jinja2.BaseLoader):
     """
@@ -1286,6 +1295,11 @@ class Device(_Connection):
             if self._proxy_command is not None and self._sock_fd is not None:
                 raise ValueError(
                     "'proxy_command' and 'sock_fd' cannot be used together"
+                )
+            if hostname is not None and not _HOSTNAME_RE.match(hostname):
+                raise ValueError(
+                    f"Invalid 'host' value {hostname!r}: only alphanumerics, dots, "
+                    "underscores, hyphens, or bracketed IPv6 literals are permitted."
                 )
             self._hostname = hostname
             # user will default to $USER

--- a/tests/unit/test_device.py
+++ b/tests/unit/test_device.py
@@ -597,6 +597,159 @@ class TestDevice(unittest.TestCase):
             _, connect_kwargs = mock_execute.call_args
             self.assertIsNone(connect_kwargs["sock"])
 
+    # ------------------------------------------------------------------
+    # Hostname validation tests (security fix: argument-injection guard)
+    # ------------------------------------------------------------------
+
+    def test_device_host_valid_ipv4(self):
+        # Plain IPv4 address must be accepted without raising.
+        dev = Device(
+            host="192.168.1.1", user="test", password="password123", gather_facts=False
+        )
+        self.assertEqual(dev._hostname, "192.168.1.1")
+
+    def test_device_host_valid_fqdn(self):
+        # Typical FQDN with dots and hyphens must be accepted.
+        dev = Device(
+            host="router.example.com",
+            user="test",
+            password="password123",
+            gather_facts=False,
+        )
+        self.assertEqual(dev._hostname, "router.example.com")
+
+    def test_device_host_valid_single_label(self):
+        # Single alphanumeric label (e.g. bare hostname) must be accepted.
+        dev = Device(
+            host="router1", user="test", password="password123", gather_facts=False
+        )
+        self.assertEqual(dev._hostname, "router1")
+
+    def test_device_host_valid_ipv6_bracketed(self):
+        # Bracketed IPv6 literal must be accepted.
+        dev = Device(
+            host="[2001:db8::1]",
+            user="test",
+            password="password123",
+            gather_facts=False,
+        )
+        self.assertEqual(dev._hostname, "[2001:db8::1]")
+
+    def test_device_host_valid_ipv6_loopback(self):
+        # Bracketed IPv6 loopback must be accepted.
+        dev = Device(
+            host="[::1]", user="test", password="password123", gather_facts=False
+        )
+        self.assertEqual(dev._hostname, "[::1]")
+
+    def test_device_host_invalid_whitespace_injection(self):
+        # Hostname with embedded space must be rejected at construction
+        # (core argument-injection vector from the security report).
+        with self.assertRaises(ValueError):
+            Device(
+                host="valid.host -oProxyCommand=touch /tmp/pwned",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_backslash_space_injection(self):
+        # Backslash-escaped space variant must also be rejected.
+        with self.assertRaises(ValueError):
+            Device(
+                host=r"valid.host:22 -oProxyCommand=touch\ /tmp/pwned",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_leading_hyphen(self):
+        # A hostname starting with a hyphen looks like an option flag to ssh.
+        with self.assertRaises(ValueError):
+            Device(
+                host="-oProxyCommand=id",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_semicolon(self):
+        # Shell metacharacter ; must be rejected.
+        with self.assertRaises(ValueError):
+            Device(
+                host="host;rm -rf /",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_backtick(self):
+        # Backtick command substitution must be rejected.
+        with self.assertRaises(ValueError):
+            Device(
+                host="host`id`",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_dollar_sign(self):
+        # Dollar-sign variable expansion must be rejected.
+        with self.assertRaises(ValueError):
+            Device(
+                host="$(id)",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_invalid_colon_port_suffix(self):
+        # host:port notation must be rejected (port belongs in the 'port' kwarg).
+        with self.assertRaises(ValueError):
+            Device(
+                host="router.example.com:22",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+
+    def test_device_host_none_with_sock_fd_allowed(self):
+        # host=None is valid for outbound-SSH (sock_fd) connections and must
+        # not be rejected by the hostname validator.
+        dev = Device(sock_fd=6, user="test", password="password123")
+        self.assertIsNone(dev._hostname)
+
+    def test_device_host_invalid_raises_value_error_not_other(self):
+        # Confirm the exception type is exactly ValueError (not ConnectError
+        # or any other exception class).
+        with self.assertRaises(ValueError) as ctx:
+            Device(
+                host="bad host",
+                user="test",
+                password="password123",
+                gather_facts=False,
+            )
+        self.assertIn("Invalid 'host' value", str(ctx.exception))
+
+    @patch("ncclient.manager.connect")
+    @patch("jnpr.junos.Device.execute")
+    def test_device_host_invalid_no_subprocess_spawned(
+        self, mock_connect, mock_execute
+    ):
+        # Verify that a malicious hostname raises BEFORE any ProxyCommand
+        # subprocess is spawned — i.e. the error fires at Device() time,
+        # not at .open() time.
+        with patch("paramiko.proxy.ProxyCommand") as mock_proxy:
+            with self.assertRaises(ValueError):
+                Device(
+                    host=r"valid.host -oProxyCommand=touch\ /tmp/pwned",
+                    user="test",
+                    password="password123",
+                    proxy_command="ssh -W %h:%p jump-host",
+                    gather_facts=False,
+                )
+            mock_proxy.assert_not_called()
+
     @patch("ncclient.manager.connect")
     @patch("jnpr.junos.Device.execute")
     def test_device_outbound(self, mock_connect, mock_execute):


### PR DESCRIPTION
```
FIX — lib/jnpr/junos/device.py
--------------------------------

Change 1 — Module-level allowlist regex (~line 52)
....................................................

    # Matches a plain hostname/IPv4 label sequence or a bracketed IPv6 literal.
    # Used to reject whitespace, leading hyphens, and shell metacharacters
    # before substituting the hostname into a proxy_command template.
    # The plain-hostname branch requires the value to start and end with an
    # alphanumeric character, which also blocks leading-hyphen argument injection.
    _HOSTNAME_RE = re.compile(
        r"^(?:[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?|\[[0-9a-fA-F:]+\])$"
    )


  1. Plain hostname / IPv4
       [A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?
       Must START and END with an alphanumeric character.
       Middle characters may be alphanumeric, dot, underscore, or hyphen.
       Examples accepted : 192.168.1.1  router.example.com  my-host_1

  2. Bracketed IPv6 literal
       \[[0-9a-fA-F:]+\]
       Examples accepted : [::1]  [2001:db8::1]

Every other character is rejected, including:
  - Whitespace (space, tab, newline)  — token-boundary for shlex.split
  - Leading hyphen                    — interpreted as an option flag by ssh
  - Colon outside IPv6 brackets       — port injection into the %h slot
  - ; & ` $ ( ) \ ' " !              — shell metacharacters


Change 2 — Fail-fast validation at construction (~line 1295)
.............................................................

    if hostname is not None and not _HOSTNAME_RE.match(hostname):
        raise ValueError(
            "Invalid 'host' value %r: only alphanumerics, dots, underscores, "
            "hyphens, or bracketed IPv6 literals are permitted." % hostname
        )
    self._hostname = hostname

Design decisions:

  - hostname is not None guard
      Outbound-SSH connections (sock_fd= mode) legitimately pass
      hostname=None. That path must not be broken.

  - Fail-fast at construction
      The ValueError is raised inside Device(...), before .open(), before
      any subprocess is spawned, and before any network I/O. The attacker
      gets no opportunity to race or partially exploit.

  - Substitution left unchanged
      The existing str.replace("%h", self._hostname) at line ~1427 is not
      modified. Once the hostname is proven safe by the regex, concatenation
      into the command string is harmless because the validated value can
      contain no whitespace or metacharacters.

```

UT tests

```
regress@masterhost:~/pyez_proxy_pr_fix/py-junos-eznc$ python3 -m nose2 -v --coverage jnpr.junos  tests.unit
test_warning (tests.unit.TestJunosInit.test_warning) ... ok
test_CommitError_repr (tests.unit.test_exception.Test_RpcError.test_CommitError_repr) ... ok
test_ConfigLoadError_repr (tests.unit.test_exception.Test_RpcError.test_ConfigLoadError_repr) ... ok
test_ConnectError (tests.unit.test_exception.Test_RpcError.test_ConnectError) ... ok
test_ConnectError_msg (tests.unit.test_exception.Test_RpcError.test_ConnectError_msg) ... ok
test_json_error (tests.unit.test_exception.Test_RpcError.test_json_error) ... ok
test_json_error_offending_line (tests.unit.test_exception.Test_RpcError.test_json_error_offending_line) ... ok
test_repr_multi_warning (tests.unit.test_exception.Test_RpcError.test_repr_multi_warning) ... ok
test_rpcerror_jxml_check (tests.unit.test_exception.Test_RpcError.test_rpcerror_jxml_check) ... ok
test_rpcerror_repr (tests.unit.test_exception.Test_RpcError.test_rpcerror_repr) ... ok
test_RpcTimeoutError_repr (tests.unit.test_exception.Test_RpcError.test_RpcTimeoutError_repr) ... ok
test_SwRollbackError_repr (tests.unit.test_exception.Test_RpcError.test_SwRollbackError_repr) ... ok
test_SwRollbackError_repr_multi (tests.unit.test_exception.Test_RpcError.test_SwRollbackError_repr_multi) ... ok
test_domain_fact_from_config (tests.unit.facts.test_domain.TestDomain.test_domain_fact_from_config) ... ok
test_domain_fact_from_file (tests.unit.facts.test_domain.TestDomain.test_domain_fact_from_file) ... ok
test_vc (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc) ... ok
test_vc_dual_master (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc_dual_master) ... ok
test_vc_empty (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc_empty) ... ok
test_vc_error (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc_error) ... ok
test_vc_mmvc (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc_mmvc) ... ok
test_vc_mmvcf (tests.unit.facts.test_get_virtual_chassis_information.TestGetVirtualChassisInformation.test_vc_mmvcf) ... ok
test_home_fact (tests.unit.facts.test_file_list.TestFileList.test_home_fact) ... ok
test_home_fact_multi_dir (tests.unit.facts.test_file_list.TestFileList.test_home_fact_multi_dir) ... ok
test_re_info_dual (tests.unit.facts.test_get_route_engine_information.TestGetRouteEngineInformation.test_re_info_dual) ... ok
test_re_info_mx_vc (tests.unit.facts.test_get_route_engine_information.TestGetRouteEngineInformation.test_re_info_mx_vc) ... ok
test_re_info_single (tests.unit.facts.test_get_route_engine_information.TestGetRouteEngineInformation.test_re_info_single) ... ok
test_current_re_fact (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact) ... ok
test_current_re_fact_empty (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_empty) ... ok
test_current_re_fact_jdm (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_jdm) ... ok
test_current_re_fact_rpc_error (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_rpc_error) ... ok
test_current_re_fact_srx_cluster_index_error (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_index_error) ... ok
test_current_re_fact_srx_cluster_primary (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_primary) ... ok
test_current_re_fact_srx_cluster_primary_id_16 (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_primary_id_16) ... 16
ok
test_current_re_fact_srx_cluster_primary_id_255 (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_primary_id_255) ... ok
test_current_re_fact_srx_cluster_primary_id_31 (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_primary_id_31) ... ok
test_current_re_fact_srx_cluster_secondary (tests.unit.facts.test_current_re.TestCurrentRe.test_current_re_fact_srx_cluster_secondary) ... ok
test_ifd_style_classic (tests.unit.facts.test_ifd_style.TestIfdStyle.test_ifd_style_classic) ... ok
test_ifd_style_None (tests.unit.facts.test_ifd_style.TestIfdStyle.test_ifd_style_None) ... ok
test_ifd_style_switch (tests.unit.facts.test_ifd_style.TestIfdStyle.test_ifd_style_switch) ... ok
test_duplicate_facts (tests.unit.facts.test__init__.TestFactInitialization.test_duplicate_facts) ... ok
test_serialnumber_error_xml (tests.unit.facts.test_get_chassis_inventory.TestChassis.test_serialnumber_error_xml) ... ok
test_serialnumber_fact_from_backplane (tests.unit.facts.test_get_chassis_inventory.TestChassis.test_serialnumber_fact_from_backplane) ... ok
test_serialnumber_fact_from_chassis (tests.unit.facts.test_get_chassis_inventory.TestChassis.test_serialnumber_fact_from_chassis) ... ok
test_serialnumber_not_master (tests.unit.facts.test_get_chassis_inventory.TestChassis.test_serialnumber_not_master) ... ok
test_sw_info_bsys (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_bsys) ... ok
test_sw_info_dual (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_dual) ... ok
test_sw_info_dual_other_re_off (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_dual_other_re_off) ... ok
test_sw_info_err (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_err) ... ok
test_sw_info_ex (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_ex) ... ok
test_sw_info_gnf (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_gnf) ... ok
test_sw_info_jdm (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_jdm) ... ok
test_sw_info_nfx (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_nfx) ... ok
test_sw_info_no_version (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_no_version) ... ok
test_sw_info_simple (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_simple) ... ok
test_sw_info_single (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_single) ... ok
test_sw_info_srx_cluster (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_srx_cluster) ... ok
test_sw_info_txp (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_txp) ... ok
test_sw_info_vc (tests.unit.facts.test_get_software_information.TestGetSoftwareInformation.test_sw_info_vc) ... ok
test_srx_cluster_fact_false (tests.unit.facts.test_get_chassis_cluster_status.TestGetChassisClusterStatus.test_srx_cluster_fact_false) ... ok
test_srx_cluster_fact_none (tests.unit.facts.test_get_chassis_cluster_status.TestGetChassisClusterStatus.test_srx_cluster_fact_none) ... ok
test_srx_cluster_fact_true (tests.unit.facts.test_get_chassis_cluster_status.TestGetChassisClusterStatus.test_srx_cluster_fact_true) ... ok
test_srx_cluster_id_fact (tests.unit.facts.test_get_chassis_cluster_status.TestGetChassisClusterStatus.test_srx_cluster_id_fact) ... ok
test_iri_host_to_ip_mapping_fact (tests.unit.facts.test_iri_mapping.TestIriMapping.test_iri_host_to_ip_mapping_fact) ... ok
test_iri_ip_to_host_mapping_fact (tests.unit.facts.test_iri_mapping.TestIriMapping.test_iri_ip_to_host_mapping_fact) ... ok
test_iri_template_host_to_ip_mapping_fact (tests.unit.facts.test_iri_mapping.TestIriMapping.test_iri_template_host_to_ip_mapping_fact) ... ok
test_iri_template_ip_to_host_mapping_fact (tests.unit.facts.test_iri_mapping.TestIriMapping.test_iri_template_ip_to_host_mapping_fact) ... ok
test_emptyget_facts (tests.unit.facts.test_swver.TestVersionInfo.test_emptyget_facts) ... ok
test_version_feature_velocity (tests.unit.facts.test_swver.TestVersionInfo.test_version_feature_velocity) ... ok
test_version_info_after_type_len_else (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_after_type_len_else) ... ok
test_version_info_constructor_else_exception (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_constructor_else_exception) ... ok
test_version_info_eq (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_eq) ... ok
test_version_info_gt (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_gt) ... ok
test_version_info_gt_eq (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_gt_eq) ... ok
test_version_info_lt (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_lt) ... ok
test_version_info_lt_eq (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_lt_eq) ... ok
test_version_info_not_eq (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_not_eq) ... ok
test_version_info_repr (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_repr) ... ok
test_version_info_X_type_non_hyphenated (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_X_type_non_hyphenated) ... ok
test_version_info_X_type_non_hyphenated_nobuild (tests.unit.facts.test_swver.TestVersionInfo.test_version_info_X_type_non_hyphenated_nobuild) ... ok
test_version_iter (tests.unit.facts.test_swver.TestVersionInfo.test_version_iter) ... ok
test_version_to_json (tests.unit.facts.test_swver.TestVersionInfo.test_version_to_json) ... ok
test_version_to_yaml (tests.unit.facts.test_swver.TestVersionInfo.test_version_to_yaml) ... ok
test_vmhost_error (tests.unit.facts.test_vmhost.TestVmHost.test_vmhost_error) ... ok
test_vmhost_false (tests.unit.facts.test_vmhost.TestVmHost.test_vmhost_false) ... ok
test_vmhost_linux (tests.unit.facts.test_vmhost.TestVmHost.test_vmhost_linux) ... ok
test_vmhost_true (tests.unit.facts.test_vmhost.TestVmHost.test_vmhost_true) ... ok
test_personality_acx (tests.unit.facts.test_personality.TestPersonality.test_personality_acx) ... ok
test_personality_firefly (tests.unit.facts.test_personality.TestPersonality.test_personality_firefly) ... ok
test_personality_gnf (tests.unit.facts.test_personality.TestPersonality.test_personality_gnf) ... ok
test_personality_jdm (tests.unit.facts.test_personality.TestPersonality.test_personality_jdm) ... ok
test_personality_m (tests.unit.facts.test_personality.TestPersonality.test_personality_m) ... ok
test_personality_mx (tests.unit.facts.test_personality.TestPersonality.test_personality_mx) ... ok
test_personality_nfx (tests.unit.facts.test_personality.TestPersonality.test_personality_nfx) ... ok
test_personality_old_vmx (tests.unit.facts.test_personality.TestPersonality.test_personality_old_vmx) ... ok
test_personality_old_vrr (tests.unit.facts.test_personality.TestPersonality.test_personality_old_vrr) ... ok
test_personality_olive (tests.unit.facts.test_personality.TestPersonality.test_personality_olive) ... ok
test_personality_ptx (tests.unit.facts.test_personality.TestPersonality.test_personality_ptx) ... ok
test_personality_srx_branch (tests.unit.facts.test_personality.TestPersonality.test_personality_srx_branch) ... ok
test_personality_srx_high_end (tests.unit.facts.test_personality.TestPersonality.test_personality_srx_high_end) ... ok
test_personality_srx_mid_range (tests.unit.facts.test_personality.TestPersonality.test_personality_srx_mid_range) ... ok
test_personality_t (tests.unit.facts.test_personality.TestPersonality.test_personality_t) ... ok
test_personality_virtual_chassis (tests.unit.facts.test_personality.TestPersonality.test_personality_virtual_chassis) ... ok
test_personality_vjx (tests.unit.facts.test_personality.TestPersonality.test_personality_vjx) ... ok
test_personality_vmx (tests.unit.facts.test_personality.TestPersonality.test_personality_vmx) ... ok
test_personality_vptx (tests.unit.facts.test_personality.TestPersonality.test_personality_vptx) ... ok
test_ethernet_mac_table_bd (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_bd) ... ok
test_ethernet_mac_table_els (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_els) ... ok
test_ethernet_mac_table_non_master_bd_mx (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_non_master_bd_mx) ... ok
test_ethernet_mac_table_non_master_bd_ptx (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_non_master_bd_ptx) ... ok
test_ethernet_mac_table_none (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_none) ... ok
test_ethernet_mac_table_vlan (tests.unit.facts.test_ethernet_mac_table.TestEthernetMacTable.test_ethernet_mac_table_vlan) ... ok
test_factcache_delete_fact (tests.unit.test_factcache.TestFactCache.test_factcache_delete_fact) ... ok
test_factcache_fact_loop (tests.unit.test_factcache.TestFactCache.test_factcache_fact_loop) ... ok
test_factcache_fail_to_return_expected_fact (tests.unit.test_factcache.TestFactCache.test_factcache_fail_to_return_expected_fact) ... ok
test_factcache_iter_facts (tests.unit.test_factcache.TestFactCache.test_factcache_iter_facts) ... ok
test_factcache_len_facts (tests.unit.test_factcache.TestFactCache.test_factcache_len_facts) ... ok
test_factcache_nonmatching_old_and_new_fact (tests.unit.test_factcache.TestFactCache.test_factcache_nonmatching_old_and_new_fact) ... ok
test_factcache_refresh_all_facts (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_all_facts) ... ok
test_factcache_refresh_exception_on_failure (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_exception_on_failure) ... ok
test_factcache_refresh_no_exception_on_failure (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_no_exception_on_failure) ... ok
test_factcache_refresh_single_key (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_single_key) ... ok
test_factcache_refresh_two_keys (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_two_keys) ... ok
test_factcache_refresh_unknown_fact (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_unknown_fact) ... ok
test_factcache_refresh_warnings_on_failure (tests.unit.test_factcache.TestFactCache.test_factcache_refresh_warnings_on_failure) ... ok
test_factcache_repr_facts (tests.unit.test_factcache.TestFactCache.test_factcache_repr_facts) ... ok
test_factcache_return_unexpected_fact (tests.unit.test_factcache.TestFactCache.test_factcache_return_unexpected_fact) ... ok
test_factcache_set_fact (tests.unit.test_factcache.TestFactCache.test_factcache_set_fact) ... ok
test_factcache_string_repr (tests.unit.test_factcache.TestFactCache.test_factcache_string_repr) ... ok
test_factcache_unknown_fact (tests.unit.test_factcache.TestFactCache.test_factcache_unknown_fact) ... ok
test_close (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_close) ... ok
test_open (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_open) ... ok
test_open_exception (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_open_exception) ... ERROR:jnpr.junos.tty_ssh:SSH Socket Error: . Checking back in: 0.1
ok
test_read (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_read) ... ok
test_tty_ssh_baud (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_tty_ssh_baud) ... ok
test_tty_ssh_rawwrite_sys_py3 (tests.unit.transport.test_tty_ssh.TestTTYSSH.test_tty_ssh_rawwrite_sys_py3) ... ok
test_ev_option (tests.unit.transport.test_tty.TestTTY.test_ev_option) ... ok
test_ev_shell (tests.unit.transport.test_tty.TestTTY.test_ev_shell) ... ok
test_loader (tests.unit.transport.test_tty.TestTTY.test_loader) ... ok
test_login_bad_password_ConnectAuthError (tests.unit.transport.test_tty.TestTTY.test_login_bad_password_ConnectAuthError) ... ok
test_login_bad_password_runtimeerror (tests.unit.transport.test_tty.TestTTY.test_login_bad_password_runtimeerror) ... ok
test_tty_already_logout (tests.unit.transport.test_tty.TestTTY.test_tty_already_logout) ... ok
test_tty_cli (tests.unit.transport.test_tty.TestTTY.test_tty_cli) ... ok
test_tty_ev_netconf_closed (tests.unit.transport.test_tty.TestTTY.test_tty_ev_netconf_closed) ... ok
test_tty_ev_tty_nologin (tests.unit.transport.test_tty.TestTTY.test_tty_ev_tty_nologin) ... ok
test_tty_login_state_machine_hotkey (tests.unit.transport.test_tty.TestTTY.test_tty_login_state_machine_hotkey) ... ok
test_tty_login_state_machine_loader (tests.unit.transport.test_tty.TestTTY.test_tty_login_state_machine_loader) ... ok
test_tty_logout_state_machine_attempt_10 (tests.unit.transport.test_tty.TestTTY.test_tty_logout_state_machine_attempt_10) ... ok
test_tty_no_login (tests.unit.transport.test_tty.TestTTY.test_tty_no_login) ... ok
test_close_connection (tests.unit.transport.test_serial.TestSerial.test_close_connection) ... ok
test_console_connected (tests.unit.transport.test_serial.TestSerial.test_console_connected) ... ok
test_tty_serial_open_exception (tests.unit.transport.test_serial.TestSerial.test_tty_serial_open_exception) ... ERROR:jnpr.junos.console:ERROR:  login:open_failed:None

ERROR:jnpr.junos.console:
Complete traceback message: Traceback (most recent call last):
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/transport/tty_serial.py", line 44, in _tty_open
    self._ser.open()
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1134, in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
    raise effect
OSError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/console.py", line 204, in open
    self._tty_login()
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/console.py", line 313, in _tty_login
    self._tty.login()
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/transport/tty.py", line 126, in login
    self._tty_open()
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/transport/tty_serial.py", line 46, in _tty_open
    raise RuntimeError("open_failed:{}".format(err.strerror))
RuntimeError: open_failed:None

ok
test_tty_serial_rawwrite (tests.unit.transport.test_serial.TestSerial.test_tty_serial_rawwrite) ... ok
test_tty_serial_read (tests.unit.transport.test_serial.TestSerial.test_tty_serial_read) ... ok
test_tty_serial_read_prompt (tests.unit.transport.test_serial.TestSerial.test_tty_serial_read_prompt) ... ok
test_tty_serial_win_connected (tests.unit.transport.test_serial.TestSerialWin.test_tty_serial_win_connected) ... ok
test_tty_serial_win_rpc_call (tests.unit.transport.test_serial.TestSerialWin.test_tty_serial_win_rpc_call) ... ok
test_close_force_false (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_close_force_false) ... ok
test_close_force_true (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_close_force_true) ... ok
test_open_at_shell_true (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_open_at_shell_true) ... ok
test_open_RuntimeError (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_open_RuntimeError) ... ok
test_rpc (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_rpc) ... ok
test_tty_netconf_multi_rpc_error (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_multi_rpc_error) ... ok
test_tty_netconf_receive_empty_line (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_empty_line) ... ok
test_tty_netconf_receive_select_error (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_select_error) ... ok
test_tty_netconf_receive_socket_error (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_socket_error) ... ok
test_tty_netconf_receive_splited_eom (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_splited_eom) ... ok
test_tty_netconf_receive_XMLSyntaxError (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_XMLSyntaxError) ... ok
test_tty_netconf_receive_XMLSyntaxError_eom_in_center (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_XMLSyntaxError_eom_in_center) ... ok
test_tty_netconf_receive_xmn_error (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_receive_xmn_error) ... ok
test_tty_netconf_single_rpc_error (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_tty_netconf_single_rpc_error) ... ok
test_zeroize_exception (tests.unit.transport.test_tty_netconf.TestTTYNetconf.test_zeroize_exception) ... ok
test_close (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_close) ... ok
test_open (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_open) ... ok
test_open_exception (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_open_exception) ... ok
test_read (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_read) ... ok
test_read_prompt_in_use_RuntimeError (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_read_prompt_in_use_RuntimeError) ... ok
test_read_prompt_RuntimeError (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_read_prompt_RuntimeError) ... ok
test_tty_telnet_baud (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_tty_telnet_baud) ... ok
test_tty_telnet_rawwrite_sys_py3 (tests.unit.transport.test_tty_telnet.TestTTYTelnet.test_tty_telnet_rawwrite_sys_py3) ... ok
test_cscript_conf (tests.unit.test_jxml.Test_JXML.test_cscript_conf) ... ok
test_cscript_conf_output_tag_child_element (tests.unit.test_jxml.Test_JXML.test_cscript_conf_output_tag_child_element) ... ok
test_cscript_conf_output_tag_not_first_child_element (tests.unit.test_jxml.Test_JXML.test_cscript_conf_output_tag_not_first_child_element) ... ok
test_cscript_conf_return_none (tests.unit.test_jxml.Test_JXML.test_cscript_conf_return_none) ... ok
test_insert (tests.unit.test_jxml.Test_JXML.test_insert) ... ok
test_name (tests.unit.test_jxml.Test_JXML.test_name) ... ok
test_remove_namespaces (tests.unit.test_jxml.Test_JXML.test_remove_namespaces) ... ok
test_console_close_error (tests.unit.test_console.TestConsole.test_console_close_error) ... ERROR:jnpr.junos.console:ERROR logout:

ok
test_console_close_error_skip_logout (tests.unit.test_console.TestConsole.test_console_close_error_skip_logout) ... ERROR:jnpr.junos.console:ERROR close:

ERROR:jnpr.junos.console:
Complete traceback message: Traceback (most recent call last):
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/console.py", line 255, in close
    self._tty._tty_close()
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1134, in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
    raise effect
RuntimeError

ok
test_console_close_socket_conn_reset (tests.unit.test_console.TestConsole.test_console_close_socket_conn_reset) ... ok
test_console_close_socket_error (tests.unit.test_console.TestConsole.test_console_close_socket_error) ... ok
test_console_close_telnet_conn_closed (tests.unit.test_console.TestConsole.test_console_close_telnet_conn_closed) ... ok
test_console_connected (tests.unit.test_console.TestConsole.test_console_connected) ... ok
test_console_gather_facts (tests.unit.test_console.TestConsole.test_console_gather_facts) ... ok
test_console_gather_facts_true (tests.unit.test_console.TestConsole.test_console_gather_facts_true) ... ok
test_console_open_error (tests.unit.test_console.TestConsole.test_console_open_error) ... ERROR:jnpr.junos.console:ERROR:  login:

ERROR:jnpr.junos.console:
Complete traceback message: Traceback (most recent call last):
  File "/home/regress/pyez_proxy_pr_fix/py-junos-eznc/lib/jnpr/junos/console.py", line 204, in open
    self._tty_login()
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1134, in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1138, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/unittest/mock.py", line 1193, in _execute_mock_call
    raise effect
RuntimeError

ok
test_console_rpc_call (tests.unit.test_console.TestConsole.test_console_rpc_call) ... ok
test_console_rpc_call_exception (tests.unit.test_console.TestConsole.test_console_rpc_call_exception) ... ok
test_console_serial (tests.unit.test_console.TestConsole.test_console_serial) ... ok
test_console_tty_open_err (tests.unit.test_console.TestConsole.test_console_tty_open_err) ... ERROR:jnpr.junos.console:Exception occurred: login:

ok
test_console_zeroize (tests.unit.test_console.TestConsole.test_console_zeroize) ... ok
test_load_console (tests.unit.test_console.TestConsole.test_load_console) ... ok
test_login_bad_password (tests.unit.test_console.TestConsole.test_login_bad_password) ... ERROR:jnpr.junos.console:Exception occurred: login:

ok
test_telnet_host_none (tests.unit.test_console.TestConsole.test_telnet_host_none) ... ok
test_telnet_old_fact_warning (tests.unit.test_console.TestConsole.test_telnet_old_fact_warning) ... ok
test_timeout_getter_setter (tests.unit.test_console.TestConsole.test_timeout_getter_setter) ... ok
test_with_context (tests.unit.test_console.TestConsole.test_with_context) ... ok
test_wrong_mode (tests.unit.test_console.TestConsole.test_wrong_mode) ... ERROR:jnpr.junos.console:Mode should be either telnet or serial
ERROR:jnpr.junos.console:Exception occurred: login:Mode to be telnet/serial

ok
test_domain_in_configuration (tests.unit.ofacts.test_domain.TestDomain.test_domain_in_configuration) ... ok
test_domain_rpc_error (tests.unit.ofacts.test_domain.TestDomain.test_domain_rpc_error) ... ok
test_resolv_conf (tests.unit.ofacts.test_domain.TestDomain.test_resolv_conf) ... ok
test_resolv_conf_file_absent_under_etc (tests.unit.ofacts.test_domain.TestDomain.test_resolv_conf_file_absent_under_etc) ... ok
test_resolv_conf_no_domain (tests.unit.ofacts.test_domain.TestDomain.test_resolv_conf_no_domain) ... ok
test_master (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_master) ... ok
test_mixed_mode_vcf (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_mixed_mode_vcf) ... ok
test_multi_instance (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_multi_instance) ... ok
test_multi_re_vc (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_multi_re_vc) ... ok
test_routing_engine_exception_ret_none (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_routing_engine_exception_ret_none) ... ok
test_vc_info_true (tests.unit.ofacts.test_routing_engines.TestRoutingEngines.test_vc_info_true) ... ok
test_2RE_true (tests.unit.ofacts.test_chassis.TestChassis.test_2RE_true) ... ok
test_chassis_exception_ConnectNotMasterError (tests.unit.ofacts.test_chassis.TestChassis.test_chassis_exception_ConnectNotMasterError) ... ok
test_chassis_exception_RpcError (tests.unit.ofacts.test_chassis.TestChassis.test_chassis_exception_RpcError) ... ok
test_chassis_exception_RuntimeError (tests.unit.ofacts.test_chassis.TestChassis.test_chassis_exception_RuntimeError) ... ok
test_ifd_style_else_condition (tests.unit.ofacts.test_ifd_style.TestIFDStyle.test_ifd_style_else_condition) ... ok
test_ifd_style_if_condition (tests.unit.ofacts.test_ifd_style.TestIFDStyle.test_ifd_style_if_condition) ... ok
test_get_swver_vc (tests.unit.ofacts.test_swver.TestSwver.test_get_swver_vc) ... ok
test_get_swver_vc_capable_standalone (tests.unit.ofacts.test_swver.TestSwver.test_get_swver_vc_capable_standalone) ... ok
test_swver (tests.unit.ofacts.test_swver.TestSwver.test_swver) ... ok
test_swver_exception_handling (tests.unit.ofacts.test_swver.TestSwver.test_swver_exception_handling) ... ok
test_swver_f_master_list (tests.unit.ofacts.test_swver.TestSwver.test_swver_f_master_list) ... ok
test_swver_hostname_none (tests.unit.ofacts.test_swver.TestSwver.test_swver_hostname_none) ... ok
test_swver_txp_master_list (tests.unit.ofacts.test_swver.TestSwver.test_swver_txp_master_list) ... ok
test_switch_style_model_ex9000 (tests.unit.ofacts.test_switch_style.TestSwitchStyle.test_switch_style_model_ex9000) ... ok
test_switch_style_model_firefly (tests.unit.ofacts.test_switch_style.TestSwitchStyle.test_switch_style_model_firefly) ... ok
test_switch_style_model_not_specific (tests.unit.ofacts.test_switch_style.TestSwitchStyle.test_switch_style_model_not_specific) ... ok
test_switch_style_mx_srx (tests.unit.ofacts.test_switch_style.TestSwitchStyle.test_switch_style_mx_srx) ... ok
test_switch_style_persona_not_specific (tests.unit.ofacts.test_switch_style.TestSwitchStyle.test_switch_style_persona_not_specific) ... ok
test_invalid_series (tests.unit.ofacts.test_personality.TestPersonality.test_invalid_series) ... ok
test_m_ex_qfx_series (tests.unit.ofacts.test_personality.TestPersonality.test_m_ex_qfx_series) ... ok
test_m_series (tests.unit.ofacts.test_personality.TestPersonality.test_m_series) ... ok
test_mx_series (tests.unit.ofacts.test_personality.TestPersonality.test_mx_series) ... ok
test_personality_olive (tests.unit.ofacts.test_personality.TestPersonality.test_personality_olive) ... ok
test_ptx_series (tests.unit.ofacts.test_personality.TestPersonality.test_ptx_series) ... ok
test_srx_high_series (tests.unit.ofacts.test_personality.TestPersonality.test_srx_high_series) ... ok
test_srx_series (tests.unit.ofacts.test_personality.TestPersonality.test_srx_series) ... ok
test_t_series (tests.unit.ofacts.test_personality.TestPersonality.test_t_series) ... ok
test_virtual_hassis (tests.unit.ofacts.test_personality.TestPersonality.test_virtual_hassis) ... ok
test_vjx_series (tests.unit.ofacts.test_personality.TestPersonality.test_vjx_series) ... ok
test_vmx_series (tests.unit.ofacts.test_personality.TestPersonality.test_vmx_series) ... ok
test_srx_cluster (tests.unit.ofacts.test_srx_cluster.TestSrxCluster.test_srx_cluster) ... ok
test_srx_cluster_no_node (tests.unit.ofacts.test_srx_cluster.TestSrxCluster.test_srx_cluster_no_node) ... ok
test_srx_cluster_node (tests.unit.ofacts.test_srx_cluster.TestSrxCluster.test_srx_cluster_node) ... ok
test_srx_cluster_none (tests.unit.ofacts.test_srx_cluster.TestSrxCluster.test_srx_cluster_none) ... ok
test_device__sshconf_lkup (tests.unit.test_device.TestDevice.test_device__sshconf_lkup) ... ok
test_device__sshconf_lkup_def (tests.unit.test_device.TestDevice.test_device__sshconf_lkup_def) ... ok
test_device__sshconf_lkup_path_not_exists (tests.unit.test_device.TestDevice.test_device__sshconf_lkup_path_not_exists) ... ok
test_device__sshconf_lkup_sock_fd (tests.unit.test_device.TestDevice.test_device__sshconf_lkup_sock_fd) ... ok
test_device_bind_kvarg (tests.unit.test_device.TestDevice.test_device_bind_kvarg) ... ok
test_device_bind_kvarg_exception (tests.unit.test_device.TestDevice.test_device_bind_kvarg_exception) ... ok
test_device_bind_varg (tests.unit.test_device.TestDevice.test_device_bind_varg) ... ok
test_device_bind_varg_exception (tests.unit.test_device.TestDevice.test_device_bind_varg_exception) ... ok
test_device_cli (tests.unit.test_device.TestDevice.test_device_cli) ... ok
test_device_cli_blank_output (tests.unit.test_device.TestDevice.test_device_cli_blank_output) ... ok
test_device_cli_conf_info (tests.unit.test_device.TestDevice.test_device_cli_conf_info) ... ok
test_device_cli_connection_exception (tests.unit.test_device.TestDevice.test_device_cli_connection_exception) ... ok
test_device_cli_format_json (tests.unit.test_device.TestDevice.test_device_cli_format_json) ... ok
test_device_cli_output (tests.unit.test_device.TestDevice.test_device_cli_output) ... ok
test_device_cli_output_warning (tests.unit.test_device.TestDevice.test_device_cli_output_warning) ... ok
test_device_cli_rpc (tests.unit.test_device.TestDevice.test_device_cli_rpc) ... ok
test_device_cli_rpc_exception (tests.unit.test_device.TestDevice.test_device_cli_rpc_exception) ... ok
test_device_cli_rpc_reply_with_message (tests.unit.test_device.TestDevice.test_device_cli_rpc_reply_with_message) ... ok
test_device_cli_timeout_exception (tests.unit.test_device.TestDevice.test_device_cli_timeout_exception) ... ok
test_device_cli_to_rpc_string (tests.unit.test_device.TestDevice.test_device_cli_to_rpc_string) ... ok
test_device_cli_to_rpc_string_complex (tests.unit.test_device.TestDevice.test_device_cli_to_rpc_string_complex) ... ok
test_device_cli_to_rpc_string_invalid (tests.unit.test_device.TestDevice.test_device_cli_to_rpc_string_invalid) ... ok
test_device_cli_to_rpc_string_strip_pipes (tests.unit.test_device.TestDevice.test_device_cli_to_rpc_string_strip_pipes) ... ok
test_device_cli_unknown_exception (tests.unit.test_device.TestDevice.test_device_cli_unknown_exception) ... ok
test_device_close (tests.unit.test_device.TestDevice.test_device_close) ... ok
test_device_conn_None_transform (tests.unit.test_device.TestDevice.test_device_conn_None_transform) ... ok
test_device_ConnectAuthError (tests.unit.test_device.TestDevice.test_device_ConnectAuthError) ... ok
test_device_ConnectRefusedError (tests.unit.test_device.TestDevice.test_device_ConnectRefusedError) ... ok
test_device_ConnectTimeoutError (tests.unit.test_device.TestDevice.test_device_ConnectTimeoutError) ... ok
test_device_ConnectUnknownHostError (tests.unit.test_device.TestDevice.test_device_ConnectUnknownHostError) ... ok
test_device_context_manager (tests.unit.test_device.TestDevice.test_device_context_manager) ... ok
test_device_diff_err_message (tests.unit.test_device.TestDevice.test_device_diff_err_message) ... ok
test_device_display_xml_exception (tests.unit.test_device.TestDevice.test_device_display_xml_exception) ... ok
test_device_display_xml_rpc (tests.unit.test_device.TestDevice.test_device_display_xml_rpc) ... ok
test_device_display_xml_rpc_text (tests.unit.test_device.TestDevice.test_device_display_xml_rpc_text) ... ok
test_device_execute (tests.unit.test_device.TestDevice.test_device_execute) ... ok
test_device_execute_closed (tests.unit.test_device.TestDevice.test_device_execute_closed) ... ok
test_device_execute_index_error (tests.unit.test_device.TestDevice.test_device_execute_index_error) ... ok
test_device_execute_permission_error (tests.unit.test_device.TestDevice.test_device_execute_permission_error) ... ok
test_device_execute_rpc_error (tests.unit.test_device.TestDevice.test_device_execute_rpc_error) ... ok
test_device_execute_timeout (tests.unit.test_device.TestDevice.test_device_execute_timeout) ... ok
test_device_execute_topy (tests.unit.test_device.TestDevice.test_device_execute_topy) ... ok
test_device_execute_unknown_exception (tests.unit.test_device.TestDevice.test_device_execute_unknown_exception) ... ok
test_device_execute_unopened (tests.unit.test_device.TestDevice.test_device_execute_unopened) ... ok
test_device_execute_ValueError (tests.unit.test_device.TestDevice.test_device_execute_ValueError) ... ok
test_device_facts (tests.unit.test_device.TestDevice.test_device_facts) ... ok
test_device_facts_error (tests.unit.test_device.TestDevice.test_device_facts_error) ... ok
test_device_facts_error_exception_on_error (tests.unit.test_device.TestDevice.test_device_facts_error_exception_on_error) ... ok
test_device_facts_refresh_old_fact_style_with_keys (tests.unit.test_device.TestDevice.test_device_facts_refresh_old_fact_style_with_keys) ... ok
test_device_facts_refresh_unknown_fact_style (tests.unit.test_device.TestDevice.test_device_facts_refresh_unknown_fact_style) ... ok
test_device_get_password (tests.unit.test_device.TestDevice.test_device_get_password) ... ok
test_device_get_timeout (tests.unit.test_device.TestDevice.test_device_get_timeout) ... ok
test_device_host_invalid_backslash_space_injection (tests.unit.test_device.TestDevice.test_device_host_invalid_backslash_space_injection) ... ok
test_device_host_invalid_backtick (tests.unit.test_device.TestDevice.test_device_host_invalid_backtick) ... ok
test_device_host_invalid_colon_port_suffix (tests.unit.test_device.TestDevice.test_device_host_invalid_colon_port_suffix) ... ok
test_device_host_invalid_dollar_sign (tests.unit.test_device.TestDevice.test_device_host_invalid_dollar_sign) ... ok
test_device_host_invalid_leading_hyphen (tests.unit.test_device.TestDevice.test_device_host_invalid_leading_hyphen) ... ok
test_device_host_invalid_no_subprocess_spawned (tests.unit.test_device.TestDevice.test_device_host_invalid_no_subprocess_spawned) ... ok
test_device_host_invalid_raises_value_error_not_other (tests.unit.test_device.TestDevice.test_device_host_invalid_raises_value_error_not_other) ... ok
test_device_host_invalid_semicolon (tests.unit.test_device.TestDevice.test_device_host_invalid_semicolon) ... ok
test_device_host_invalid_whitespace_injection (tests.unit.test_device.TestDevice.test_device_host_invalid_whitespace_injection) ... ok
test_device_host_mand_param (tests.unit.test_device.TestDevice.test_device_host_mand_param) ... ok
test_device_host_none_with_sock_fd_allowed (tests.unit.test_device.TestDevice.test_device_host_none_with_sock_fd_allowed) ... ok
test_device_host_valid_fqdn (tests.unit.test_device.TestDevice.test_device_host_valid_fqdn) ... ok
test_device_host_valid_ipv4 (tests.unit.test_device.TestDevice.test_device_host_valid_ipv4) ... ok
test_device_host_valid_ipv6_bracketed (tests.unit.test_device.TestDevice.test_device_host_valid_ipv6_bracketed) ... ok
test_device_host_valid_ipv6_loopback (tests.unit.test_device.TestDevice.test_device_host_valid_ipv6_loopback) ... ok
test_device_host_valid_single_label (tests.unit.test_device.TestDevice.test_device_host_valid_single_label) ... ok
test_device_hostname (tests.unit.test_device.TestDevice.test_device_hostname) ... ok
test_device_local (tests.unit.test_device.TestDevice.test_device_local) ... ok
test_device_manages (tests.unit.test_device.TestDevice.test_device_manages) ... ok
test_device_master_gnf_is_backup (tests.unit.test_device.TestDevice.test_device_master_gnf_is_backup) ... ok
test_device_master_gnf_is_master (tests.unit.test_device.TestDevice.test_device_master_gnf_is_master) ... ok
test_device_master_is_backup (tests.unit.test_device.TestDevice.test_device_master_is_backup) ... ok
test_device_master_is_master (tests.unit.test_device.TestDevice.test_device_master_is_master) ... ok
test_device_master_is_multi_chassis_non_master1 (tests.unit.test_device.TestDevice.test_device_master_is_multi_chassis_non_master1) ... ok
test_device_master_is_multi_chassis_non_master2 (tests.unit.test_device.TestDevice.test_device_master_is_multi_chassis_non_master2) ... ok
test_device_master_is_none1 (tests.unit.test_device.TestDevice.test_device_master_is_none1) ... ok
test_device_master_is_none2 (tests.unit.test_device.TestDevice.test_device_master_is_none2) ... ok
test_device_master_is_old_facts (tests.unit.test_device.TestDevice.test_device_master_is_old_facts) ... ok
test_device_master_is_re0_only (tests.unit.test_device.TestDevice.test_device_master_is_re0_only) ... ok
test_device_master_setter (tests.unit.test_device.TestDevice.test_device_master_setter) ... ok
test_device_ofacts_exception (tests.unit.test_device.TestDevice.test_device_ofacts_exception) ... ok
test_device_old_style_facts_error_exception_on_error (tests.unit.test_device.TestDevice.test_device_old_style_facts_error_exception_on_error) ... ok
test_device_open (tests.unit.test_device.TestDevice.test_device_open) ... ok
test_device_open_normalize (tests.unit.test_device.TestDevice.test_device_open_normalize) ... ok
test_device_open_with_bind_addr (tests.unit.test_device.TestDevice.test_device_open_with_bind_addr) ... ok
test_device_open_with_hostkey_verify_False (tests.unit.test_device.TestDevice.test_device_open_with_hostkey_verify_False) ... ok
test_device_open_with_hostkey_verify_True (tests.unit.test_device.TestDevice.test_device_open_with_hostkey_verify_True) ... ok
test_device_open_with_look_for_keys_False (tests.unit.test_device.TestDevice.test_device_open_with_look_for_keys_False) ... ok
test_device_open_with_look_for_keys_True (tests.unit.test_device.TestDevice.test_device_open_with_look_for_keys_True) ... ok
test_device_open_with_proxy_command (tests.unit.test_device.TestDevice.test_device_open_with_proxy_command) ... ok
test_device_open_with_proxy_command_empty_string (tests.unit.test_device.TestDevice.test_device_open_with_proxy_command_empty_string) ... ok
test_device_other_error (tests.unit.test_device.TestDevice.test_device_other_error) ... ok
test_device_outbound (tests.unit.test_device.TestDevice.test_device_outbound) ... ok
test_device_probe_error (tests.unit.test_device.TestDevice.test_device_probe_error) ... ok
test_device_probe_timeout_exception (tests.unit.test_device.TestDevice.test_device_probe_timeout_exception) ... ok
test_device_probe_timeout_gt_zero (tests.unit.test_device.TestDevice.test_device_probe_timeout_gt_zero) ... ok
test_device_probe_timeout_zero (tests.unit.test_device.TestDevice.test_device_probe_timeout_zero) ... ok
test_device_property_logfile_close (tests.unit.test_device.TestDevice.test_device_property_logfile_close) ... ok
test_device_property_logfile_exception (tests.unit.test_device.TestDevice.test_device_property_logfile_exception) ... ok
test_device_property_logfile_isinstance (tests.unit.test_device.TestDevice.test_device_property_logfile_isinstance) ... ok
test_device_re_name_is_bsys_re0 (tests.unit.test_device.TestDevice.test_device_re_name_is_bsys_re0) ... ok
test_device_re_name_is_lcc_re1 (tests.unit.test_device.TestDevice.test_device_re_name_is_lcc_re1) ... ok
test_device_re_name_is_none1 (tests.unit.test_device.TestDevice.test_device_re_name_is_none1) ... ok
test_device_re_name_is_none2 (tests.unit.test_device.TestDevice.test_device_re_name_is_none2) ... ok
test_device_re_name_is_old_facts (tests.unit.test_device.TestDevice.test_device_re_name_is_old_facts) ... ok
test_device_re_name_is_re0 (tests.unit.test_device.TestDevice.test_device_re_name_is_re0) ... ok
test_device_re_name_is_re0_only (tests.unit.test_device.TestDevice.test_device_re_name_is_re0_only) ... ok
test_device_re_name_setter (tests.unit.test_device.TestDevice.test_device_re_name_setter) ... ok
test_device_repr (tests.unit.test_device.TestDevice.test_device_repr) ... ok
test_device_rpc_json_ex (tests.unit.test_device.TestDevice.test_device_rpc_json_ex) ... ok
test_device_rpcmeta (tests.unit.test_device.TestDevice.test_device_rpcmeta) ... ok
test_device_set_facts_exception (tests.unit.test_device.TestDevice.test_device_set_facts_exception) ... ok
test_device_set_ofacts_exception (tests.unit.test_device.TestDevice.test_device_set_ofacts_exception) ... ok
test_device_set_password (tests.unit.test_device.TestDevice.test_device_set_password) ... ok
test_device_set_timeout (tests.unit.test_device.TestDevice.test_device_set_timeout) ... ok
test_device_set_timeout_invalid_string_value (tests.unit.test_device.TestDevice.test_device_set_timeout_invalid_string_value) ... ok
test_device_set_timeout_invalid_type (tests.unit.test_device.TestDevice.test_device_set_timeout_invalid_type) ... ok
test_device_set_timeout_string (tests.unit.test_device.TestDevice.test_device_set_timeout_string) ... ok
test_device_template (tests.unit.test_device.TestDevice.test_device_template) ... ok
test_device_uptime (tests.unit.test_device.TestDevice.test_device_uptime) ... ok
test_device_user (tests.unit.test_device.TestDevice.test_device_user) ... ok
test_new_console_return (tests.unit.test_device.TestDevice.test_new_console_return) ... ok
test_temp_load_get_source_filter_false (tests.unit.test_device.Test_MyTemplateLoader.test_temp_load_get_source_filter_false) ... ok
test_temp_load_get_source_filter_true (tests.unit.test_device.Test_MyTemplateLoader.test_temp_load_get_source_filter_true) ... ok
test_warning (tests.unit.test_junos.TestJunosInit.test_warning) ... sys.version_info(major=3, minor=12, micro=0, releaselevel='final', serial=0)
ok
test_ignore_warning_false (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_false) ... ok
test_ignore_warning_list_3snf_no_match (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_list_3snf_no_match) ... ok
test_ignore_warning_list_3snf_warnings (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_list_3snf_warnings) ... /usr/local/lib/python3.12/unittest/case.py:725: FutureWarning: Truth-testing of elements was a source of confusion and will always return True in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if not expr:
ok
test_ignore_warning_list_3warn_match (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_list_3warn_match) ... ok
test_ignore_warning_list_3warn_no_match (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_list_3warn_no_match) ... ok
test_ignore_warning_missing (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_missing) ... ok
test_ignore_warning_string_1snf_warning_1err (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_string_1snf_warning_1err) ... ok
test_ignore_warning_string_3snf_no_match (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_string_3snf_no_match) ... ok
test_ignore_warning_string_3snf_warnings (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_string_3snf_warnings) ... ok
test_ignore_warning_true_3snf_warnings (tests.unit.test_decorators.Test_Decorators.test_ignore_warning_true_3snf_warnings) ... ok
test_normalize_false_false (tests.unit.test_decorators.Test_Decorators.test_normalize_false_false) ... ok
test_normalize_false_true (tests.unit.test_decorators.Test_Decorators.test_normalize_false_true) ... ok
test_normalize_false_true_except (tests.unit.test_decorators.Test_Decorators.test_normalize_false_true_except) ... ok
test_normalize_true_false (tests.unit.test_decorators.Test_Decorators.test_normalize_true_false) ... ok
test_normalize_true_false_except (tests.unit.test_decorators.Test_Decorators.test_normalize_true_false_except) ... ok
test_normalize_true_true (tests.unit.test_decorators.Test_Decorators.test_normalize_true_true) ... ok
test_normalize_true_true_except (tests.unit.test_decorators.Test_Decorators.test_normalize_true_true_except) ... ok
test_timeout (tests.unit.test_decorators.Test_Decorators.test_timeout) ... ok
test_timeout_except (tests.unit.test_decorators.Test_Decorators.test_timeout_except) ... ok
test_get_config_filter_xml_model (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_config_filter_xml_model) ... ok
test_get_config_filter_xml_string (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_config_filter_xml_string) ... ok
test_get_config_filter_xml_string_xml (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_config_filter_xml_string_xml) ... ok
test_get_config_format_json_JSONLoadError_with_line (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_config_format_json_JSONLoadError_with_line) ... ok
test_get_rpc (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_rpc) ... ok
test_get_rpc_ignore_warning_bool (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_rpc_ignore_warning_bool) ... ok
test_get_rpc_ignore_warning_list (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_rpc_ignore_warning_list) ... ok
test_get_rpc_ignore_warning_str (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_get_rpc_ignore_warning_str) ... ok
test_model_true (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_model_true) ... ok
test_rpcmeta_constructor (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_constructor) ... ok
test_rpcmeta_exec_rpc_format_json_14_2 (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_format_json_14_2) ... ok
test_rpcmeta_exec_rpc_format_json_gt_14_2 (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_format_json_gt_14_2) ... ok
test_rpcmeta_exec_rpc_format_json_lt_14_2 (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_format_json_lt_14_2) ... ok
test_rpcmeta_exec_rpc_kvargs_bool_False (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_kvargs_bool_False) ... ok
test_rpcmeta_exec_rpc_kvargs_bool_true (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_kvargs_bool_true) ... ok
test_rpcmeta_exec_rpc_kvargs_dict (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_kvargs_dict) ... ok
test_rpcmeta_exec_rpc_kvargs_list_with_dict (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_kvargs_list_with_dict) ... ok
test_rpcmeta_exec_rpc_kvargs_tuple (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_kvargs_tuple) ... ok
test_rpcmeta_exec_rpc_normalize (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_normalize) ... ok
test_rpcmeta_exec_rpc_vargs (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_exec_rpc_vargs) ... ok
test_rpcmeta_get_config (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_get_config) ... ok
test_rpcmeta_load_config (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_load_config) ... ok
test_rpcmeta_load_config_option_action (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_load_config_option_action) ... ok
test_rpcmeta_load_config_with_configuration_tag (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_load_config_with_configuration_tag) ... ok
test_rpcmeta_option_format (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_option_format) ... ok
test_rpcmeta_option_format_json (tests.unit.test_rpcmeta.Test_RpcMetaExec.test_rpcmeta_option_format_json) ... ok
test_generate_sax_parser_fields_with_diff_child_xpaths (tests.unit.factory.test_optable.TestFactoryOpTable.test_generate_sax_parser_fields_with_diff_child_xpaths) ... ok
test_generate_sax_parser_fields_with_many_slash (tests.unit.factory.test_optable.TestFactoryOpTable.test_generate_sax_parser_fields_with_many_slash) ... ok
test_generate_sax_parser_item_with_many_slash (tests.unit.factory.test_optable.TestFactoryOpTable.test_generate_sax_parser_item_with_many_slash) ... ok
test_generate_sax_parser_same_parents_with_diff_fields (tests.unit.factory.test_optable.TestFactoryOpTable.test_generate_sax_parser_same_parents_with_diff_fields) ... ok
test_key_and_item_pipe_delim_with_Null_use_Null (tests.unit.factory.test_optable.TestFactoryOpTable.test_key_and_item_pipe_delim_with_Null_use_Null) ... ok
test_key_pipe_delim_with_Null (tests.unit.factory.test_optable.TestFactoryOpTable.test_key_pipe_delim_with_Null) ... ok
test_key_pipe_delim_with_Null_use_Null (tests.unit.factory.test_optable.TestFactoryOpTable.test_key_pipe_delim_with_Null_use_Null) ... ok
test_optable_get (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_get) ... ok
test_optable_get_key (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_get_key) ... ok
test_optable_path (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_path) ... ok
test_optable_view_get (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_view_get) ... ok
test_optable_view_get_astype_bool (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_view_get_astype_bool) ... ok
test_optable_view_get_astype_bool_regex (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_view_get_astype_bool_regex) ... ok
test_optable_view_get_unknown_field (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_view_get_unknown_field) ... ok
test_optable_xml (tests.unit.factory.test_optable.TestFactoryOpTable.test_optable_xml) ... ok
test_viewfields_astype (tests.unit.factory.test_view_fields.TestFactoryViewFields.test_viewfields_astype) ... ok
test_viewfields_flag (tests.unit.factory.test_view_fields.TestFactoryViewFields.test_viewfields_flag) ... ok
test_viewfields_int (tests.unit.factory.test_view_fields.TestFactoryViewFields.test_viewfields_int) ... ok
test_viewfields_string (tests.unit.factory.test_view_fields.TestFactoryViewFields.test_viewfields_string) ... ok
test_viewfields_table (tests.unit.factory.test_view_fields.TestFactoryViewFields.test_viewfields_table) ... ok
test_view___getattr___munch (tests.unit.factory.test_view.TestFactoryView.test_view___getattr___munch) ... ok
test_view___getattr___munch_tag (tests.unit.factory.test_view.TestFactoryView.test_view___getattr___munch_tag) ... ok
test_view___getattr___raise_RuntimeError (tests.unit.factory.test_view.TestFactoryView.test_view___getattr___raise_RuntimeError) ... ok
test_view___getattr__table_item (tests.unit.factory.test_view.TestFactoryView.test_view___getattr__table_item) ... ok
test_view___getattr__wrong_attr (tests.unit.factory.test_view.TestFactoryView.test_view___getattr__wrong_attr) ... ok
test_view_asview (tests.unit.factory.test_view.TestFactoryView.test_view_asview) ... ok
test_view_d (tests.unit.factory.test_view.TestFactoryView.test_view_d) ... ok
test_view_init (tests.unit.factory.test_view.TestFactoryView.test_view_init) ... ok
test_view_init_lxml_exception (tests.unit.factory.test_view.TestFactoryView.test_view_init_lxml_exception) ... ok
test_view_init_multi_exception (tests.unit.factory.test_view.TestFactoryView.test_view_init_multi_exception) ... ok
test_view_name (tests.unit.factory.test_view.TestFactoryView.test_view_name) ... ok
test_view_name_xpath_composite (tests.unit.factory.test_view.TestFactoryView.test_view_name_xpath_composite) ... ok
test_view_name_xpath_none (tests.unit.factory.test_view.TestFactoryView.test_view_name_xpath_none) ... ok
test_view_refresh_can_refresh_false (tests.unit.factory.test_view.TestFactoryView.test_view_refresh_can_refresh_false) ... ok
test_view_refresh_can_refresh_true (tests.unit.factory.test_view.TestFactoryView.test_view_refresh_can_refresh_true) ... ok
test_view_repr (tests.unit.factory.test_view.TestFactoryView.test_view_repr) ... ok
test_view_updater_all_false (tests.unit.factory.test_view.TestFactoryView.test_view_updater_all_false) ... ok
test_view_updater_context (tests.unit.factory.test_view.TestFactoryView.test_view_updater_context) ... ok
test_view_updater_fields_true (tests.unit.factory.test_view.TestFactoryView.test_view_updater_fields_true) ... ok
test_view_updater_groups_true (tests.unit.factory.test_view.TestFactoryView.test_view_updater_groups_true) ... ok
test_view_updater_with_groups_all_false (tests.unit.factory.test_view.TestFactoryView.test_view_updater_with_groups_all_false) ... ok
test_view_updater_with_groups_all_true (tests.unit.factory.test_view.TestFactoryView.test_view_updater_with_groups_all_true) ... ok
test_cfgtable_dict_set (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_dict_set) ... ok
test_cfgtable_dot_none_RuntimeError (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_dot_none_RuntimeError) ... ok
test_cfgtable_enum_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_enum_error) ... ok
test_cfgtable_enum_value_str_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_enum_value_str_error) ... ok
test_cfgtable_enum_value_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_enum_value_type_error) ... ok
test_cfgtable_field_value_xpath (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_field_value_xpath) ... ok
test_cfgtable_get (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get) ... ok
test_cfgtable_get_caller_provided_kvargs (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get_caller_provided_kvargs) ... ok
test_cfgtable_get_fields (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get_fields) ... ok
test_cfgtable_get_group (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get_group) ... ok
test_cfgtable_get_namesonly (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get_namesonly) ... ok
test_cfgtable_get_options (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_get_options) ... ok
test_cfgtable_int_min_max_value_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_int_min_max_value_error) ... ok
test_cfgtable_invalid_field_dict_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_field_dict_error) ... ok
test_cfgtable_invalid_field_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_field_error) ... ok
test_cfgtable_invalid_field_value_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_field_value_error) ... ok
test_cfgtable_invalid_key_field_not_defined_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_key_field_not_defined_error) ... ok
test_cfgtable_invalid_key_field_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_key_field_type_error) ... ok
test_cfgtable_invalid_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_type_error) ... ok
test_cfgtable_invalid_view_not_defined_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_invalid_view_not_defined_type_error) ... ok
test_cfgtable_junos (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_junos) ... ok
test_cfgtable_junos1 (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_junos1) ... ok
test_cfgtable_junos2 (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_junos2) ... ok
test_cfgtable_key_value_none (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_key_value_none) ... ok
test_cfgtable_load (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_load) ... ok
test_cfgtable_load_append_not_call_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_load_append_not_call_error) ... ok
test_cfgtable_path (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_path) ... ok
test_cfgtable_set (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set) ... ok
test_cfgtable_set_append_not_call_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set_append_not_call_error) ... ok
test_cfgtable_set_bool (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set_bool) ... ok
test_cfgtable_set_group (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set_group) ... ok
test_cfgtable_set_inactive (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set_inactive) ... ok
test_cfgtable_set_no_key_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_set_no_key_error) ... ok
test_cfgtable_str_key_field (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_str_key_field) ... ok
test_cfgtable_str_min_max_value_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_str_min_max_value_error) ... ok
test_cfgtable_table_options (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_table_options) ... ok
test_cfgtable_unfreeze (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_unfreeze) ... ok
test_cfgtable_unsupported_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_unsupported_type_error) ... ok
test_cfgtable_user_defined_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_user_defined_type_error) ... ok
test_cfgtable_with_block (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_with_block) ... ok
test_cfgtable_wrong_type_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_wrong_type_error) ... ok
test_cfgtable_xml (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_cfgtable_xml) ... ok
test_optable_get_key_required_error (tests.unit.factory.test_cfgtable.TestFactoryCfgTable.test_optable_get_key_required_error) ... ok
test_config_constructor (tests.unit.factory.test_table.TestFactoryTable.test_config_constructor) ... ok
test_keys__keys_composite (tests.unit.factory.test_table.TestFactoryTable.test_keys__keys_composite) ... ok
test_keys__keys_pipe (tests.unit.factory.test_table.TestFactoryTable.test_keys__keys_pipe) ... ok
test_keys_RuntimeError (tests.unit.factory.test_table.TestFactoryTable.test_keys_RuntimeError) ... ok
test_table__contains__ (tests.unit.factory.test_table.TestFactoryTable.test_table__contains__) ... ok
test_table__getitem__ (tests.unit.factory.test_table.TestFactoryTable.test_table__getitem__) ... ok
test_table__getitem__slice (tests.unit.factory.test_table.TestFactoryTable.test_table__getitem__slice) ... ok
test_table__getitem__tuple (tests.unit.factory.test_table.TestFactoryTable.test_table__getitem__tuple) ... ok
test_table_get_keys_values (tests.unit.factory.test_table.TestFactoryTable.test_table_get_keys_values) ... ok
test_table_get_return_none (tests.unit.factory.test_table.TestFactoryTable.test_table_get_return_none) ... ok
test_table_get_RuntimeError (tests.unit.factory.test_table.TestFactoryTable.test_table_get_RuntimeError) ... ok
test_table_hostname (tests.unit.factory.test_table.TestFactoryTable.test_table_hostname) ... ok
test_table_is_container (tests.unit.factory.test_table.TestFactoryTable.test_table_is_container) ... ok
test_table_items (tests.unit.factory.test_table.TestFactoryTable.test_table_items) ... ok
test_table_repr_xml_none (tests.unit.factory.test_table.TestFactoryTable.test_table_repr_xml_none) ... ok
test_table_repr_xml_not_none (tests.unit.factory.test_table.TestFactoryTable.test_table_repr_xml_not_none) ... ok
test_table_savexml (tests.unit.factory.test_table.TestFactoryTable.test_table_savexml) ... ok
test_table_view_setter_ValueError (tests.unit.factory.test_table.TestFactoryTable.test_table_view_setter_ValueError) ... ok
test_FactoryLoader__add_dictfield_RuntimeError (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__add_dictfield_RuntimeError) ... ok
test_FactoryLoader__add_dictfield_ValueError (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__add_dictfield_ValueError) ... ok
test_FactoryLoader__build_cfgtable (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__build_cfgtable) ... ok
test_FactoryLoader__build_optable (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__build_optable) ... ok
test_FactoryLoader__build_view (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__build_view) ... ok
test_FactoryLoader__fieldfunc_False (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_False) ... ok
test_FactoryLoader__fieldfunc_False_fail (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_False_fail) ... ok
test_FactoryLoader__fieldfunc_False_regex (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_False_regex) ... ok
test_FactoryLoader__fieldfunc_False_regex_fail (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_False_regex_fail) ... ok
test_FactoryLoader__fieldfunc_True (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_True) ... ok
test_FactoryLoader__fieldfunc_True_fail (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_True_fail) ... ok
test_FactoryLoader__fieldfunc_True_regex (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_True_regex) ... ok
test_FactoryLoader__fieldfunc_True_regex_fail (tests.unit.factory.test_factory_loader.TestFactoryLoader.test_FactoryLoader__fieldfunc_True_regex_fail) ... ok
test_json_rpc (tests.unit.factory.test_to_json.TestToJson.test_json_rpc) ... ok
test_pyez_encoder_default (tests.unit.factory.test_to_json.TestToJson.test_pyez_encoder_default) ... ok
test_table_encoder_default (tests.unit.factory.test_to_json.TestToJson.test_table_encoder_default) ... ok
test_table_json (tests.unit.factory.test_to_json.TestToJson.test_table_json) ... ok
test_view_encoder_default (tests.unit.factory.test_to_json.TestToJson.test_view_encoder_default) ... ok
test_view_json (tests.unit.factory.test_to_json.TestToJson.test_view_json) ... ok
test_factory_cls_cfgtable (tests.unit.factory.test_factory_cls.TestFactoryCls.test_factory_cls_cfgtable) ... ok
test_factory_cls_factorytable (tests.unit.factory.test_factory_cls.TestFactoryCls.test_factory_cls_factorytable) ... ok
test_factory_cls_factoryview (tests.unit.factory.test_factory_cls.TestFactoryCls.test_factory_cls_factoryview) ... ok
test_factory_cls_optable (tests.unit.factory.test_factory_cls.TestFactoryCls.test_factory_cls_optable) ... ok
test__contains__ (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test__contains__) ... ok
test_cmdtable_iter (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_cmdtable_iter) ... ok
test_cmdview_properties (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_cmdview_properties) ... ok
test_exists (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_exists) ... ok
test_field_eval (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_field_eval) ... ok
test_fpcmemory_multi_key_columns (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_fpcmemory_multi_key_columns) ... ok
test_get_api_params (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_get_api_params) ... ok
test_item_regex_pq3_pci (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_item_regex_pq3_pci) ... ok
test_item_with_fields_delimiter (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_item_with_fields_delimiter) ... ok
test_new_line_in_data (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_new_line_in_data) ... ok
test_pci_errs_multi_key_regex (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_pci_errs_multi_key_regex) ... ok
test_regex_with_fields (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_regex_with_fields) ... ok
test_request_pfe_rpc_not_avialable (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_request_pfe_rpc_not_avialable) ... ok
test_table_eval_expression (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_eval_expression) ... ok
test_table_eval_expression_exception (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_eval_expression_exception) ... ERROR:jnpr.junos.factory.state_machine:eval expression for 'total_interrupt' failed due to name 'xxxx' is not defined
ok
test_table_eval_with_filters (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_eval_with_filters) ... ok
test_table_item_group_key_mismatch (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_item_group_key_mismatch) ... ok
test_table_path_option (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_path_option) ... ok
test_table_with_item_regex (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_with_item_regex) ... ok
test_table_with_item_without_view (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_table_with_item_without_view) ... ok
test_textfsm_table (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_textfsm_table) ... ok
test_textfsm_table_mutli_key (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_textfsm_table_mutli_key) ... ok
test_title_in_view (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_title_in_view) ... ok
test_title_without_view (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_title_without_view) ... ok
test_unstructured_cmerror (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_cmerror) ... ok
test_unstructured_cmerror_multiline_header (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_cmerror_multiline_header) ... ok
test_unstructured_icmpstats_nested (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_icmpstats_nested) ... ok
test_unstructured_ithrottle_key_args (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_ithrottle_key_args) ... ok
test_unstructured_linkstats (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_linkstats) ... ok
test_unstructured_mtip_cge_regex (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_mtip_cge_regex) ... ok
test_unstructured_sysctl_oneline_op (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_sysctl_oneline_op) ... ok
test_unstructured_ttpstatistics (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_unstructured_ttpstatistics) ... ok
test_valueerror_with_no_target (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_valueerror_with_no_target) ... ok
test_view_setter_raise_exception (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_view_setter_raise_exception) ... ok
test_view_variable (tests.unit.factory.test_cmdtable.TestFactoryCMDTable.test_view_variable) ... ok
test_converts_integer_item (tests.unit.factory.test_state_machine.TestConvertToDataType.test_converts_integer_item) ... ok
test_converts_mixed_items (tests.unit.factory.test_state_machine.TestConvertToDataType.test_converts_mixed_items) ... ok
test_converts_string_items (tests.unit.factory.test_state_machine.TestConvertToDataType.test_converts_string_items) ... ok
test_data_type_float (tests.unit.factory.test_state_machine.TestDataType.test_data_type_float) ... ok
test_data_type_hex_string (tests.unit.factory.test_state_machine.TestDataType.test_data_type_hex_string) ... ok
test_data_type_integer (tests.unit.factory.test_state_machine.TestDataType.test_data_type_integer) ... ok
test_data_type_plain_string (tests.unit.factory.test_state_machine.TestDataType.test_data_type_plain_string) ... ok
test_numbers_no_deprecation_warning (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_no_deprecation_warning)
Ensure no PyparsingDeprecationWarning is raised when using the identifier. ... ok
test_numbers_parse_action_joins_parts (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_parse_action_joins_parts) ... ok
test_numbers_parse_action_single_token (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_parse_action_single_token) ... ok
test_numbers_parses_float (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_parses_float) ... ok
test_numbers_parses_integer (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_parses_integer) ... ok
test_numbers_rejects_non_numeric (tests.unit.factory.test_state_machine.TestIdentifiersNumbers.test_numbers_rejects_non_numeric) ... ok
test_words_no_deprecation_warning (tests.unit.factory.test_state_machine.TestIdentifiersWords.test_words_no_deprecation_warning)
Ensure no PyparsingDeprecationWarning is raised when using the identifier. ... ok
test_words_parse_action_joins_with_space (tests.unit.factory.test_state_machine.TestIdentifiersWords.test_words_parse_action_joins_with_space) ... ok
test_words_parses_multiple_words (tests.unit.factory.test_state_machine.TestIdentifiersWords.test_words_parses_multiple_words) ... ok
test_words_parses_single_word (tests.unit.factory.test_state_machine.TestIdentifiersWords.test_words_parses_single_word) ... ok
test_startshell_close (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_close) ... ok
test_startshell_context (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_context) ... ok
test_startshell_open_with_bourne_shell (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_open_with_bourne_shell) ... ok
test_startshell_open_with_junos_term (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_open_with_junos_term) ... ok
test_startshell_open_with_shell_term (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_open_with_shell_term) ... ok
test_startshell_run (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_run) ... ok
test_startshell_run_regex (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_run_regex) ... ok
test_startshell_run_this_None (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_run_this_None) ... ok
test_startshell_wait_for (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_wait_for) ... ok
test_startshell_wait_for_regex (tests.unit.utils.test_start_shell.TestStartShell.test_startshell_wait_for_regex) ... ok
test__enter__batch_exception_RpcError (tests.unit.utils.test_config.TestConfig.test__enter__batch_exception_RpcError) ... ok
test__enter__batch_exception_RpcTimeoutError (tests.unit.utils.test_config.TestConfig.test__enter__batch_exception_RpcTimeoutError) ... ok
test__enter__dyanamic_exception_RpcError (tests.unit.utils.test_config.TestConfig.test__enter__dyanamic_exception_RpcError) ... ok
test__enter__private_exception_RpcError (tests.unit.utils.test_config.TestConfig.test__enter__private_exception_RpcError) ... ok
test__enter__private_exception_RpcTimeoutError (tests.unit.utils.test_config.TestConfig.test__enter__private_exception_RpcTimeoutError) ... ok
test_commit_check (tests.unit.utils.test_config.TestConfig.test_commit_check) ... ok
test_commit_check_exception (tests.unit.utils.test_config.TestConfig.test_commit_check_exception) ... ok
test_commit_check_RpcTimeoutError (tests.unit.utils.test_config.TestConfig.test_commit_check_RpcTimeoutError) ... ok
test_commit_configuration_multi_rpc_error (tests.unit.utils.test_config.TestConfig.test_commit_configuration_multi_rpc_error) ... ok
test_commit_RpcTimeoutError (tests.unit.utils.test_config.TestConfig.test_commit_RpcTimeoutError) ... ok
test_config_commit_check_exception_RpcError (tests.unit.utils.test_config.TestConfig.test_config_commit_check_exception_RpcError) ... ok
test_config_commit_combination (tests.unit.utils.test_config.TestConfig.test_config_commit_combination) ... ok
test_config_commit_comment (tests.unit.utils.test_config.TestConfig.test_config_commit_comment) ... ok
test_config_commit_confirm (tests.unit.utils.test_config.TestConfig.test_config_commit_confirm) ... ok
test_config_commit_detail (tests.unit.utils.test_config.TestConfig.test_config_commit_detail) ... ok
test_config_commit_exception (tests.unit.utils.test_config.TestConfig.test_config_commit_exception) ... ok
test_config_commit_exception_RpcError (tests.unit.utils.test_config.TestConfig.test_config_commit_exception_RpcError) ... ok
test_config_commit_force_sync (tests.unit.utils.test_config.TestConfig.test_config_commit_force_sync) ... ok
test_config_commit_full (tests.unit.utils.test_config.TestConfig.test_config_commit_full) ... ok
test_config_commit_sync (tests.unit.utils.test_config.TestConfig.test_config_commit_sync) ... ok
test_config_commit_timeout (tests.unit.utils.test_config.TestConfig.test_config_commit_timeout) ... ok
test_config_commit_xml_exception (tests.unit.utils.test_config.TestConfig.test_config_commit_xml_exception) ... ok
test_config_confirm_true (tests.unit.utils.test_config.TestConfig.test_config_confirm_true) ... ok
test_config_constructor (tests.unit.utils.test_config.TestConfig.test_config_constructor) ... ok
test_config_diff (tests.unit.utils.test_config.TestConfig.test_config_diff) ... ok
test_config_diff_exception (tests.unit.utils.test_config.TestConfig.test_config_diff_exception) ... ok
test_config_diff_exception_severity_warning (tests.unit.utils.test_config.TestConfig.test_config_diff_exception_severity_warning) ... ok
test_config_diff_exception_severity_warning_still_raise (tests.unit.utils.test_config.TestConfig.test_config_diff_exception_severity_warning_still_raise) ... ok
test_config_diff_rpc_timeout (tests.unit.utils.test_config.TestConfig.test_config_diff_rpc_timeout) ... ok
test_config_diff_use_fast_diff (tests.unit.utils.test_config.TestConfig.test_config_diff_use_fast_diff) ... ok
test_config_diff_use_fast_diff_rb_id_gt_0 (tests.unit.utils.test_config.TestConfig.test_config_diff_use_fast_diff_rb_id_gt_0) ... ok
test_config_load (tests.unit.utils.test_config.TestConfig.test_config_load) ... ok
test_config_load_len_with_format_set (tests.unit.utils.test_config.TestConfig.test_config_load_len_with_format_set) ... ok
test_config_load_len_with_format_text (tests.unit.utils.test_config.TestConfig.test_config_load_len_with_format_text) ... ok
test_config_load_len_with_format_xml (tests.unit.utils.test_config.TestConfig.test_config_load_len_with_format_xml) ... ok
test_config_load_lformat_byext_ValueError (tests.unit.utils.test_config.TestConfig.test_config_load_lformat_byext_ValueError) ... ok
test_config_load_lset_format_ValueError (tests.unit.utils.test_config.TestConfig.test_config_load_lset_format_ValueError) ... ok
test_config_load_lset_from_rexp_conf (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_conf) ... ok
test_config_load_lset_from_rexp_conf_replace_tag (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_conf_replace_tag) ... ok
test_config_load_lset_from_rexp_error (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_error) ... ok
test_config_load_lset_from_rexp_insert (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_insert) ... ok
test_config_load_lset_from_rexp_json (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_json) ... ok
test_config_load_lset_from_rexp_set (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set) ... ok
test_config_load_lset_from_rexp_set_activate (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_activate) ... ok
test_config_load_lset_from_rexp_set_annotate (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_annotate) ... ok
test_config_load_lset_from_rexp_set_copy (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_copy) ... ok
test_config_load_lset_from_rexp_set_deactivate (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_deactivate) ... ok
test_config_load_lset_from_rexp_set_delete (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_delete) ... ok
test_config_load_lset_from_rexp_set_protect (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_protect) ... ok
test_config_load_lset_from_rexp_set_rename (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_rename) ... ok
test_config_load_lset_from_rexp_set_unprotect (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_set_unprotect) ... ok
test_config_load_lset_from_rexp_xml (tests.unit.utils.test_config.TestConfig.test_config_load_lset_from_rexp_xml) ... ok
test_config_load_path_set (tests.unit.utils.test_config.TestConfig.test_config_load_path_set) ... ok
test_config_load_path_text (tests.unit.utils.test_config.TestConfig.test_config_load_path_text) ... ok
test_config_load_path_xml (tests.unit.utils.test_config.TestConfig.test_config_load_path_xml) ... ok
test_config_load_template (tests.unit.utils.test_config.TestConfig.test_config_load_template) ... ok
test_config_load_template_path (tests.unit.utils.test_config.TestConfig.test_config_load_template_path) ... ok
test_config_load_try_load_rpcerror (tests.unit.utils.test_config.TestConfig.test_config_load_try_load_rpcerror) ... ok
test_config_load_try_load_rpctimeouterror (tests.unit.utils.test_config.TestConfig.test_config_load_try_load_rpctimeouterror) ... ok
test_config_load_update (tests.unit.utils.test_config.TestConfig.test_config_load_update) ... ok
test_config_load_update_merge_overwrite (tests.unit.utils.test_config.TestConfig.test_config_load_update_merge_overwrite) ... ok
test_config_load_url (tests.unit.utils.test_config.TestConfig.test_config_load_url) ... ok
test_config_load_vargs_len (tests.unit.utils.test_config.TestConfig.test_config_load_vargs_len) ... ok
test_config_load_with_format_json (tests.unit.utils.test_config.TestConfig.test_config_load_with_format_json) ... ok
test_config_load_with_format_json_from_file_ext (tests.unit.utils.test_config.TestConfig.test_config_load_with_format_json_from_file_ext) ... ok
test_config_lock (tests.unit.utils.test_config.TestConfig.test_config_lock) ... ok
test_config_lock_ConnectClosedError (tests.unit.utils.test_config.TestConfig.test_config_lock_ConnectClosedError) ... ok
test_config_lock_exception (tests.unit.utils.test_config.TestConfig.test_config_lock_exception) ... ok
test_config_lock_LockError (tests.unit.utils.test_config.TestConfig.test_config_lock_LockError) ... ok
test_config_mode_batch (tests.unit.utils.test_config.TestConfig.test_config_mode_batch) ... ok
test_config_mode_batch_open_configuration_ex (tests.unit.utils.test_config.TestConfig.test_config_mode_batch_open_configuration_ex) ... ok
test_config_mode_close_configuration_ex (tests.unit.utils.test_config.TestConfig.test_config_mode_close_configuration_ex) ... ok
test_config_mode_dynamic (tests.unit.utils.test_config.TestConfig.test_config_mode_dynamic) ... ok
test_config_mode_ephemeral_default (tests.unit.utils.test_config.TestConfig.test_config_mode_ephemeral_default) ... ok
test_config_mode_ephemeral_instance (tests.unit.utils.test_config.TestConfig.test_config_mode_ephemeral_instance) ... ok
test_config_mode_exclusive (tests.unit.utils.test_config.TestConfig.test_config_mode_exclusive) ... ok
test_config_mode_private (tests.unit.utils.test_config.TestConfig.test_config_mode_private) ... ok
test_config_mode_private_open_configuration_ex (tests.unit.utils.test_config.TestConfig.test_config_mode_private_open_configuration_ex) ... ok
test_config_mode_undefined (tests.unit.utils.test_config.TestConfig.test_config_mode_undefined) ... ok
test_config_pdiff (tests.unit.utils.test_config.TestConfig.test_config_pdiff) ... Stuff
ok
test_config_rollback (tests.unit.utils.test_config.TestConfig.test_config_rollback) ... ok
test_config_rollback_exception (tests.unit.utils.test_config.TestConfig.test_config_rollback_exception) ... ok
test_config_try_load_exception (tests.unit.utils.test_config.TestConfig.test_config_try_load_exception) ... ok
test_config_unlock (tests.unit.utils.test_config.TestConfig.test_config_unlock) ... ok
test_config_unlock_ConnectClosedError (tests.unit.utils.test_config.TestConfig.test_config_unlock_ConnectClosedError) ... ok
test_config_unlock_exception (tests.unit.utils.test_config.TestConfig.test_config_unlock_exception) ... ok
test_config_unlock_LockError (tests.unit.utils.test_config.TestConfig.test_config_unlock_LockError) ... ok
test_config_unsupported_kwargs (tests.unit.utils.test_config.TestConfig.test_config_unsupported_kwargs) ... ok
test_load_config_patch (tests.unit.utils.test_config.TestConfig.test_load_config_patch) ... ok
test_load_config_text (tests.unit.utils.test_config.TestConfig.test_load_config_text) ... ok
test_load_merge_true (tests.unit.utils.test_config.TestConfig.test_load_merge_true) ... ok
test_rescue_action_delete (tests.unit.utils.test_config.TestConfig.test_rescue_action_delete) ... ok
test_rescue_action_get (tests.unit.utils.test_config.TestConfig.test_rescue_action_get) ... ok
test_rescue_action_get_exception (tests.unit.utils.test_config.TestConfig.test_rescue_action_get_exception) ... ok
test_rescue_action_reload (tests.unit.utils.test_config.TestConfig.test_rescue_action_reload) ... ok
test_rescue_action_reload_exception (tests.unit.utils.test_config.TestConfig.test_rescue_action_reload_exception) ... ok
test_rescue_action_save (tests.unit.utils.test_config.TestConfig.test_rescue_action_save) ... ok
test_rescue_action_unsupported_action (tests.unit.utils.test_config.TestConfig.test_rescue_action_unsupported_action) ... ok
test_cat (tests.unit.utils.test_fs.TestFS.test_cat) ... ok
test_cat_wrong_path_return_none (tests.unit.utils.test_fs.TestFS.test_cat_wrong_path_return_none) ... ok
test_checksum_return_none (tests.unit.utils.test_fs.TestFS.test_checksum_return_none) ... ok
test_checksum_return_rsp (tests.unit.utils.test_fs.TestFS.test_checksum_return_rsp) ... ok
test_checksum_unknown_calc (tests.unit.utils.test_fs.TestFS.test_checksum_unknown_calc) ... ok
test_copy_return_false (tests.unit.utils.test_fs.TestFS.test_copy_return_false) ... ok
test_copy_return_true (tests.unit.utils.test_fs.TestFS.test_copy_return_true) ... ok
test_copy_routing_instance_return_true (tests.unit.utils.test_fs.TestFS.test_copy_routing_instance_return_true) ... ok
test_copy_source_address_return_true (tests.unit.utils.test_fs.TestFS.test_copy_source_address_return_true) ... ok
test_cwd (tests.unit.utils.test_fs.TestFS.test_cwd) ... ok
test_directory_usage (tests.unit.utils.test_fs.TestFS.test_directory_usage) ... ok
test_directory_usage_error (tests.unit.utils.test_fs.TestFS.test_directory_usage_error) ... ok
test_directory_usage_no_dir_name (tests.unit.utils.test_fs.TestFS.test_directory_usage_no_dir_name) ... ok
test_directory_usage_no_directory (tests.unit.utils.test_fs.TestFS.test_directory_usage_no_directory) ... ok
test_ls_brief_true (tests.unit.utils.test_fs.TestFS.test_ls_brief_true) ... ok
test_ls_calling___decode_dir (tests.unit.utils.test_fs.TestFS.test_ls_calling___decode_dir) ... ok
test_ls_calling___decode_dir_type_symbolic_link (tests.unit.utils.test_fs.TestFS.test_ls_calling___decode_dir_type_symbolic_link) ... ok
test_ls_calling___decode_file (tests.unit.utils.test_fs.TestFS.test_ls_calling___decode_file) ... ok
test_ls_link_path_false (tests.unit.utils.test_fs.TestFS.test_ls_link_path_false) ... ok
test_ls_return_none (tests.unit.utils.test_fs.TestFS.test_ls_return_none) ... ok
test_mkdir (tests.unit.utils.test_fs.TestFS.test_mkdir) ... 
ok
test_move_return_false (tests.unit.utils.test_fs.TestFS.test_move_return_false) ... ok
test_move_return_true (tests.unit.utils.test_fs.TestFS.test_move_return_true) ... ok
test_pwd (tests.unit.utils.test_fs.TestFS.test_pwd) ... ok
test_rm_return_false (tests.unit.utils.test_fs.TestFS.test_rm_return_false) ... ok
test_rm_return_true (tests.unit.utils.test_fs.TestFS.test_rm_return_true) ... ok
test_rmdir (tests.unit.utils.test_fs.TestFS.test_rmdir) ... 
ok
test_stat_calling___decode_dir (tests.unit.utils.test_fs.TestFS.test_stat_calling___decode_dir) ... ok
test_stat_calling___decode_file (tests.unit.utils.test_fs.TestFS.test_stat_calling___decode_file) ... ok
test_stat_return_none (tests.unit.utils.test_fs.TestFS.test_stat_return_none) ... ok
test_storage_cleanup (tests.unit.utils.test_fs.TestFS.test_storage_cleanup) ... ok
test_storage_cleanup_check (tests.unit.utils.test_fs.TestFS.test_storage_cleanup_check) ... ok
test_storage_usage (tests.unit.utils.test_fs.TestFS.test_storage_usage) ... ok
test_storage_usage_linux (tests.unit.utils.test_fs.TestFS.test_storage_usage_linux) ... ok
test_symlink (tests.unit.utils.test_fs.TestFS.test_symlink) ... 
ok
test_tgz_return_error (tests.unit.utils.test_fs.TestFS.test_tgz_return_error) ... ok
test_tgz_return_true (tests.unit.utils.test_fs.TestFS.test_tgz_return_true) ... ok
test_check_satellite_alive_all_down (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_all_down) ... ok
test_check_satellite_alive_multiple_up (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_multiple_up) ... ok
test_check_satellite_alive_not_found (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_not_found) ... ok
test_check_satellite_alive_one_down (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_one_down) ... ok
test_check_satellite_alive_rpc_error (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_rpc_error) ... ok
test_check_satellite_alive_single_up (tests.unit.utils.test_sw.TestSW.test_check_satellite_alive_single_up) ... ok
test_sw_check_pending_install (tests.unit.utils.test_sw.TestSW.test_sw_check_pending_install) ... ok
test_sw_check_pending_install_RpcError_continue (tests.unit.utils.test_sw.TestSW.test_sw_check_pending_install_RpcError_continue) ... ok
test_sw_constructor_multi_re (tests.unit.utils.test_sw.TestSW.test_sw_constructor_multi_re) ... ok
test_sw_constructor_multi_vc (tests.unit.utils.test_sw.TestSW.test_sw_constructor_multi_vc) ... ok
test_sw_halt (tests.unit.utils.test_sw.TestSW.test_sw_halt) ... ok
test_sw_halt_exception (tests.unit.utils.test_sw.TestSW.test_sw_halt_exception) ... ok
test_sw_halt_multi_re_vc (tests.unit.utils.test_sw.TestSW.test_sw_halt_multi_re_vc) ... ok
test_sw_hashfile (tests.unit.utils.test_sw.TestSW.test_sw_hashfile) ... ok
test_sw_install_issu (tests.unit.utils.test_sw.TestSW.test_sw_install_issu) ... ok
test_sw_install_issu_nssu_both_error (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_nssu_both_error) ... ok
test_sw_install_issu_nssu_single_re_error (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_nssu_single_re_error) ... ok
test_sw_install_issu_single_re_error (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_single_re_error) ... ok
test_sw_install_issu_validate_False (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_validate_False) ... ok
test_sw_install_issu_validate_True (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_validate_True) ... ok
test_sw_install_issu_with_routing_instance (tests.unit.utils.test_sw.TestSW.test_sw_install_issu_with_routing_instance) ... ok
test_sw_install_kwargs_force_host (tests.unit.utils.test_sw.TestSW.test_sw_install_kwargs_force_host) ... ok
test_sw_install_mixed_vc (tests.unit.utils.test_sw.TestSW.test_sw_install_mixed_vc) ... ok
test_sw_install_mixed_vc_safe_copy_false (tests.unit.utils.test_sw.TestSW.test_sw_install_mixed_vc_safe_copy_false) ... ok
test_sw_install_mixed_vc_TypeError (tests.unit.utils.test_sw.TestSW.test_sw_install_mixed_vc_TypeError) ... ok
test_sw_install_mixed_vc_ValueError (tests.unit.utils.test_sw.TestSW.test_sw_install_mixed_vc_ValueError) ... ok
test_sw_install_mixed_vc_with_copy (tests.unit.utils.test_sw.TestSW.test_sw_install_mixed_vc_with_copy) ... ok
test_sw_install_multi_mx (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_mx) ... ok
test_sw_install_multi_mx_msg_check (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_mx_msg_check) ... ok
test_sw_install_multi_mx_msg_check_failure (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_mx_msg_check_failure) ... ok
test_sw_install_multi_vc (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_vc) ... ok
test_sw_install_multi_vc_member_id (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_vc_member_id) ... ok
test_sw_install_multi_vc_mode_disabled (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_vc_mode_disabled) ... ok
test_sw_install_multi_vc_multiple_member_id (tests.unit.utils.test_sw.TestSW.test_sw_install_multi_vc_multiple_member_id) ... ok
test_sw_install_no_package_result (tests.unit.utils.test_sw.TestSW.test_sw_install_no_package_result) ... ok
test_sw_install_nonexistent_mx80_package (tests.unit.utils.test_sw.TestSW.test_sw_install_nonexistent_mx80_package) ... ok
test_sw_install_nssu (tests.unit.utils.test_sw.TestSW.test_sw_install_nssu) ... ok
test_sw_install_nssu_validate_False (tests.unit.utils.test_sw.TestSW.test_sw_install_nssu_validate_False) ... ok
test_sw_install_nssu_validate_True (tests.unit.utils.test_sw.TestSW.test_sw_install_nssu_validate_True) ... ok
test_sw_install_nssu_with_satellite_name (tests.unit.utils.test_sw.TestSW.test_sw_install_nssu_with_satellite_name) ... ok
test_sw_install_satellite_none_alive (tests.unit.utils.test_sw.TestSW.test_sw_install_satellite_none_alive) ... ok
test_sw_install_satellite_rpc_error (tests.unit.utils.test_sw.TestSW.test_sw_install_satellite_rpc_error) ... ok
test_sw_install_single_re (tests.unit.utils.test_sw.TestSW.test_sw_install_single_re) ... ok
test_sw_install_single_re_on_multi_re (tests.unit.utils.test_sw.TestSW.test_sw_install_single_re_on_multi_re) ... ok
test_sw_install_srx_branch_cluster (tests.unit.utils.test_sw.TestSW.test_sw_install_srx_branch_cluster) ... ok
test_sw_install_url_in_pkg_set (tests.unit.utils.test_sw.TestSW.test_sw_install_url_in_pkg_set) ... ok
test_sw_install_validate (tests.unit.utils.test_sw.TestSW.test_sw_install_validate) ... ok
test_sw_install_via_url (tests.unit.utils.test_sw.TestSW.test_sw_install_via_url) ... ok
test_sw_install_vmhost (tests.unit.utils.test_sw.TestSW.test_sw_install_vmhost) ... ok
test_sw_install_with_routing_instance (tests.unit.utils.test_sw.TestSW.test_sw_install_with_routing_instance) ... ok
test_sw_install_with_satellite_name (tests.unit.utils.test_sw.TestSW.test_sw_install_with_satellite_name) ... ok
test_sw_install_with_satellite_name_list (tests.unit.utils.test_sw.TestSW.test_sw_install_with_satellite_name_list) ... ok
test_sw_inventory (tests.unit.utils.test_sw.TestSW.test_sw_inventory) ... ok
test_sw_local_checksum_unknown_alg (tests.unit.utils.test_sw.TestSW.test_sw_local_checksum_unknown_alg) ... ok
test_sw_local_md5 (tests.unit.utils.test_sw.TestSW.test_sw_local_md5) ... ok
test_sw_local_sha1 (tests.unit.utils.test_sw.TestSW.test_sw_local_sha1) ... ok
test_sw_local_sha256 (tests.unit.utils.test_sw.TestSW.test_sw_local_sha256) ... ok
test_sw_pkgadd (tests.unit.utils.test_sw.TestSW.test_sw_pkgadd) ... ok
test_sw_pkgadd_pkg_set (tests.unit.utils.test_sw.TestSW.test_sw_pkgadd_pkg_set) ... ok
test_sw_pkgaddISSU (tests.unit.utils.test_sw.TestSW.test_sw_pkgaddISSU) ... ok
test_sw_pkgaddNSSU (tests.unit.utils.test_sw.TestSW.test_sw_pkgaddNSSU) ... ok
test_sw_poweroff (tests.unit.utils.test_sw.TestSW.test_sw_poweroff) ... ok
test_sw_poweroff_exception (tests.unit.utils.test_sw.TestSW.test_sw_poweroff_exception) ... ok
test_sw_poweroff_multi_re_vc (tests.unit.utils.test_sw.TestSW.test_sw_poweroff_multi_re_vc) ... ok
test_sw_progress (tests.unit.utils.test_sw.TestSW.test_sw_progress) ... ok
test_sw_progress_true (tests.unit.utils.test_sw.TestSW.test_sw_progress_true) ... ok
test_sw_put (tests.unit.utils.test_sw.TestSW.test_sw_put) ... ok
test_sw_put_ftp (tests.unit.utils.test_sw.TestSW.test_sw_put_ftp) ... ok
test_sw_put_progress (tests.unit.utils.test_sw.TestSW.test_sw_put_progress) ... ok
test_sw_reboot (tests.unit.utils.test_sw.TestSW.test_sw_reboot) ... ok
test_sw_reboot_at (tests.unit.utils.test_sw.TestSW.test_sw_reboot_at) ... ok
test_sw_reboot_exception (tests.unit.utils.test_sw.TestSW.test_sw_reboot_exception) ... ok
test_sw_reboot_exception_RpcTimeoutError (tests.unit.utils.test_sw.TestSW.test_sw_reboot_exception_RpcTimeoutError) ... ok
test_sw_reboot_mixed_vc (tests.unit.utils.test_sw.TestSW.test_sw_reboot_mixed_vc) ... ok
test_sw_reboot_mixed_vc_all_re_false (tests.unit.utils.test_sw.TestSW.test_sw_reboot_mixed_vc_all_re_false) ... ok
test_sw_reboot_multi_re_vc (tests.unit.utils.test_sw.TestSW.test_sw_reboot_multi_re_vc) ... ok
test_sw_reboot_output_in_reply (tests.unit.utils.test_sw.TestSW.test_sw_reboot_output_in_reply) ... ok
test_sw_reboot_satellite_none_alive (tests.unit.utils.test_sw.TestSW.test_sw_reboot_satellite_none_alive) ... ok
test_sw_reboot_with_satellite_name (tests.unit.utils.test_sw.TestSW.test_sw_reboot_with_satellite_name) ... ok
test_sw_reboot_with_satellite_name_list (tests.unit.utils.test_sw.TestSW.test_sw_reboot_with_satellite_name_list) ... ok
test_sw_remote_checksum_md5 (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_md5) ... ok
test_sw_remote_checksum_not_found (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_not_found) ... ok
test_sw_remote_checksum_not_rpc_error (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_not_rpc_error) ... ok
test_sw_remote_checksum_sha1 (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_sha1) ... ok
test_sw_remote_checksum_sha256 (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_sha256) ... ok
test_sw_remote_checksum_unknown_alg (tests.unit.utils.test_sw.TestSW.test_sw_remote_checksum_unknown_alg) ... ok
test_sw_rollback (tests.unit.utils.test_sw.TestSW.test_sw_rollback) ... ok
test_sw_rollback_exception (tests.unit.utils.test_sw.TestSW.test_sw_rollback_exception) ... ok
test_sw_rollback_multi (tests.unit.utils.test_sw.TestSW.test_sw_rollback_multi) ... ok
test_sw_rollback_multi_exception (tests.unit.utils.test_sw.TestSW.test_sw_rollback_multi_exception) ... ok
test_sw_rollback_satellite_none_alive (tests.unit.utils.test_sw.TestSW.test_sw_rollback_satellite_none_alive) ... ok
test_sw_rollback_with_satellite_name (tests.unit.utils.test_sw.TestSW.test_sw_rollback_with_satellite_name) ... ok
test_sw_rollback_with_satellite_name_list (tests.unit.utils.test_sw.TestSW.test_sw_rollback_with_satellite_name_list) ... ok
test_sw_safe_copy (tests.unit.utils.test_sw.TestSW.test_sw_safe_copy) ... ok
test_sw_safe_copy_checksum_none (tests.unit.utils.test_sw.TestSW.test_sw_safe_copy_checksum_none) ... ok
test_sw_safe_copy_cleanfs_fail (tests.unit.utils.test_sw.TestSW.test_sw_safe_copy_cleanfs_fail) ... ok
test_sw_safe_copy_missing_local_file (tests.unit.utils.test_sw.TestSW.test_sw_safe_copy_missing_local_file) ... ok
test_sw_safe_copy_return_false (tests.unit.utils.test_sw.TestSW.test_sw_safe_copy_return_false) ... ok
test_sw_safe_install (tests.unit.utils.test_sw.TestSW.test_sw_safe_install) ... ok
test_sw_safe_install_copy_fail (tests.unit.utils.test_sw.TestSW.test_sw_safe_install_copy_fail) ... ok
test_sw_val_issu_request_shell_execute_gres_on (tests.unit.utils.test_sw.TestSW.test_sw_val_issu_request_shell_execute_gres_on) ... ok
test_sw_validate (tests.unit.utils.test_sw.TestSW.test_sw_validate) ... ok
test_sw_validate_issu (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu) ... ok
test_sw_validate_issu_2re_false (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_2re_false) ... ok
test_sw_validate_issu_commit_sync_off (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_commit_sync_off) ... ok
test_sw_validate_issu_nonstop_routing_off (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_nonstop_routing_off) ... ok
test_sw_validate_issu_request_shell_execute (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_request_shell_execute) ... ok
test_sw_validate_issu_ss_graceful_off (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_ss_graceful_off) ... ok
test_sw_validate_issu_ss_login_other_re_fail (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_ss_login_other_re_fail) ... ok
test_sw_validate_issu_stateful_replication_off (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_stateful_replication_off) ... ok
test_sw_validate_issu_validation_succeeded (tests.unit.utils.test_sw.TestSW.test_sw_validate_issu_validation_succeeded) ... ok
test_sw_validate_no_package_result (tests.unit.utils.test_sw.TestSW.test_sw_validate_no_package_result) ... ok
test_sw_validate_no_package_result_error (tests.unit.utils.test_sw.TestSW.test_sw_validate_no_package_result_error) ... ok
test_sw_validate_nssu (tests.unit.utils.test_sw.TestSW.test_sw_validate_nssu) ... ok
test_sw_validate_satellite_nested_error (tests.unit.utils.test_sw.TestSW.test_sw_validate_satellite_nested_error) ... ok
test_sw_validate_satellite_nested_success (tests.unit.utils.test_sw.TestSW.test_sw_validate_satellite_nested_success) ... ok
test_sw_validate_satellite_none_alive (tests.unit.utils.test_sw.TestSW.test_sw_validate_satellite_none_alive) ... ok
test_sw_validate_satellite_rpc_error (tests.unit.utils.test_sw.TestSW.test_sw_validate_satellite_rpc_error) ... ok
test_sw_validate_with_satellite_name (tests.unit.utils.test_sw.TestSW.test_sw_validate_with_satellite_name) ... ok
test_sw_validate_with_satellite_name_list (tests.unit.utils.test_sw.TestSW.test_sw_validate_with_satellite_name_list) ... ok
test_sw_zeroize (tests.unit.utils.test_sw.TestSW.test_sw_zeroize) ... ok
test_sw_zeroize_exception (tests.unit.utils.test_sw.TestSW.test_sw_zeroize_exception) ... ok
test_sw_zeroize_non_vmhost_uses_system_rpc (tests.unit.utils.test_sw.TestSW.test_sw_zeroize_non_vmhost_uses_system_rpc) ... ok
test_sw_zeroize_vmhost (tests.unit.utils.test_sw.TestSW.test_sw_zeroize_vmhost) ... ok
test_sw_zeroize_vmhost_exception (tests.unit.utils.test_sw.TestSW.test_sw_zeroize_vmhost_exception) ... ok
test_sw_zeroize_vmhost_uses_vmhost_rpc (tests.unit.utils.test_sw.TestSW.test_sw_zeroize_vmhost_uses_vmhost_rpc) ... ok
test_scp_close (tests.unit.utils.test_scp.TestScp.test_scp_close) ... ok
test_scp_console (tests.unit.utils.test_scp.TestScp.test_scp_console) ... ok
test_scp_context (tests.unit.utils.test_scp.TestScp.test_scp_context) ... ok
test_scp_honors_device_allow_agent (tests.unit.utils.test_scp.TestScp.test_scp_honors_device_allow_agent) ... ok
test_scp_honors_device_look_for_keys (tests.unit.utils.test_scp.TestScp.test_scp_honors_device_look_for_keys) ... {'hostname': '1.1.1.1', 'port': 22, 'username': 'user', 'password': None, 'sock': None, 'allow_agent': True, 'look_for_keys': False}
ok
test_scp_open (tests.unit.utils.test_scp.TestScp.test_scp_open) ... ok
test_scp_progress (tests.unit.utils.test_scp.TestScp.test_scp_progress) ... 1.1.1.1: test: 50 / 100 (50%)
None
ok
test_scp_progress_true (tests.unit.utils.test_scp.TestScp.test_scp_progress_true) ... ok
test_scp_proxycommand (tests.unit.utils.test_scp.TestScp.test_scp_proxycommand) ... ok
test_scp_user_def_progress (tests.unit.utils.test_scp.TestScp.test_scp_user_def_progress) ... ok
test_scp_user_def_progress_args_2 (tests.unit.utils.test_scp.TestScp.test_scp_user_def_progress_args_2) ... ok
test_scp_with_password_disables_agent_by_default (tests.unit.utils.test_scp.TestScp.test_scp_with_password_disables_agent_by_default) ... ok
test_ssh_private_key_file (tests.unit.utils.test_scp.TestScp.test_ssh_private_key_file) ... ok
test_ftp_close (tests.unit.utils.test_ftp.TestFtp.test_ftp_close) ... ok
test_ftp_context (tests.unit.utils.test_ftp.TestFtp.test_ftp_context) ... ok
test_ftp_dnload_file (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file) ... ok
test_ftp_dnload_file_errors (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file_errors) ... ERROR:jnpr.junos.utils.ftp:'NoneType' object has no attribute 'sendall'
ok
test_ftp_dnload_file_get (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file_get) ... ERROR:jnpr.junos.utils.ftp:'NoneType' object has no attribute 'sendall'
ok
test_ftp_dnload_file_get_retr (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file_get_retr) ... ok
test_ftp_dnload_file_get_rf_filename (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file_get_rf_filename) ... ok
test_ftp_dnload_file_get_rf_filename_cb (tests.unit.utils.test_ftp.TestFtp.test_ftp_dnload_file_get_rf_filename_cb) ... ok
test_ftp_open (tests.unit.utils.test_ftp.TestFtp.test_ftp_open) ... ok
test_ftp_open_erors (tests.unit.utils.test_ftp.TestFtp.test_ftp_open_erors) ... ok
test_ftp_upload_file (tests.unit.utils.test_ftp.TestFtp.test_ftp_upload_file) ... ok
test_ftp_upload_file_errors (tests.unit.utils.test_ftp.TestFtp.test_ftp_upload_file_errors) ... ERROR:jnpr.junos.utils.ftp:'NoneType' object has no attribute 'sendall'
ERROR:jnpr.junos.utils.ftp:'NoneType' object has no attribute 'sendall'
ok
test_ftp_upload_file_rem_full_path (tests.unit.utils.test_ftp.TestFtp.test_ftp_upload_file_rem_full_path) ... ok
test_ftp_upload_file_rem_path (tests.unit.utils.test_ftp.TestFtp.test_ftp_upload_file_rem_path) ... ok
test_ftp_upload_file_rem_path_create (tests.unit.utils.test_ftp.TestFtp.test_ftp_upload_file_rem_path_create) ... ok
test_dev_setter_exception (tests.unit.utils.test_util.TestUtil.test_dev_setter_exception) ... ok
test_repr (tests.unit.utils.test_util.TestUtil.test_repr) ... ok
test_rpc_setter_exception (tests.unit.utils.test_util.TestUtil.test_rpc_setter_exception) ... ok

----------------------------------------------------------------------
Ran 904 tests in 9.849s

OK
regress@masterhost:~/pyez_proxy_pr_fix/py-junos-eznc$ 
```

FT logs

```
xyz@xyz:~/pyez_proxy_pr_fix/py-junos-eznc/tests/functional$ python3 -m nose2 -v -c nose2.cfg
test_load_config_jinja2 (tests.functional.test_config.TestCore.test_load_config_jinja2) ... ok
test_load_config_jinja2_template (tests.functional.test_config.TestCore.test_load_config_jinja2_template) ... ok
test_load_config_json (tests.functional.test_config.TestCore.test_load_config_json) ... ok
test_load_config_set (tests.functional.test_config.TestCore.test_load_config_set) ... ok
test_load_config_text (tests.functional.test_config.TestCore.test_load_config_text) ... ok
test_load_config_xml (tests.functional.test_config.TestCore.test_load_config_xml) ... ok
test_config_exception (tests.functional.test_exception.TestUtilFs.test_config_exception) ... ok
test_device_rpc_timeout (tests.functional.test_exception.TestUtilFs.test_device_rpc_timeout) ... ok
test_exception (tests.functional.test_exception.TestUtilFs.test_exception) ... ok
test_exception_commitError (tests.functional.test_exception.TestUtilFs.test_exception_commitError) ... ok
test_exception_commitError_commitCheck (tests.functional.test_exception.TestUtilFs.test_exception_commitError_commitCheck) ... ok
test_exception_severity (tests.functional.test_exception.TestUtilFs.test_exception_severity) ... ok
test_FS_checksum (tests.functional.test_exception.TestUtilFs.test_FS_checksum) ... ok
test_load_exception (tests.functional.test_exception.TestUtilFs.test_load_exception) ... ok
test_lock_exception (tests.functional.test_exception.TestUtilFs.test_lock_exception) ... ok
test_rescue_action (tests.functional.test_exception.TestUtilFs.test_rescue_action) ... ok
test_rollback_id (tests.functional.test_exception.TestUtilFs.test_rollback_id) ... ok
test_rpc_exception (tests.functional.test_exception.TestUtilFs.test_rpc_exception) ... ok
test_rpc_exist (tests.functional.test_exception.TestUtilFs.test_rpc_exist) ... ok
test_rpc_load_extension (tests.functional.test_exception.TestUtilFs.test_rpc_load_extension) ... ok
test_rpc_no_format (tests.functional.test_exception.TestUtilFs.test_rpc_no_format) ... ok
test_rpc_set_override (tests.functional.test_exception.TestUtilFs.test_rpc_set_override) ... ok
test_unlock_exception (tests.functional.test_exception.TestUtilFs.test_unlock_exception) ... ok
test_device_rpc (tests.functional.test_rpc.TestCore.test_device_rpc) ... ok
test_device_rpc_format_text (tests.functional.test_rpc.TestCore.test_device_rpc_format_text) ... ok
test_device_rpc_timeout (tests.functional.test_rpc.TestCore.test_device_rpc_timeout) ... ok
test_display_xml_rpc (tests.functional.test_rpc.TestCore.test_display_xml_rpc) ... ok
test_getConfig (tests.functional.test_rpc.TestCore.test_getConfig) ... ok
test_interface_terse_text (tests.functional.test_rpc.TestCore.test_interface_terse_text) ... ok
test_route_information (tests.functional.test_rpc.TestCore.test_route_information) ... ok
test_rpc_get_interface_information_mtun (tests.functional.test_rpc.TestCore.test_rpc_get_interface_information_mtun) ... ok
test_scp_put (tests.functional.test_file_scp.test.test_scp_put) ... xyz: b'scp_file.txt': 1 / 1 (100%)
ok
test_scp_put_file_get (tests.functional.test_file_scp.test.test_scp_put_file_get) ... ok
test_scp_put_with_allow_agent_disabled (tests.functional.test_scp.TestScp.test_scp_put_with_allow_agent_disabled) ... ok
test_scp_put_with_look_for_keys_disabled (tests.functional.test_scp.TestScp.test_scp_put_with_look_for_keys_disabled) ... ok
test_arp_table (tests.functional.test_table_present.test_table.test_arp_table) ... ['56:04:26:00:27:05', '00:01:00:02:00:03', '00:00:5e:38:04:c8', '56:04:26:00:27:05', '56:04:26:00:27:05', '56:04:26:00:27:96']
ok
test_arp_table_to_json (tests.functional.test_table_present.test_table.test_arp_table_to_json) ... ok
test_table_get_value (tests.functional.test_table_present.test_table.test_table_get_value) ... ok
test_utils_fs_cat (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_cat) ... ok
test_utils_fs_checksum (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_checksum) ... ok
test_utils_fs_cp (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_cp) ... ok
test_utils_fs_ls (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_ls) ... ok
test_utils_fs_mkdir (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_mkdir) ... ok
test_utils_fs_mv (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_mv) ... ok
test_utils_fs_pwd (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_pwd) ... ok
test_utils_fs_rm (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_rm) ... ok
test_utils_fs_rmdir (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_rmdir) ... ok
test_utils_fs_stat (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_stat) ... ok
test_utils_fs_storageUsage (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_storageUsage) ... ok
test_utils_fs_symlink (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_symlink) ... ok
test_utils_fs_tgz (tests.functional.test_utils_file_system.TestUtilsFS.test_utils_fs_tgz) ... ok
test_device_facts (tests.functional.test_core.TestCore.test_device_facts) ... ok
test_device_get_timeout (tests.functional.test_core.TestCore.test_device_get_timeout) ... ok
test_device_open (tests.functional.test_core.TestCore.test_device_open) ... ok
test_device_rpc (tests.functional.test_core.TestCore.test_device_rpc) ... ok
test_device_rpc_format_text (tests.functional.test_core.TestCore.test_device_rpc_format_text) ... ok
test_device_rpc_normalize_true (tests.functional.test_core.TestCore.test_device_rpc_normalize_true) ... ok
test_device_rpc_timeout (tests.functional.test_core.TestCore.test_device_rpc_timeout) ... ok
test_device_set_timeout (tests.functional.test_core.TestCore.test_device_set_timeout) ... ok
test_load_config (tests.functional.test_core.TestCore.test_load_config) ... ok
test_table_json (tests.functional.test_table.TestTable.test_table_json) ... ok
test_table_union (tests.functional.test_table.TestTable.test_table_union) ... ok
test_shell_run (tests.functional.test_shell.test.test_shell_run) ... ok
test_device_open_key_pass (tests.functional.test_device_ssh.TestDeviceSsh.test_device_open_key_pass) ... ok

----------------------------------------------------------------------
Ran 64 tests in 86.560s

OK
```