### PR TITLE
sw validate default set to True

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ A clear and concise description of the bug.
 # Minimal reproducible example
 from jnpr.junos import Device
 
-dev = Device(host='router.example.com', user='admin')
+dev = Device(host="router.example.com", user="admin")
 dev.open()
 # ...
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,7 +23,7 @@ Describe how you'd like the feature to work. Include API sketches or usage examp
 # Example of how you'd like to use the new feature
 from jnpr.junos import Device
 
-dev = Device(host='router.example.com', user='admin')
+dev = Device(host="router.example.com", user="admin")
 dev.open()
 # proposed new API usage...
 ```

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ The following is a quick "hello, world" example to ensure that the software was 
 from pprint import pprint
 from jnpr.junos import Device
 
-with Device(host='my_host_or_ipaddr', user='jeremy', password='jeremy123' ) as dev:
-    pprint( dev.facts )
+with Device(host="my_host_or_ipaddr", user="jeremy", password="jeremy123") as dev:
+    pprint(dev.facts)
 ````
 Example output for an SRX-210 device:
 ````python

--- a/lib/jnpr/junos/console.py
+++ b/lib/jnpr/junos/console.py
@@ -2,6 +2,7 @@ import logging
 import socket
 import sys
 import traceback
+import types
 import warnings
 
 from jnpr.junos import jxml as JXML
@@ -15,6 +16,7 @@ from jnpr.junos.transport.tty_ssh import SSH
 from jnpr.junos.transport.tty_telnet import Telnet
 from lxml import etree
 from ncclient.devices.junos import JunosDeviceHandler
+from ncclient.operations.rpc import RPCReply
 from ncclient.xml_ import NCElement
 
 logger = logging.getLogger("jnpr.junos.console")
@@ -270,9 +272,13 @@ class Console(_Connection):
             else rpc_cmd_e
         )
         reply = self._tty.nc.rpc(rpc_cmd)
-        rpc_rsp_e = NCElement(
-            reply, self.junos_dev_handler.transform_reply(), self._huge_tree
-        )._NCElement__doc
+        transform_reply = self.junos_dev_handler.transform_reply()
+        if isinstance(transform_reply, types.FunctionType):
+            # A callable transform is applied to the parsed reply element,
+            # but console RPCs hand back the reply as a raw string.
+            reply = RPCReply(reply, huge_tree=self._huge_tree)
+            reply.parse()
+        rpc_rsp_e = NCElement(reply, transform_reply, self._huge_tree)._NCElement__doc
         return rpc_rsp_e
 
     # -------------------------------------------------------------------------

--- a/lib/jnpr/junos/utils/sw.py
+++ b/lib/jnpr/junos/utils/sw.py
@@ -424,9 +424,9 @@ class SW(Util):
 
         if vmhost is False:
             if isinstance(remote_package, (list, tuple)) and self._mixed_VC:
-                args = dict(no_validate=True, set=remote_package)
+                args = dict(no_validate=False, set=remote_package)
             else:
-                args = dict(no_validate=True, package_name=remote_package)
+                args = dict(no_validate=False, package_name=remote_package)
             args.update(kvargs)
             rsp = self.rpc.request_package_add(**args)
         else:
@@ -907,7 +907,7 @@ class SW(Util):
         pkg_set=None,
         remote_path="/var/tmp",
         progress=None,
-        validate=False,
+        validate=True,
         checksum=None,
         cleanfs=True,
         no_copy=False,

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -237,7 +237,9 @@ class TestSW(unittest.TestCase):
     def test_sw_install_nonexistent_mx80_package(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.sw._multi_RE = False
-        var_ret = self.sw.install("test_no_mx80_packages.tgz", no_copy=True, validate=False)
+        var_ret = self.sw.install(
+            "test_no_mx80_packages.tgz", no_copy=True, validate=False
+        )
         self.assertFalse(var_ret[0])
 
     @patch("jnpr.junos.Device.execute")
@@ -758,7 +760,9 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.return_value = True, "msg"
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        self.assertTrue(self.sw.install("file", no_copy=True, progress=True, validate=False)[0])
+        self.assertTrue(
+            self.sw.install("file", no_copy=True, progress=True, validate=False)[0]
+        )
 
     @patch(builtin_string + ".print")
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
@@ -767,7 +771,9 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.side_effect = [(True, "re0"), (True, "re1")]
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True, validate=False)
+        bool_ret, msg = self.sw.install(
+            "file", no_copy=True, progress=True, validate=False
+        )
         self.assertEqual(msg, "re0\nre1")
         self.assertTrue(bool_ret)
 
@@ -778,7 +784,9 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.side_effect = [(True, "re0"), (False, "re1 install failed")]
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True, validate=False)
+        bool_ret, msg = self.sw.install(
+            "file", no_copy=True, progress=True, validate=False
+        )
         self.assertEqual(msg, "re0\nre1 install failed")
         self.assertFalse(bool_ret)
 
@@ -797,7 +805,9 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = True
         self.sw._multi_VC = True
         self.sw._RE_list = ("version_RE0", "version_RE1")
-        self.assertTrue(self.sw.install("file", member_id=["1"], no_copy=True, validate=False)[0])
+        self.assertTrue(
+            self.sw.install("file", member_id=["1"], no_copy=True, validate=False)[0]
+        )
 
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_install_multi_vc_multiple_member_id(self, mock_pkgadd):
@@ -806,7 +816,11 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = False
         self.sw._multi_VC_nsync = True
         self.sw._RE_list = ("version_RE0", "version_RE1")
-        self.assertTrue(self.sw.install("file", member_id=["0", "1"], no_copy=True, validate=False)[0])
+        self.assertTrue(
+            self.sw.install("file", member_id=["0", "1"], no_copy=True, validate=False)[
+                0
+            ]
+        )
 
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_install_mixed_vc(self, mock_pkgadd):
@@ -950,7 +964,9 @@ class TestSW(unittest.TestCase):
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_with_routing_instance(self, mock_execute):
-        self.sw.install("file", no_copy=True, routing_instance="mgmt_junos", validate=False)
+        self.sw.install(
+            "file", no_copy=True, routing_instance="mgmt_junos", validate=False
+        )
         rpc = etree.tostring(mock_execute.call_args[0][0]).decode("utf-8")
         self.assertTrue("<routing-instance>mgmt_junos</routing-instance>" in rpc)
 
@@ -984,7 +1000,13 @@ class TestSW(unittest.TestCase):
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_issu_with_routing_instance(self, mock_execute):
-        self.sw.install("file", no_copy=True, issu=True, routing_instance="mgmt_junos", validate=False)
+        self.sw.install(
+            "file",
+            no_copy=True,
+            issu=True,
+            routing_instance="mgmt_junos",
+            validate=False,
+        )
         rpc = etree.tostring(mock_execute.call_args[0][0]).decode("utf-8")
         self.assertTrue("<routing-instance>mgmt_junos</routing-instance>" in rpc)
 

--- a/tests/unit/utils/test_sw.py
+++ b/tests/unit/utils/test_sw.py
@@ -237,7 +237,7 @@ class TestSW(unittest.TestCase):
     def test_sw_install_nonexistent_mx80_package(self, mock_execute):
         mock_execute.side_effect = self._mock_manager
         self.sw._multi_RE = False
-        var_ret = self.sw.install("test_no_mx80_packages.tgz", no_copy=True)
+        var_ret = self.sw.install("test_no_mx80_packages.tgz", no_copy=True, validate=False)
         self.assertFalse(var_ret[0])
 
     @patch("jnpr.junos.Device.execute")
@@ -758,7 +758,7 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.return_value = True, "msg"
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        self.assertTrue(self.sw.install("file", no_copy=True, progress=True)[0])
+        self.assertTrue(self.sw.install("file", no_copy=True, progress=True, validate=False)[0])
 
     @patch(builtin_string + ".print")
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
@@ -767,7 +767,7 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.side_effect = [(True, "re0"), (True, "re1")]
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True)
+        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True, validate=False)
         self.assertEqual(msg, "re0\nre1")
         self.assertTrue(bool_ret)
 
@@ -778,7 +778,7 @@ class TestSW(unittest.TestCase):
         mock_pkgadd.side_effect = [(True, "re0"), (False, "re1 install failed")]
         self.sw._multi_RE = True
         self.sw._multi_MX = True
-        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True)
+        bool_ret, msg = self.sw.install("file", no_copy=True, progress=True, validate=False)
         self.assertEqual(msg, "re0\nre1 install failed")
         self.assertFalse(bool_ret)
 
@@ -788,7 +788,7 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = True
         self.sw._multi_VC = True
         self.sw._RE_list = ("version_RE0", "version_RE1")
-        self.assertTrue(self.sw.install("file", no_copy=True)[0])
+        self.assertTrue(self.sw.install("file", no_copy=True, validate=False)[0])
 
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_install_multi_vc_member_id(self, mock_pkgadd):
@@ -797,7 +797,7 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = True
         self.sw._multi_VC = True
         self.sw._RE_list = ("version_RE0", "version_RE1")
-        self.assertTrue(self.sw.install("file", member_id=["1"], no_copy=True)[0])
+        self.assertTrue(self.sw.install("file", member_id=["1"], no_copy=True, validate=False)[0])
 
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_install_multi_vc_multiple_member_id(self, mock_pkgadd):
@@ -806,7 +806,7 @@ class TestSW(unittest.TestCase):
         self.sw._multi_RE = False
         self.sw._multi_VC_nsync = True
         self.sw._RE_list = ("version_RE0", "version_RE1")
-        self.assertTrue(self.sw.install("file", member_id=["0", "1"], no_copy=True)[0])
+        self.assertTrue(self.sw.install("file", member_id=["0", "1"], no_copy=True, validate=False)[0])
 
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_install_mixed_vc(self, mock_pkgadd):
@@ -840,7 +840,7 @@ class TestSW(unittest.TestCase):
             "personality": "SWITCH",
         }
         sw = self.get_sw()
-        sw.install(package="abc.tgz", no_copy=True)
+        sw.install(package="abc.tgz", no_copy=True, validate=False)
         self.assertFalse(sw._multi_VC)
         calls = [
             call("/var/tmp/abc.tgz", dev_timeout=1800, vmhost=False, re0=True),
@@ -911,38 +911,38 @@ class TestSW(unittest.TestCase):
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_kwargs_force_host(self, mock_execute):
-        self.sw.install("file", no_copy=True, force_host=True)
+        self.sw.install("file", no_copy=True, force_host=True, validate=False)
         rpc = [
-            "<request-package-add><force-host/><no-validate/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><no-validate/><force-host/><re1/></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><no-validate/><re1/><force-host/></request-package-add>",
-            "<request-package-add><force-host/><no-validate/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
-            "<request-package-add><force-host/><re1/><no-validate/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><no-validate/><re1/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
-            "<request-package-add><no-validate/><package-name>/var/tmp/file</package-name><force-host/><re1/></request-package-add>",
-            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><no-validate/><re1/></request-package-add>",
-            "<request-package-add><re1/><no-validate/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
-            "<request-package-add><re1/><force-host/><package-name>/var/tmp/file</package-name><no-validate/></request-package-add>",
-            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><force-host/><no-validate/></request-package-add>",
-            "<request-package-add><re1/><force-host/><no-validate/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><no-validate/><force-host/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><no-validate/><re1/></request-package-add>",
-            "<request-package-add><no-validate/><re1/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><re1/><no-validate/></request-package-add>",
-            "<request-package-add><no-validate/><force-host/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
-            "<request-package-add><force-host/><no-validate/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><no-validate/></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><no-validate/><force-host/></request-package-add>",
-            "<request-package-add><no-validate/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><no-validate/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><no-validate/></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><no-validate/><force-host/></request-package-add>",
-            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><force-host/><no-validate/></request-package-add>",
-            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><re1/><no-validate/></request-package-add>",
-            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><no-validate/><force-host/></request-package-add>",
-            "<request-package-add><no-validate/><package-name>/var/tmp/file</package-name><re1/><force-host/></request-package-add>",
-            "<request-package-add><re1/><no-validate/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
-            "<request-package-add><force-host/><re1/><package-name>/var/tmp/file</package-name><no-validate/></request-package-add>",
+            "<request-package-add><force-host/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><re1/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><force-host/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
+            "<request-package-add><force-host/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><re1/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
+            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><re1/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><re1/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><force-host/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><re1/></request-package-add>",
+            "<request-package-add><re1/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/><re1/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><force-host/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><force-host/></request-package-add>",
+            "<request-package-add><force-host/><package-name>/var/tmp/file</package-name><re1/></request-package-add>",
+            "<request-package-add><re1/><package-name>/var/tmp/file</package-name><force-host/></request-package-add>",
+            "<request-package-add><package-name>/var/tmp/file</package-name><re1/><force-host/></request-package-add>",
+            "<request-package-add><re1/><force-host/><package-name>/var/tmp/file</package-name></request-package-add>",
+            "<request-package-add><force-host/><re1/><package-name>/var/tmp/file</package-name></request-package-add>",
         ]
         self.assertTrue(
             etree.tostring(mock_execute.call_args[0][0]).decode("utf-8") in rpc
@@ -950,7 +950,7 @@ class TestSW(unittest.TestCase):
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_with_routing_instance(self, mock_execute):
-        self.sw.install("file", no_copy=True, routing_instance="mgmt_junos")
+        self.sw.install("file", no_copy=True, routing_instance="mgmt_junos", validate=False)
         rpc = etree.tostring(mock_execute.call_args[0][0]).decode("utf-8")
         self.assertTrue("<routing-instance>mgmt_junos</routing-instance>" in rpc)
 
@@ -984,7 +984,7 @@ class TestSW(unittest.TestCase):
 
     @patch("jnpr.junos.Device.execute")
     def test_sw_install_issu_with_routing_instance(self, mock_execute):
-        self.sw.install("file", no_copy=True, issu=True, routing_instance="mgmt_junos")
+        self.sw.install("file", no_copy=True, issu=True, routing_instance="mgmt_junos", validate=False)
         rpc = etree.tostring(mock_execute.call_args[0][0]).decode("utf-8")
         self.assertTrue("<routing-instance>mgmt_junos</routing-instance>" in rpc)
 
@@ -1183,7 +1183,7 @@ class TestSW(unittest.TestCase):
     @patch("jnpr.junos.utils.sw.SW.pkgadd")
     def test_sw_check_pending_install_RpcError_continue(self, mock_pkgadd):
         mock_pkgadd.return_value = True, "msg"
-        self.assertTrue(self.sw.install("test.tgz", no_copy=True)[0])
+        self.assertTrue(self.sw.install("test.tgz", no_copy=True, validate=False)[0])
 
     def _myprogress(self, dev, report):
         pass


### PR DESCRIPTION

Change 1 — sw.pkgadd(): no_validate=True → no_validate=False

```
Before: 
Every direct pkgadd call for Classic/EVO/Mixed VC hard-coded no_validate=True — the install RPC never validated regardless of what the caller wanted.

After: 
Default is no_validate=False — Junos validates by default. 
```

Change 2 — sw.install(): validate=False → validate=True

```
Before: 
Unless validate=True was explicitly passed, no validation occurred — self.validate() was skipped, and pkgadd hard-coded no_validate=True for Classic/EVO/Mixed VC. vmhost only got no_validate=True injected when validate=False.

After: 
Default is validate=True — self.validate() runs automatically for Classic/EVO/Mixed VC before install. vmhost validates during the install RPC (Junos default). 
```

12 tests — added validate=False to sw.install() calls

These tests are not exercising validation logic. With validate=True now the default, they would unexpectedly trigger self.validate() → request-package-validate RPC, which their mocks did not set up. Adding validate=False keeps each test focused on its original intent:

test_sw_install_nonexistent_mx80_package
test_sw_install_multi_mx
test_sw_install_multi_mx_msg_check
test_sw_install_multi_mx_msg_check_failure
test_sw_install_multi_vc
test_sw_install_multi_vc_member_id
test_sw_install_multi_vc_multiple_member_id
test_sw_install_multi_vc_mode_disabled
test_sw_install_with_routing_instance
test_sw_install_issu_with_routing_instance
test_sw_install_kwargs_force_host
test_sw_check_pending_install_RpcError_continue

1 test — updated expected RPC XML strings
test_sw_install_kwargs_force_host — all 30 expected <request-package-add> XML strings had <no-validate/> removed. Since pkgadd now defaults to no_validate=False, the element is absent from the RPC, so the old strings would never match.


tables and views:
```
  File "/home//.local/lib/python3.12/site-packages/ncclient/xml_.py", line 166, in __init__
    self.__doc = self.__transform_reply(result._root)
                                        ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute '_root'

Root cause
Table.get() in optable.py:82 unconditionally installs a callable transform on the device:
self.D.transform = lambda: remove_namespaces_and_spaces

That makes junos_dev_handler.transform_reply() return a Python function instead of the default XSLT stylesheet bytes. In ncclient's NCElement.__init__, a types.FunctionType transform takes a different branch:

if isinstance(transform_reply, types.FunctionType):
    self.__doc = self.__transform_reply(result._root)   # expects an RPCReply
else:
    self.__doc = self.remove_namespaces(self.__result)  # accepts a raw string

Over NETCONF/SSH this is fine — ncclient passes an RPCReply. But the console/telnet path in console.py:266 gets the reply from tty_netconf.rpc(), which returns the raw string, and passes that straight into NCElement. Hence 'str' object has no attribute '_root'.

So the bug only shows up for mode="telnet"/serial + Table/View usage

Fix
In Console._rpc_reply, wrap the raw reply in an RPCReply (and parse it) when the transform is a callable, matching what ncclient does on the SSH path:

reply = self._tty.nc.rpc(rpc_cmd)
transform_reply = self.junos_dev_handler.transform_reply()
if isinstance(transform_reply, types.FunctionType):
    # A callable transform is applied to the parsed reply element,
    # but console RPCs hand back the reply as a raw string.
    reply = RPCReply(reply, huge_tree=self._huge_tree)
    reply.parse()
rpc_rsp_e = NCElement(reply, transform_reply, self._huge_tree)._NCElement__doc

With fix:

:~/pyez_check/py-junos-eznc/tests$ python3 check_issue_1335.py 
SystemStorageTable:xx.xx.xx.xx: 0 items
~/pyez_check/py-junos-eznc/tests$ python3 check_issue_ssh_1335.py 
SystemStorageTable:xx.xx.xx.xx: 0 items
```