### PR TITLE
Gathered facts of satellite device

### DIFF
--- a/lib/jnpr/junos/facts/__init__.py
+++ b/lib/jnpr/junos/facts/__init__.py
@@ -42,6 +42,7 @@ import jnpr.junos.facts.get_chassis_cluster_status
 import jnpr.junos.facts.get_chassis_inventory
 import jnpr.junos.facts.get_route_engine_information
 import jnpr.junos.facts.get_software_information
+import jnpr.junos.facts.get_jnu_satellites_information
 import jnpr.junos.facts.get_virtual_chassis_information
 import jnpr.junos.facts.ifd_style
 import jnpr.junos.facts.iri_mapping

--- a/lib/jnpr/junos/facts/get_jnu_satellites_information.py
+++ b/lib/jnpr/junos/facts/get_jnu_satellites_information.py
@@ -1,0 +1,222 @@
+from jnpr.junos.exception import RpcError
+
+
+def provides_facts():
+    """
+    Returns a dictionary keyed on the facts provided by this module. The value
+    of each key is the doc string describing the fact.
+    """
+    return {
+        "jnu_satellite": "A boolean indicating if JNU satellite devices are "
+        "present. False if none found or RPC not supported.",
+        "satellites_info": "A dictionary keyed on satellite name. Each value "
+        "is a dictionary of facts collected from that satellite, "
+        "mirroring the same facts gathered for the main device: "
+        "'alive', 'hostname', 'model', 'version', 'os_name', "
+        "'serialnumber', '2RE', 'RE_hw_mi', 'RE0', 'RE1', "
+        "'re_info', 're_master', 'master', 'vc_capable', "
+        "'vc_mode', 'vc_fabric', 'vc_master'. Fields that "
+        "cannot be determined are set to None.",
+    }
+
+
+def _get_sat_dev(rsp, name):
+    """Return the <satellite-device> element matching *name*, or first found."""
+    sat_dev = rsp.find(
+        ".//satellite-device[satellite-mgmt-ip='{}']".format(name)
+    )
+    return sat_dev if sat_dev is not None else rsp.find(".//satellite-device")
+
+
+def _collect_sw_facts(device, name, sat_facts):
+    """Populate software version facts from get_software_information."""
+    try:
+        rsp = device.rpc.get_software_information(
+            device_list=name, normalize=True
+        )
+        if rsp is None or rsp is True:
+            return
+        sat_dev = _get_sat_dev(rsp, name)
+        if sat_dev is None:
+            return
+        sw = sat_dev.find(".//software-information")
+        if sw is None:
+            return
+        sat_facts["hostname"] = sw.findtext("host-name")
+        sat_facts["os_name"] = sw.findtext("os-name")
+        sat_facts["model"] = sw.findtext("product-model") or sat_facts["model"]
+        sat_facts["version"] = sw.findtext("junos-version") or sat_facts["version"]
+    except Exception:
+        pass
+
+
+def _collect_re_facts(device, name, sat_facts):
+    """Populate RE facts from get_route_engine_information."""
+    try:
+        rsp = device.rpc.get_route_engine_information(
+            device_list=name, normalize=True
+        )
+        if rsp is None or rsp is True:
+            return
+        sat_dev = _get_sat_dev(rsp, name)
+        if sat_dev is None:
+            return
+        re_list = sat_dev.findall(".//route-engine")
+        sat_facts["2RE"] = len(re_list) > 1
+        sat_facts["RE_hw_mi"] = False
+        re_info_node = {"default": {}}
+        first_slot = None
+        master_slot = None
+        for re in re_list:
+            slot = re.findtext("slot", "0")
+            info = {
+                "mastership_state": re.findtext("mastership-state", "master"),
+                "status": re.findtext("status"),
+                "model": re.findtext("model"),
+                "last_reboot_reason": re.findtext("last-reboot-reason"),
+                "up_time": re.findtext("up-time"),
+            }
+            re_info_node[slot] = info
+            if first_slot is None:
+                first_slot = slot
+                re_info_node["default"] = dict(info)
+            if info["mastership_state"] == "master" and master_slot is None:
+                master_slot = slot
+            if slot == "0":
+                sat_facts["RE0"] = dict(info)
+            elif slot == "1":
+                sat_facts["RE1"] = dict(info)
+        sat_facts["re_info"] = {"default": re_info_node}
+        sat_facts["re_master"] = {"default": master_slot or first_slot or "0"}
+        sat_facts["master"] = "RE{}".format(master_slot or first_slot or "0")
+    except Exception:
+        pass
+
+
+def _collect_chassis_facts(device, name, sat_facts):
+    """Populate chassis inventory facts from get_chassis_inventory."""
+    try:
+        rsp = device.rpc.get_chassis_inventory(
+            device_list=name, normalize=True
+        )
+        if rsp is None or rsp is True:
+            return
+        sat_dev = _get_sat_dev(rsp, name)
+        if sat_dev is None:
+            return
+        sat_facts["serialnumber"] = (
+            sat_dev.findtext(".//chassis[1]/serial-number")
+            or sat_dev.findtext('.//chassis-module[name="Midplane"]/serial-number')
+        )
+    except Exception:
+        pass
+
+
+def _collect_vc_facts(device, name, sat_facts):
+    """Populate virtual chassis facts from get_virtual_chassis_information."""
+    sat_facts["vc_capable"] = False
+    sat_facts["vc_mode"] = None
+    sat_facts["vc_fabric"] = None
+    sat_facts["vc_master"] = None
+    try:
+        rsp = device.rpc.get_virtual_chassis_information(
+            device_list=name, normalize=True
+        )
+        if rsp is None or rsp is True:
+            return
+        sat_dev = _get_sat_dev(rsp, name)
+        if sat_dev is None:
+            return
+        # If the satellite returned an rpc-error (e.g. VC subsystem not running)
+        # vc_capable remains False.
+        if sat_dev.find(".//rpc-error") is not None:
+            return
+        vc_info = sat_dev.find(".//virtual-chassis-information")
+        if vc_info is None:
+            return
+        sat_facts["vc_capable"] = True
+        sat_facts["vc_mode"] = vc_info.findtext(".//virtual-chassis-mode")
+        vc_id_info = vc_info.find(".//virtual-chassis-id-information")
+        if vc_id_info is not None:
+            sat_facts["vc_fabric"] = vc_id_info.get("style") == "fabric"
+        for member_id in vc_info.xpath(
+            ".//member-role[starts-with(.,'Master')]/preceding-sibling::member-id"
+        ):
+            if sat_facts["vc_master"] is None:
+                sat_facts["vc_master"] = member_id.text
+    except Exception:
+        pass
+
+
+def get_facts(device):
+    """
+    Gathers satellite device facts from the <get-jnu-satellites-information/>
+    RPC, then for each live satellite collects the same facts as the main
+    device via device-list RPCs:
+      - software version  : get_software_information
+      - RE information    : get_route_engine_information
+      - chassis inventory : get_chassis_inventory
+      - virtual chassis   : get_virtual_chassis_information
+    """
+    jnu_satellite = False
+    satellites_info = {}
+
+    try:
+        rsp = device.rpc.get_jnu_satellites_information(normalize=True)
+        if rsp is None or rsp is True:
+            return {"jnu_satellite": jnu_satellite, "satellites_info": satellites_info}
+
+        if rsp.tag == "error":
+            raise RpcError()
+
+        sat_list = rsp.findall(".//satellite-information")
+        if not sat_list:
+            return {"jnu_satellite": jnu_satellite, "satellites_info": satellites_info}
+
+        jnu_satellite = True
+
+        for sat in sat_list:
+            name = sat.findtext("satellite-ip")
+            if not name:
+                continue
+
+            alive = sat.findtext("alive")
+
+            sat_facts = {
+                "alive": alive,
+                "model": sat.findtext("satellite-model"),
+                "version": sat.findtext("satellite-version"),
+                "hostname": None,
+                "os_name": None,
+                "serialnumber": None,
+                "2RE": False,
+                "RE_hw_mi": False,
+                "RE0": None,
+                "RE1": None,
+                "re_info": None,
+                "re_master": None,
+                "master": None,
+                "vc_capable": False,
+                "vc_mode": None,
+                "vc_fabric": None,
+                "vc_master": None,
+            }
+
+            if alive == "up":
+                _collect_sw_facts(device, name, sat_facts)
+                _collect_re_facts(device, name, sat_facts)
+                _collect_chassis_facts(device, name, sat_facts)
+                _collect_vc_facts(device, name, sat_facts)
+
+            satellites_info[name] = sat_facts
+
+    except RpcError:
+        # Device does not support JNU satellites RPC — not an error condition.
+        pass
+    except Exception:
+        pass
+
+    return {
+        "jnu_satellite": jnu_satellite,
+        "satellites_info": satellites_info,
+    }

--- a/lib/jnpr/junos/facts/get_jnu_satellites_information.py
+++ b/lib/jnpr/junos/facts/get_jnu_satellites_information.py
@@ -22,18 +22,14 @@ def provides_facts():
 
 def _get_sat_dev(rsp, name):
     """Return the <satellite-device> element matching *name*, or first found."""
-    sat_dev = rsp.find(
-        ".//satellite-device[satellite-mgmt-ip='{}']".format(name)
-    )
+    sat_dev = rsp.find(".//satellite-device[satellite-mgmt-ip='{}']".format(name))
     return sat_dev if sat_dev is not None else rsp.find(".//satellite-device")
 
 
 def _collect_sw_facts(device, name, sat_facts):
     """Populate software version facts from get_software_information."""
     try:
-        rsp = device.rpc.get_software_information(
-            device_list=name, normalize=True
-        )
+        rsp = device.rpc.get_software_information(device_list=name, normalize=True)
         if rsp is None or rsp is True:
             return
         sat_dev = _get_sat_dev(rsp, name)
@@ -53,9 +49,7 @@ def _collect_sw_facts(device, name, sat_facts):
 def _collect_re_facts(device, name, sat_facts):
     """Populate RE facts from get_route_engine_information."""
     try:
-        rsp = device.rpc.get_route_engine_information(
-            device_list=name, normalize=True
-        )
+        rsp = device.rpc.get_route_engine_information(device_list=name, normalize=True)
         if rsp is None or rsp is True:
             return
         sat_dev = _get_sat_dev(rsp, name)
@@ -96,18 +90,15 @@ def _collect_re_facts(device, name, sat_facts):
 def _collect_chassis_facts(device, name, sat_facts):
     """Populate chassis inventory facts from get_chassis_inventory."""
     try:
-        rsp = device.rpc.get_chassis_inventory(
-            device_list=name, normalize=True
-        )
+        rsp = device.rpc.get_chassis_inventory(device_list=name, normalize=True)
         if rsp is None or rsp is True:
             return
         sat_dev = _get_sat_dev(rsp, name)
         if sat_dev is None:
             return
-        sat_facts["serialnumber"] = (
-            sat_dev.findtext(".//chassis[1]/serial-number")
-            or sat_dev.findtext('.//chassis-module[name="Midplane"]/serial-number')
-        )
+        sat_facts["serialnumber"] = sat_dev.findtext(
+            ".//chassis[1]/serial-number"
+        ) or sat_dev.findtext('.//chassis-module[name="Midplane"]/serial-number')
     except Exception:
         pass
 

--- a/lib/jnpr/junos/ofacts/__init__.py
+++ b/lib/jnpr/junos/ofacts/__init__.py
@@ -3,6 +3,7 @@ from jnpr.junos.ofacts.domain import facts_domain
 from jnpr.junos.ofacts.ifd_style import facts_ifd_style
 from jnpr.junos.ofacts.personality import facts_personality
 from jnpr.junos.ofacts.routing_engines import facts_routing_engines
+from jnpr.junos.ofacts.satellites import facts_satellites
 from jnpr.junos.ofacts.session import facts_session
 from jnpr.junos.ofacts.srx_cluster import facts_srx_cluster
 from jnpr.junos.ofacts.switch_style import facts_switch_style
@@ -18,6 +19,7 @@ FACT_LIST = [
     facts_ifd_style,
     facts_switch_style,
     facts_session,
+    facts_satellites,  # last - depends on no other fact
 ]
 
 __all__ = ["FACT_LIST"]

--- a/lib/jnpr/junos/ofacts/satellites.py
+++ b/lib/jnpr/junos/ofacts/satellites.py
@@ -1,0 +1,185 @@
+def _get_sat_dev(rsp, name):
+    """Return the <satellite-device> element matching *name*, or first found."""
+    sat_dev = rsp.find(
+        ".//satellite-device[satellite-mgmt-ip='{}']".format(name)
+    )
+    return sat_dev if sat_dev is not None else rsp.find(".//satellite-device")
+
+
+def facts_satellites(junos, facts):
+    """
+    Collects JNU satellite device facts, mirroring the same facts gathered
+    for the main device via device-list RPCs:
+      - software version  : get_software_information
+      - RE information    : get_route_engine_information
+      - chassis inventory : get_chassis_inventory
+      - virtual chassis   : get_virtual_chassis_information
+
+    The following facts are assigned:
+        facts['jnu_satellite']  : True if satellite devices are present,
+                                  False otherwise.
+        facts['satellites_info']: A dict keyed by satellite name. Each value
+                                  is a dict with keys: 'alive', 'hostname',
+                                  'model', 'version', 'os_name',
+                                  'serialnumber', '2RE', 'RE_hw_mi',
+                                  'RE0', 'RE1', 're_info', 're_master',
+                                  'master', 'vc_capable', 'vc_mode',
+                                  'vc_fabric', 'vc_master'.
+    """
+    facts["jnu_satellite"] = False
+    facts["satellites_info"] = {}
+
+    try:
+        rsp = junos.rpc.get_jnu_satellites_information()
+        if rsp is None or rsp is True:
+            return
+
+        sat_list = rsp.findall(".//satellite-information")
+        if not sat_list:
+            return
+
+        facts["jnu_satellite"] = True
+
+        for sat in sat_list:
+            name = sat.findtext("satellite-ip")
+            if not name:
+                continue
+
+            alive = sat.findtext("alive")
+
+            sat_facts = {
+                "alive": alive,
+                "model": sat.findtext("satellite-model"),
+                "version": sat.findtext("satellite-version"),
+                "hostname": None,
+                "os_name": None,
+                "serialnumber": None,
+                "2RE": False,
+                "RE_hw_mi": False,
+                "RE0": None,
+                "RE1": None,
+                "re_info": None,
+                "re_master": None,
+                "master": None,
+                "vc_capable": False,
+                "vc_mode": None,
+                "vc_fabric": None,
+                "vc_master": None,
+            }
+
+            if alive == "up":
+                # --- software version facts ---
+                try:
+                    sw_rsp = junos.rpc.get_software_information(device_list=name)
+                    if sw_rsp is not None and sw_rsp is not True:
+                        sat_dev = _get_sat_dev(sw_rsp, name)
+                        if sat_dev is not None:
+                            sw = sat_dev.find(".//software-information")
+                            if sw is not None:
+                                sat_facts["hostname"] = sw.findtext("host-name")
+                                sat_facts["os_name"] = sw.findtext("os-name")
+                                sat_facts["model"] = (
+                                    sw.findtext("product-model") or sat_facts["model"]
+                                )
+                                sat_facts["version"] = (
+                                    sw.findtext("junos-version") or sat_facts["version"]
+                                )
+                except Exception:
+                    pass
+
+                # --- RE facts ---
+                try:
+                    re_rsp = junos.rpc.get_route_engine_information(device_list=name)
+                    if re_rsp is not None and re_rsp is not True:
+                        sat_dev = _get_sat_dev(re_rsp, name)
+                        if sat_dev is not None:
+                            re_list = sat_dev.findall(".//route-engine")
+                            sat_facts["2RE"] = len(re_list) > 1
+                            re_info_node = {"default": {}}
+                            first_slot = None
+                            master_slot = None
+                            for re in re_list:
+                                slot = re.findtext("slot", "0")
+                                info = {
+                                    "mastership_state": re.findtext(
+                                        "mastership-state", "master"
+                                    ),
+                                    "status": re.findtext("status"),
+                                    "model": re.findtext("model"),
+                                    "last_reboot_reason": re.findtext(
+                                        "last-reboot-reason"
+                                    ),
+                                    "up_time": re.findtext("up-time"),
+                                }
+                                re_info_node[slot] = info
+                                if first_slot is None:
+                                    first_slot = slot
+                                    re_info_node["default"] = dict(info)
+                                if (
+                                    info["mastership_state"] == "master"
+                                    and master_slot is None
+                                ):
+                                    master_slot = slot
+                                if slot == "0":
+                                    sat_facts["RE0"] = dict(info)
+                                elif slot == "1":
+                                    sat_facts["RE1"] = dict(info)
+                            sat_facts["re_info"] = {"default": re_info_node}
+                            sat_facts["re_master"] = {
+                                "default": master_slot or first_slot or "0"
+                            }
+                            sat_facts["master"] = "RE{}".format(
+                                master_slot or first_slot or "0"
+                            )
+                except Exception:
+                    pass
+
+                # --- chassis inventory facts ---
+                try:
+                    inv_rsp = junos.rpc.get_chassis_inventory(device_list=name)
+                    if inv_rsp is not None and inv_rsp is not True:
+                        sat_dev = _get_sat_dev(inv_rsp, name)
+                        if sat_dev is not None:
+                            sat_facts["serialnumber"] = (
+                                sat_dev.findtext(".//chassis[1]/serial-number")
+                                or sat_dev.findtext(
+                                    './/chassis-module[name="Midplane"]/serial-number'
+                                )
+                            )
+                except Exception:
+                    pass
+
+                # --- virtual chassis facts ---
+                try:
+                    vc_rsp = junos.rpc.get_virtual_chassis_information(
+                        device_list=name
+                    )
+                    if vc_rsp is not None and vc_rsp is not True:
+                        sat_dev = _get_sat_dev(vc_rsp, name)
+                        if sat_dev is not None and sat_dev.find(".//rpc-error") is None:
+                            vc_info = sat_dev.find(".//virtual-chassis-information")
+                            if vc_info is not None:
+                                sat_facts["vc_capable"] = True
+                                sat_facts["vc_mode"] = vc_info.findtext(
+                                    ".//virtual-chassis-mode"
+                                )
+                                vc_id_info = vc_info.find(
+                                    ".//virtual-chassis-id-information"
+                                )
+                                if vc_id_info is not None:
+                                    sat_facts["vc_fabric"] = (
+                                        vc_id_info.get("style") == "fabric"
+                                    )
+                                for member_id in vc_info.xpath(
+                                    ".//member-role[starts-with(.,'Master')]"
+                                    "/preceding-sibling::member-id"
+                                ):
+                                    if sat_facts["vc_master"] is None:
+                                        sat_facts["vc_master"] = member_id.text
+                except Exception:
+                    pass
+
+            facts["satellites_info"][name] = sat_facts
+
+    except Exception:
+        pass

--- a/lib/jnpr/junos/ofacts/satellites.py
+++ b/lib/jnpr/junos/ofacts/satellites.py
@@ -1,8 +1,6 @@
 def _get_sat_dev(rsp, name):
     """Return the <satellite-device> element matching *name*, or first found."""
-    sat_dev = rsp.find(
-        ".//satellite-device[satellite-mgmt-ip='{}']".format(name)
-    )
+    sat_dev = rsp.find(".//satellite-device[satellite-mgmt-ip='{}']".format(name))
     return sat_dev if sat_dev is not None else rsp.find(".//satellite-device")
 
 
@@ -140,20 +138,17 @@ def facts_satellites(junos, facts):
                     if inv_rsp is not None and inv_rsp is not True:
                         sat_dev = _get_sat_dev(inv_rsp, name)
                         if sat_dev is not None:
-                            sat_facts["serialnumber"] = (
-                                sat_dev.findtext(".//chassis[1]/serial-number")
-                                or sat_dev.findtext(
-                                    './/chassis-module[name="Midplane"]/serial-number'
-                                )
+                            sat_facts["serialnumber"] = sat_dev.findtext(
+                                ".//chassis[1]/serial-number"
+                            ) or sat_dev.findtext(
+                                './/chassis-module[name="Midplane"]/serial-number'
                             )
                 except Exception:
                     pass
 
                 # --- virtual chassis facts ---
                 try:
-                    vc_rsp = junos.rpc.get_virtual_chassis_information(
-                        device_list=name
-                    )
+                    vc_rsp = junos.rpc.get_virtual_chassis_information(device_list=name)
                     if vc_rsp is not None and vc_rsp is not True:
                         sat_dev = _get_sat_dev(vc_rsp, name)
                         if sat_dev is not None and sat_dev.find(".//rpc-error") is None:

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -151,6 +151,144 @@ class SW(Util):
 
         return alive_satellites
 
+    def _install_on_satellites(
+        self, remote_package, alive_satellites, vmhost, timeout, validate, **kwargs
+    ):
+        """Install software on satellite devices using their facts to determine
+        the correct RE/VC/vmhost strategy per satellite.
+
+        For each alive satellite, inspects the satellite's facts from
+        ``dev.facts['satellites_info']`` to decide:
+          - If satellite is a VC member: install per VC member
+          - If satellite is dual-RE: install on re0 and re1
+          - Otherwise: simple single-RE install
+
+        :param str remote_package:
+          Remote path to the package on the device.
+        :param list alive_satellites:
+          List of satellite names that are alive.
+        :param bool vmhost:
+          Whether vmhost install is requested.
+        :param int timeout:
+          RPC timeout for the install operation.
+        :param bool validate:
+          Whether to validate before install.
+        :param dict kwargs:
+          Additional kwargs passed through to pkgadd.
+
+        :returns: tuple(bool, str) — overall success status and messages.
+        """
+        overall_ok = True
+        overall_msg = ""
+        satellites_info = self._dev.facts.get("satellites_info", {})
+
+        for sat_name in alive_satellites:
+            sat_facts = satellites_info.get(sat_name, {})
+            sat_kwargs = dict(kwargs)
+            sat_kwargs["device_list"] = [sat_name]
+
+            # Determine satellite vmhost status from its facts
+            sat_vmhost = vmhost
+
+            # --- Validate on satellite if requested ---
+            if validate is True:
+                self.log(
+                    "validating software on satellite %s ... "
+                    "please be patient ..." % sat_name
+                )
+                try:
+                    v_ok = self.validate(
+                        remote_package,
+                        satellite_name=sat_name,
+                        dev_timeout=timeout,
+                    )
+                except RpcError as e:
+                    if "syntax error" in (getattr(e, "message", "") or ""):
+                        v_ok = True
+                    else:
+                        overall_ok = False
+                        overall_msg += (
+                            "\nSatellite %s: validation raised error: %s"
+                            % (sat_name, str(e))
+                        )
+                        continue
+                if v_ok is not True:
+                    overall_ok = False
+                    overall_msg += (
+                        "\nSatellite %s: package validation failed" % sat_name
+                    )
+                    continue
+
+            # --- Determine install strategy based on satellite RE/VC facts ---
+            sat_vc_capable = sat_facts.get("vc_capable", False)
+            sat_vc_mode = sat_facts.get("vc_mode")
+            sat_dual_re = sat_facts.get("2RE", False)
+            sat_vc_master = sat_facts.get("vc_master")
+
+            if sat_vc_capable and sat_vc_mode not in (None, "Disabled"):
+                # Satellite is a VC member — install per member
+                self.log(
+                    "installing software on satellite %s (VC mode) ... "
+                    "please be patient ..." % sat_name
+                )
+                if sat_vc_master is not None:
+                    sat_kwargs["member"] = sat_vc_master
+                bool_ret, msg = self.pkgadd(
+                    remote_package,
+                    vmhost=sat_vmhost,
+                    dev_timeout=timeout,
+                    **sat_kwargs,
+                )
+                overall_ok = overall_ok and bool_ret
+                overall_msg += "\nSatellite %s (VC): %s" % (sat_name, msg)
+            elif sat_dual_re:
+                # Satellite has dual RE — install on both re0 and re1
+                self.log(
+                    "installing software on satellite %s RE0 ... "
+                    "please be patient ..." % sat_name
+                )
+                sat_kwargs_re0 = dict(sat_kwargs)
+                sat_kwargs_re0["re0"] = True
+                bool_ret, msg = self.pkgadd(
+                    remote_package,
+                    vmhost=sat_vmhost,
+                    dev_timeout=timeout,
+                    **sat_kwargs_re0,
+                )
+                overall_ok = overall_ok and bool_ret
+                overall_msg += "\nSatellite %s RE0: %s" % (sat_name, msg)
+
+                self.log(
+                    "installing software on satellite %s RE1 ... "
+                    "please be patient ..." % sat_name
+                )
+                sat_kwargs_re1 = dict(sat_kwargs)
+                sat_kwargs_re1["re1"] = True
+                bool_ret, msg = self.pkgadd(
+                    remote_package,
+                    vmhost=sat_vmhost,
+                    dev_timeout=timeout,
+                    **sat_kwargs_re1,
+                )
+                overall_ok = overall_ok and bool_ret
+                overall_msg += "\nSatellite %s RE1: %s" % (sat_name, msg)
+            else:
+                # Single RE satellite — simple install
+                self.log(
+                    "installing software on satellite %s ... "
+                    "please be patient ..." % sat_name
+                )
+                bool_ret, msg = self.pkgadd(
+                    remote_package,
+                    vmhost=sat_vmhost,
+                    dev_timeout=timeout,
+                    **sat_kwargs,
+                )
+                overall_ok = overall_ok and bool_ret
+                overall_msg += "\nSatellite %s: %s" % (sat_name, msg)
+
+        return overall_ok, overall_msg.strip()
+
     # -----------------------------------------------------------------------
     # CLASS METHODS
     # -----------------------------------------------------------------------
@@ -978,8 +1116,6 @@ class SW(Util):
                     error_msg = "ERROR: No alive satellites available for installation"
                     _progress(error_msg)
                     return False, error_msg
-                if "device_list" not in kwargs:
-                    kwargs["device_list"] = alive_satellites
             except RpcError as err:
                 error_msg = "Problem checking satellite device status: %s" % (str(err))
                 _progress(error_msg)
@@ -1055,6 +1191,20 @@ class SW(Util):
 
         if len(remote_pkg_set) == 1:
             remote_package = remote_pkg_set[0]
+
+            # -----------------------------------------------------------------
+            # Satellite install path: use satellite facts for RE/VC handling
+            # -----------------------------------------------------------------
+            if satellite_name is not None:
+                return self._install_on_satellites(
+                    remote_package,
+                    alive_satellites,
+                    vmhost=vmhost,
+                    timeout=timeout,
+                    validate=validate,
+                    **kwargs,
+                )
+
             # validate can't be used in the case of a Mixed VC
             # With vmhost=True, validate is handled in the package add.
             if validate is True:

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -207,9 +207,9 @@ class SW(Util):
                         v_ok = True
                     else:
                         overall_ok = False
-                        overall_msg += (
-                            "\nSatellite %s: validation raised error: %s"
-                            % (sat_name, str(e))
+                        overall_msg += "\nSatellite %s: validation raised error: %s" % (
+                            sat_name,
+                            str(e),
                         )
                         continue
                 if v_ok is not True:

--- a/tests/unit/facts/rpc-reply/satellites_down_get-jnu-satellites-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_down_get-jnu-satellites-information.xml
@@ -1,0 +1,10 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <jnu-satellites-information>
+        <satellite-information>
+            <satellite-ip>satellite_one</satellite-ip>
+            <alive>down</alive>
+            <satellite-model>mx960</satellite-model>
+            <satellite-version>26.3I20260309_1406_babud</satellite-version>
+        </satellite-information>
+    </jnu-satellites-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_get-chassis-inventory.xml
+++ b/tests/unit/facts/rpc-reply/satellites_get-chassis-inventory.xml
@@ -1,0 +1,19 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <satellite-device-information>
+        <satellite-device>
+            <satellite-mgmt-ip>satellite_one</satellite-mgmt-ip>
+            <chassis-inventory>
+                <chassis>
+                    <name>Chassis</name>
+                    <serial-number>VM6A2F86A07D</serial-number>
+                    <description>MX960</description>
+                    <chassis-module>
+                        <name>Routing Engine 0</name>
+                        <serial-number>574b94ec-68</serial-number>
+                        <description>RE-VMX</description>
+                    </chassis-module>
+                </chassis>
+            </chassis-inventory>
+        </satellite-device>
+    </satellite-device-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_get-jnu-satellites-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_get-jnu-satellites-information.xml
@@ -1,0 +1,16 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <jnu-satellites-information>
+        <satellite-information>
+            <satellite-ip>satellite_one</satellite-ip>
+            <alive>up</alive>
+            <satellite-model>mx960</satellite-model>
+            <satellite-version>26.3I20260309_1406_babud</satellite-version>
+        </satellite-information>
+        <satellite-information>
+            <satellite-ip>satellite_two</satellite-ip>
+            <alive>up</alive>
+            <satellite-model>mx960</satellite-model>
+            <satellite-version>26.3I20260309_1406_babud</satellite-version>
+        </satellite-information>
+    </jnu-satellites-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_get-route-engine-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_get-route-engine-information.xml
@@ -1,0 +1,19 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <satellite-device-information>
+        <satellite-device>
+            <satellite-mgmt-ip>satellite_one</satellite-mgmt-ip>
+            <route-engine-information>
+                <route-engine>
+                    <slot>0</slot>
+                    <mastership-state>master</mastership-state>
+                    <mastership-priority>master (default)</mastership-priority>
+                    <status>OK</status>
+                    <model>RE-VMX</model>
+                    <serial-number>574b94ec-68</serial-number>
+                    <up-time>36 minutes, 28 seconds</up-time>
+                    <last-reboot-reason>Router rebooted after a normal shutdown.</last-reboot-reason>
+                </route-engine>
+            </route-engine-information>
+        </satellite-device>
+    </satellite-device-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_get-virtual-chassis-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_get-virtual-chassis-information.xml
@@ -1,0 +1,13 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <satellite-device-information>
+        <satellite-device>
+            <satellite-mgmt-ip>satellite_one</satellite-mgmt-ip>
+            <rpc-error>
+                <error-type>protocol</error-type>
+                <error-tag>operation-failed</error-tag>
+                <error-severity>error</error-severity>
+                <error-message>the virtual-chassis-control subsystem is not running</error-message>
+            </rpc-error>
+        </satellite-device>
+    </satellite-device-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_none_get-jnu-satellites-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_none_get-jnu-satellites-information.xml
@@ -1,0 +1,4 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <jnu-satellites-information>
+    </jnu-satellites-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_one_get-software-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_one_get-software-information.xml
@@ -1,0 +1,14 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <satellite-device-information>
+        <satellite-device>
+            <satellite-mgmt-ip>satellite_one</satellite-mgmt-ip>
+            <software-information>
+                <host-name>r0_re0</host-name>
+                <product-model>mx960</product-model>
+                <product-name>mx960</product-name>
+                <os-name>junos</os-name>
+                <junos-version>26.3I20260309_1406_babud</junos-version>
+            </software-information>
+        </satellite-device>
+    </satellite-device-information>
+</rpc-reply>

--- a/tests/unit/facts/rpc-reply/satellites_two_get-software-information.xml
+++ b/tests/unit/facts/rpc-reply/satellites_two_get-software-information.xml
@@ -1,0 +1,14 @@
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/26.3I20260309_1406_babud/junos">
+    <satellite-device-information>
+        <satellite-device>
+            <satellite-mgmt-ip>satellite_two</satellite-mgmt-ip>
+            <software-information>
+                <host-name>r1_re0</host-name>
+                <product-model>mx960</product-model>
+                <product-name>mx960</product-name>
+                <os-name>junos</os-name>
+                <junos-version>26.3I20260309_1406_babud</junos-version>
+            </software-information>
+        </satellite-device>
+    </satellite-device-information>
+</rpc-reply>

--- a/tests/unit/facts/test_get_jnu_satellites_information.py
+++ b/tests/unit/facts/test_get_jnu_satellites_information.py
@@ -72,9 +72,7 @@ class TestGetJnuSatellitesInformation(unittest.TestCase):
         if not args:
             return None
         if args[0].tag == "get-jnu-satellites-information":
-            return self._read_file(
-                "satellites_down_get-jnu-satellites-information.xml"
-            )
+            return self._read_file("satellites_down_get-jnu-satellites-information.xml")
         return None
 
     def _mock_satellites_rpc_error(self, *args, **kwargs):

--- a/tests/unit/facts/test_get_jnu_satellites_information.py
+++ b/tests/unit/facts/test_get_jnu_satellites_information.py
@@ -1,0 +1,173 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from jnpr.junos import Device
+from jnpr.junos.exception import RpcError
+from ncclient.manager import Manager, make_device_handler
+from ncclient.transport import SSHSession
+
+
+class TestGetJnuSatellitesInformation(unittest.TestCase):
+    @patch("ncclient.manager.connect")
+    def setUp(self, mock_connect):
+        mock_connect.side_effect = self._mock_manager_setup
+        self.dev = Device(
+            host="1.1.1.1", user="rick", password="password123", gather_facts=False
+        )
+        self.dev.open()
+
+    def _read_file(self, fname):
+        from ncclient.xml_ import NCElement
+
+        fpath = os.path.join(os.path.dirname(__file__), "rpc-reply", fname)
+        with open(fpath) as f:
+            foo = f.read()
+        rpc_reply = NCElement(
+            foo, self.dev._conn._device_handler.transform_reply()
+        )._NCElement__doc[0]
+        return rpc_reply
+
+    def _mock_manager_setup(self, *args, **kwargs):
+        if kwargs:
+            device_params = kwargs["device_params"]
+            device_handler = make_device_handler(device_params)
+            session = SSHSession(device_handler)
+            return Manager(session, device_handler)
+
+    # -----------------------------------------------------------------------
+    # helpers that map each RPC tag to the right fixture file
+    # -----------------------------------------------------------------------
+
+    def _mock_satellites_up(self, *args, **kwargs):
+        """Two satellites, both up, full set of per-satellite RPCs."""
+        if not args:
+            return None
+        tag = args[0].tag
+        if tag == "get-jnu-satellites-information":
+            return self._read_file("satellites_get-jnu-satellites-information.xml")
+        # device-list kwarg tells us which satellite is being queried
+        device_list = args[0].findtext("device-list") or ""
+        if tag == "get-software-information":
+            key = "one" if "satellite_one" in device_list else "two"
+            return self._read_file(
+                "satellites_{}_get-software-information.xml".format(key)
+            )
+        if tag == "get-route-engine-information":
+            return self._read_file("satellites_get-route-engine-information.xml")
+        if tag == "get-chassis-inventory":
+            return self._read_file("satellites_get-chassis-inventory.xml")
+        if tag == "get-virtual-chassis-information":
+            return self._read_file("satellites_get-virtual-chassis-information.xml")
+        return None
+
+    def _mock_satellites_none(self, *args, **kwargs):
+        if not args:
+            return None
+        if args[0].tag == "get-jnu-satellites-information":
+            return self._read_file("satellites_none_get-jnu-satellites-information.xml")
+        return None
+
+    def _mock_satellites_down(self, *args, **kwargs):
+        if not args:
+            return None
+        if args[0].tag == "get-jnu-satellites-information":
+            return self._read_file(
+                "satellites_down_get-jnu-satellites-information.xml"
+            )
+        return None
+
+    def _mock_satellites_rpc_error(self, *args, **kwargs):
+        if not args:
+            return None
+        if args[0].tag == "get-jnu-satellites-information":
+            raise RpcError()
+        return None
+
+    # -----------------------------------------------------------------------
+    # test cases
+    # -----------------------------------------------------------------------
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellites_present(self, mock_execute):
+        mock_execute.side_effect = self._mock_satellites_up
+        self.assertTrue(self.dev.facts["jnu_satellite"])
+        info = self.dev.facts["satellites_info"]
+        self.assertIn("satellite_one", info)
+        self.assertIn("satellite_two", info)
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_alive_status(self, mock_execute):
+        mock_execute.side_effect = self._mock_satellites_up
+        info = self.dev.facts["satellites_info"]
+        self.assertEqual(info["satellite_one"]["alive"], "up")
+        self.assertEqual(info["satellite_two"]["alive"], "up")
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_software_facts(self, mock_execute):
+        mock_execute.side_effect = self._mock_satellites_up
+        sat = self.dev.facts["satellites_info"]["satellite_one"]
+        self.assertEqual(sat["hostname"], "r0_re0")
+        self.assertEqual(sat["model"], "mx960")
+        self.assertEqual(sat["version"], "26.3I20260309_1406_babud")
+        self.assertEqual(sat["os_name"], "junos")
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_re_facts(self, mock_execute):
+        mock_execute.side_effect = self._mock_satellites_up
+        sat = self.dev.facts["satellites_info"]["satellite_one"]
+        self.assertFalse(sat["2RE"])
+        self.assertIsNotNone(sat["RE0"])
+        self.assertEqual(sat["RE0"]["mastership_state"], "master")
+        self.assertEqual(sat["RE0"]["status"], "OK")
+        self.assertEqual(sat["RE0"]["model"], "RE-VMX")
+        self.assertIsNone(sat["RE1"])
+        self.assertEqual(sat["master"], "RE0")
+        self.assertIsNotNone(sat["re_info"])
+        self.assertIsNotNone(sat["re_master"])
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_chassis_inventory_facts(self, mock_execute):
+        mock_execute.side_effect = self._mock_satellites_up
+        sat = self.dev.facts["satellites_info"]["satellite_one"]
+        self.assertEqual(sat["serialnumber"], "VM6A2F86A07D")
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_vc_not_capable(self, mock_execute):
+        """Satellite returns rpc-error for VC — vc_capable must be False."""
+        mock_execute.side_effect = self._mock_satellites_up
+        sat = self.dev.facts["satellites_info"]["satellite_one"]
+        self.assertFalse(sat["vc_capable"])
+        self.assertIsNone(sat["vc_mode"])
+        self.assertIsNone(sat["vc_fabric"])
+        self.assertIsNone(sat["vc_master"])
+
+    @patch("jnpr.junos.Device.execute")
+    def test_no_satellites(self, mock_execute):
+        """Empty satellite list — jnu_satellite must be False."""
+        mock_execute.side_effect = self._mock_satellites_none
+        self.assertFalse(self.dev.facts["jnu_satellite"])
+        self.assertEqual(self.dev.facts["satellites_info"], {})
+
+    @patch("jnpr.junos.Device.execute")
+    def test_satellite_down_skips_detail_rpcs(self, mock_execute):
+        """Down satellite — detail RPCs are not called, fields are None."""
+        mock_execute.side_effect = self._mock_satellites_down
+        self.assertTrue(self.dev.facts["jnu_satellite"])
+        sat = self.dev.facts["satellites_info"]["satellite_one"]
+        self.assertEqual(sat["alive"], "down")
+        self.assertIsNone(sat["hostname"])
+        self.assertIsNone(sat["serialnumber"])
+        self.assertIsNone(sat["RE0"])
+        self.assertFalse(sat["vc_capable"])
+
+    @patch("jnpr.junos.Device.execute")
+    def test_rpc_not_supported(self, mock_execute):
+        """Device does not support JNU satellites RPC — no exception raised."""
+        mock_execute.side_effect = self._mock_satellites_rpc_error
+        self.assertFalse(self.dev.facts["jnu_satellite"])
+        self.assertEqual(self.dev.facts["satellites_info"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_console.py
+++ b/tests/unit/test_console.py
@@ -207,7 +207,7 @@ class TestConsole(unittest.TestCase):
 
         mock_fact_list.__iter__.return_value = [facts_session]
         self.dev.facts_refresh()
-        self.assertEqual(mock_rpc.call_count, 8)
+        self.assertEqual(mock_rpc.call_count, 9)
 
     @patch("jnpr.junos.console.Console._tty_login")
     @patch("jnpr.junos.console.FACT_LIST")
@@ -226,11 +226,13 @@ class TestConsole(unittest.TestCase):
                 "2RE": False,
                 "RE_hw_mi": False,
                 "ifd_style": "CLASSIC",
-                "serialnumber": "UNKNOWN",
+                "jnu_satellite": False,
                 "model": "UNKNOWN",
-                "vc_capable": False,
-                "switch_style": "NONE",
                 "personality": "UNKNOWN",
+                "satellites_info": {},
+                "serialnumber": "UNKNOWN",
+                "switch_style": "NONE",
+                "vc_capable": False,
             },
         )
 

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -966,11 +966,21 @@ class TestSW(unittest.TestCase):
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_with_satellite_name_list(self, mock_execute, mock_sat_check):
         mock_sat_check.return_value = ["sat1", "sat2"]
+        mock_execute.side_effect = self._mock_manager
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+            "sat2": {"2RE": False, "vc_capable": False},
+        }
         self.sw.install("file", no_copy=True, satellite_name=["sat1", "sat2"])
-        rpc = etree.tostring(mock_execute.call_args[0][0]).decode("utf-8")
-        self.assertTrue(rpc.count("<device-list>") == 2)
-        self.assertTrue("<device-list>sat1</device-list>" in rpc)
-        self.assertTrue("<device-list>sat2</device-list>" in rpc)
+        # New behavior: each satellite gets its own pkgadd call
+        # Verify both satellites were addressed via execute calls
+        all_rpcs = "".join(
+            etree.tostring(c[0][0]).decode("utf-8")
+            for c in mock_execute.call_args_list
+            if c[0]
+        )
+        self.assertIn("<device-list>sat1</device-list>", all_rpcs)
+        self.assertIn("<device-list>sat2</device-list>", all_rpcs)
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_issu_with_routing_instance(self, mock_execute):
@@ -1391,6 +1401,262 @@ class TestSW(unittest.TestCase):
     def test_sw_rollback_satellite_none_alive(self, mock_sat_check):
         mock_sat_check.return_value = []
         self.assertRaises(SwRollbackError, self.sw.rollback, satellite_name="sat_down")
+
+    # -------------------------------------------------------------------------
+    # _install_on_satellites tests
+    # -------------------------------------------------------------------------
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_single_re(self, mock_pkgadd):
+        """Single-RE satellite: one pkgadd call with device_list."""
+        mock_pkgadd.return_value = (True, "installed ok")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=False
+        )
+        self.assertTrue(ok)
+        self.assertIn("Satellite sat1:", msg)
+        mock_pkgadd.assert_called_once()
+        call_kwargs = mock_pkgadd.call_args[1]
+        self.assertEqual(call_kwargs["device_list"], ["sat1"])
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_dual_re(self, mock_pkgadd):
+        """Dual-RE satellite: two pkgadd calls (re0, re1)."""
+        mock_pkgadd.side_effect = [
+            (True, "re0 installed"),
+            (True, "re1 installed"),
+        ]
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": True, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=False
+        )
+        self.assertTrue(ok)
+        self.assertIn("Satellite sat1 RE0:", msg)
+        self.assertIn("Satellite sat1 RE1:", msg)
+        self.assertEqual(mock_pkgadd.call_count, 2)
+        # First call has re0=True
+        first_kwargs = mock_pkgadd.call_args_list[0][1]
+        self.assertTrue(first_kwargs.get("re0"))
+        # Second call has re1=True
+        second_kwargs = mock_pkgadd.call_args_list[1][1]
+        self.assertTrue(second_kwargs.get("re1"))
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_dual_re_failure(self, mock_pkgadd):
+        """Dual-RE satellite: re1 install fails, overall_ok is False."""
+        mock_pkgadd.side_effect = [
+            (True, "re0 ok"),
+            (False, "re1 failed"),
+        ]
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": True, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=False
+        )
+        self.assertFalse(ok)
+        self.assertIn("re1 failed", msg)
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_vc_mode(self, mock_pkgadd):
+        """VC-capable satellite: pkgadd called with member kwarg."""
+        mock_pkgadd.return_value = (True, "vc installed")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {
+                "2RE": False,
+                "vc_capable": True,
+                "vc_mode": "Enabled",
+                "vc_master": "0",
+            },
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=False
+        )
+        self.assertTrue(ok)
+        self.assertIn("Satellite sat1 (VC):", msg)
+        call_kwargs = mock_pkgadd.call_args[1]
+        self.assertEqual(call_kwargs["member"], "0")
+        self.assertEqual(call_kwargs["device_list"], ["sat1"])
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_vc_disabled_uses_single(self, mock_pkgadd):
+        """VC-capable but Disabled mode: falls through to single-RE path."""
+        mock_pkgadd.return_value = (True, "ok")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {
+                "2RE": False,
+                "vc_capable": True,
+                "vc_mode": "Disabled",
+            },
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=False
+        )
+        self.assertTrue(ok)
+        self.assertIn("Satellite sat1:", msg)
+        self.assertNotIn("(VC)", msg)
+
+    @patch("jnpr.junos.utils.sw.SW.validate")
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_validate_true(self, mock_pkgadd, mock_validate):
+        """validate=True: validate() called before pkgadd for each satellite."""
+        mock_validate.return_value = True
+        mock_pkgadd.return_value = (True, "ok")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=True
+        )
+        self.assertTrue(ok)
+        mock_validate.assert_called_once_with(
+            "/var/tmp/pkg.tgz", satellite_name="sat1", dev_timeout=1800
+        )
+        mock_pkgadd.assert_called_once()
+
+    @patch("jnpr.junos.utils.sw.SW.validate")
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_validate_fails(self, mock_pkgadd, mock_validate):
+        """validate=True but validation fails: pkgadd not called, result is False."""
+        mock_validate.return_value = False
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=True
+        )
+        self.assertFalse(ok)
+        self.assertIn("validation failed", msg)
+        mock_pkgadd.assert_not_called()
+
+    @patch("jnpr.junos.utils.sw.SW.validate")
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_validate_rpc_error(self, mock_pkgadd, mock_validate):
+        """validate raises RpcError (not syntax error): skip satellite."""
+        mock_validate.side_effect = RpcError(rsp=etree.XML("<rpc-error/>"))
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=True
+        )
+        self.assertFalse(ok)
+        self.assertIn("validation raised error", msg)
+        mock_pkgadd.assert_not_called()
+
+    @patch("jnpr.junos.utils.sw.SW.validate")
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_validate_syntax_error_continues(
+        self, mock_pkgadd, mock_validate
+    ):
+        """validate raises RpcError with 'syntax error': treat as ok, proceed."""
+        err = RpcError(rsp=etree.XML("<rpc-error/>"))
+        err.message = "syntax error"
+        mock_validate.side_effect = err
+        mock_pkgadd.return_value = (True, "ok")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=False, timeout=1800, validate=True
+        )
+        self.assertTrue(ok)
+        mock_pkgadd.assert_called_once()
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_multiple_satellites(self, mock_pkgadd):
+        """Multiple satellites: each gets its own pkgadd call."""
+        mock_pkgadd.side_effect = [
+            (True, "sat1 ok"),
+            (True, "sat2 ok"),
+        ]
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+            "sat2": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz",
+            ["sat1", "sat2"],
+            vmhost=False,
+            timeout=1800,
+            validate=False,
+        )
+        self.assertTrue(ok)
+        self.assertEqual(mock_pkgadd.call_count, 2)
+        # Verify each call used different device_list
+        self.assertEqual(mock_pkgadd.call_args_list[0][1]["device_list"], ["sat1"])
+        self.assertEqual(mock_pkgadd.call_args_list[1][1]["device_list"], ["sat2"])
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_no_facts_uses_single_path(self, mock_pkgadd):
+        """Satellite not in satellites_info: defaults to single-RE path."""
+        mock_pkgadd.return_value = (True, "ok")
+        self.dev.facts["satellites_info"] = {}
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz",
+            ["unknown_sat"],
+            vmhost=False,
+            timeout=1800,
+            validate=False,
+        )
+        self.assertTrue(ok)
+        self.assertIn("Satellite unknown_sat:", msg)
+
+    @patch("jnpr.junos.utils.sw.SW.pkgadd")
+    def test_install_on_satellites_vmhost_passed(self, mock_pkgadd):
+        """vmhost=True is passed through to pkgadd."""
+        mock_pkgadd.return_value = (True, "ok")
+        self.dev.facts["satellites_info"] = {
+            "sat1": {"2RE": False, "vc_capable": False},
+        }
+        ok, msg = self.sw._install_on_satellites(
+            "/var/tmp/pkg.tgz", ["sat1"], vmhost=True, timeout=1800, validate=False
+        )
+        self.assertTrue(ok)
+        call_kwargs = mock_pkgadd.call_args[1]
+        self.assertTrue(call_kwargs["vmhost"])
+
+    # -------------------------------------------------------------------------
+    # install() with satellite_name end-to-end tests
+    # -------------------------------------------------------------------------
+
+    @patch("jnpr.junos.utils.sw.SW._install_on_satellites")
+    @patch("jnpr.junos.utils.sw.SW._check_satellite_alive")
+    @patch("jnpr.junos.Device.execute")
+    def test_sw_install_satellite_calls_install_on_satellites(
+        self, mock_execute, mock_sat_check, mock_install_sat
+    ):
+        """install(satellite_name=...) delegates to _install_on_satellites."""
+        mock_execute.side_effect = self._mock_manager
+        mock_sat_check.return_value = ["sat1"]
+        mock_install_sat.return_value = (True, "done")
+        ok, msg = self.sw.install("test.tgz", no_copy=True, satellite_name="sat1")
+        self.assertTrue(ok)
+        mock_install_sat.assert_called_once()
+        call_args = mock_install_sat.call_args
+        self.assertEqual(call_args[0][1], ["sat1"])  # alive_satellites
+
+    @patch("jnpr.junos.utils.sw.SW._install_on_satellites")
+    @patch("jnpr.junos.utils.sw.SW._check_satellite_alive")
+    @patch("jnpr.junos.Device.execute")
+    def test_sw_install_satellite_multiple_alive(
+        self, mock_execute, mock_sat_check, mock_install_sat
+    ):
+        """install(satellite_name=[...]) passes all alive satellites."""
+        mock_execute.side_effect = self._mock_manager
+        mock_sat_check.return_value = ["sat1", "sat2"]
+        mock_install_sat.return_value = (True, "all ok")
+        ok, msg = self.sw.install(
+            "test.tgz", no_copy=True, satellite_name=["sat1", "sat2"]
+        )
+        self.assertTrue(ok)
+        call_args = mock_install_sat.call_args
+        self.assertEqual(call_args[0][1], ["sat1", "sat2"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Gathered facts about the satellite device

## Description

Gathered facts about the satellite device

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] Feature / Enhancement (non-breaking change that adds functionality)
- [ ] Task / Chore (refactor, dependency update, CI, docs, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Changes Made

<!-- List the key changes introduced by this PR -->

- get_jnu_satellites_information.py — New facts module that collects satellite device information via get-jnu-satellites-information RPC. Provides jnu_satellite (bool) and satellites_info (dict with per-satellite facts: alive, hostname, model, version, serialnumber, 2RE, RE0, RE1, re_info, re_master, vc_capable, vc_mode, vc_master, etc.)

- satellites.py — Old-style facts module (ofacts pattern) for satellite facts using the same logic

- test_get_jnu_satellites_information.py — 9 unit tests for the satellite facts module

---

## Checklist

### Code Quality

- [X] Code follows the project's style guidelines
- [X] `ruff format --check .` passes with no formatting issues
- [X] `pylint` reports no new errors or warnings (run against changed `.py` files)

```bash
ruff format --check .
pylint <changed_files>
```

### Unit Tests

- [X] New or updated unit tests have been added under `tests/unit/`
- [X] All unit tests pass locally

```bash
nose2 -vvv tests.unit --with-coverage --coverage-report xml
```

- [X] Code coverage has not decreased (check `coverage.xml`)

### Functional Tests

- [ ] Functional tests in `tests/functional/` have been reviewed for impact
- [X] Any affected functional tests pass (requires a live Junos device or vMX)

```bash
nose2 -vvv tests.functional
```

### Documentation

- [X] Docstrings updated for any new/changed public methods or classes
- [X] Sphinx docs build cleanly (if docs were changed)

```bash
sphinx-build -b html docs docs/_build/html -W
```

### General

- [ ] `RELEASE-NOTES.md` updated (if applicable)
- [X] No hardcoded credentials, IPs, or sensitive data introduced
- [ ] Dependencies in `requirements.txt` updated (if new packages were added)

---

## Testing Matrix

<!-- Confirm which Python versions / OS combinations you tested locally, if any -->

| Python | OS | Passed? |
|--------|----|---------|
| 3.x    |   Junos  | [Passed]     |

---

## Additional Notes

<!-- Anything else reviewers should know: deployment considerations, follow-up tasks, known limitations, etc. -->
